### PR TITLE
feat: Bump Version 5.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 511000000
-        versionName = "5.1.1"
+        versionCode = 512000000
+        versionName = "5.1.2"
         signingConfig = signingConfigs.getByName("config")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["MAPS_API_KEY"] = props["GOOGLE_MAP_API_KEY"]?.toString() ?: ""

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabCityFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabCityFragment.kt
@@ -52,7 +52,12 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000379 && bus.route.seq == 216000068 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000379 && bus.route.seq == 216000068 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
@@ -74,7 +79,12 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000381 && bus.route.seq == 216000068 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000381 && bus.route.seq == 216000068 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
@@ -96,7 +106,12 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000383 && bus.route.seq == 216000068 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000383 && bus.route.seq == 216000068 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
@@ -106,7 +121,12 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
         parentViewModel.result.observe(viewLifecycleOwner) { busList ->
             if (busList == null) return@observe
             val currentTime = LocalTime.now()
-            val secondBusList = busList.first { bus -> bus.stop.seq == 216000138 && bus.route.seq == 216000068 }
+            val secondBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000138 && bus.route.seq == 216000068 }
+            if (secondBusList == null) {
+                busSecondAdapter.updateData(emptyList())
+                binding.noRealtimeDataSecond.visibility = View.VISIBLE
+                return@observe
+            }
             val secondBusRealtime = secondBusList.arrival.filter { arrival -> arrival.isRealtime }
             val secondBusTimetable = if (secondBusRealtime.isNotEmpty()) {
                 secondBusList.arrival.filter { arrival ->

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabOtherFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabOtherFragment.kt
@@ -32,20 +32,30 @@ class BusTabOtherFragment @Inject constructor() : Fragment() {
         val busSecondAdapter = BusRealtimeListAdapter()
         parentViewModel.result.observe(viewLifecycleOwner) { busList ->
             if (busList == null) return@observe
-            val firstBusList = busList.first { bus -> bus.stop.seq == 216000759 && bus.route.seq == 216000075 }
-            val secondBusList = busList.first { bus -> bus.stop.seq == 213000487 && bus.route.seq == 216000075 }
-            busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
-                BusArrivalItem(firstBusList.route.name, arrival)
-            })
-            busSecondAdapter.updateData(secondBusList.arrival.filter {
-                !it.isRealtime
-            }.map { arrival ->
-                BusArrivalItem(secondBusList.route.name, arrival)
-            })
-            binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
-            binding.noRealtimeDataSecond.visibility = if (
-                secondBusList.arrival.none { arrival -> arrival.isRealtime }
-            ) View.VISIBLE else View.GONE
+            val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000759 && bus.route.seq == 216000075 }
+            val secondBusList = busList.firstOrNull { bus -> bus.stop.seq == 213000487 && bus.route.seq == 216000075 }
+            if (firstBusList == null) {
+                busFirstAdapter.updateData(emptyList())
+                binding.noRealtimeDataFirst.visibility = View.VISIBLE
+            } else {
+                busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
+                    BusArrivalItem(firstBusList.route.name, arrival)
+                })
+                binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
+            }
+            if (secondBusList == null) {
+                busSecondAdapter.updateData(emptyList())
+                binding.noRealtimeDataSecond.visibility = View.VISIBLE
+            } else {
+                busSecondAdapter.updateData(secondBusList.arrival.filter {
+                    !it.isRealtime
+                }.map { arrival ->
+                    BusArrivalItem(secondBusList.route.name, arrival)
+                })
+                binding.noRealtimeDataSecond.visibility = if (
+                    secondBusList.arrival.none { arrival -> arrival.isRealtime }
+                ) View.VISIBLE else View.GONE
+            }
         }
         binding.apply {
             headerFirst.text = getString(R.string.bus_header_format, "50", getString(R.string.bus_stop_terminal))

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSeoulFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSeoulFragment.kt
@@ -52,7 +52,12 @@ class BusTabSeoulFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000379 && bus.route.seq == 216000061 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000379 && bus.route.seq == 216000061 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
@@ -77,7 +82,12 @@ class BusTabSeoulFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000381 && bus.route.seq == 216000061 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000381 && bus.route.seq == 216000061 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
@@ -102,7 +112,12 @@ class BusTabSeoulFragment @Inject constructor() : Fragment() {
                         }
                     }
                     parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.first { bus -> bus.stop.seq == 216000383 && bus.route.seq == 216000061 }
+                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000383 && bus.route.seq == 216000061 }
+                        if (firstBusList == null) {
+                            busFirstAdapter.updateData(emptyList())
+                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                            return@observe
+                        }
                         busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/timetable/BusRouteDialogViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/timetable/BusRouteDialogViewModel.kt
@@ -28,7 +28,7 @@ class BusRouteDialogViewModel @Inject constructor(private val apolloClient: Apol
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.bus != null) {
-                val route = response.data?.bus?.first()
+                val route = response.data?.bus?.firstOrNull()
                 if (route != null) { _result.value = route }
                 _queryError.value = null
             } else {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/setting/LanguageSettingDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/setting/LanguageSettingDialog.kt
@@ -3,7 +3,6 @@ import app.kobuggi.hyuabot.util.AnalyticsContentType
 import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -13,7 +12,6 @@ import androidx.core.os.LocaleListCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import app.kobuggi.hyuabot.databinding.DialogSettingLanguageBinding
-import app.kobuggi.hyuabot.ui.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -46,12 +44,5 @@ class LanguageSettingDialog @Inject constructor() : DialogFragment() {
             dismiss()
         }
         return binding.root
-    }
-
-    override fun onDismiss(dialog: DialogInterface) {
-        super.onDismiss(dialog)
-        if (requireActivity() is MainActivity){
-            (requireActivity() as MainActivity).onDismiss(dialog)
-        }
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleStopDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleStopDialog.kt
@@ -189,6 +189,10 @@ class ShuttleStopDialog @Inject constructor() : BottomSheetDialogFragment(), OnM
         return dialog
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        binding.stopMapView.onSaveInstanceState(outState)
+    }
     override fun onStart() {
         super.onStart()
         binding.stopMapView.onStart()

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleStopDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleStopDialog.kt
@@ -87,9 +87,9 @@ class ShuttleStopDialog @Inject constructor() : BottomSheetDialogFragment(), OnM
         viewModel.departureList.observe(viewLifecycleOwner) {
             when (stopID) {
                 R.string.shuttle_tab_dormitory_out, R.string.shuttle_tab_shuttlecock_out -> {
-                    val departureForStation = it.first { item -> item.destination == "STATION" }.entries.sortedBy { item -> item.time }
-                    val departureForTerminal = it.first { item -> item.destination == "TERMINAL" }.entries.sortedBy { item -> item.time }
-                    val departureForJungangStation = it.first { item -> item.destination == "JUNGANG" }.entries.sortedBy { item -> item.time }
+                    val departureForStation = it.firstOrNull { item -> item.destination == "STATION" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
+                    val departureForTerminal = it.firstOrNull { item -> item.destination == "TERMINAL" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
+                    val departureForJungangStation = it.firstOrNull { item -> item.destination == "JUNGANG" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
                     val weekdaysStationDepartureList = departureForStation.filter { item -> item.weekday }
                     val weekendsStationDepartureList = departureForStation.filter { item -> !item.weekday }
                     val weekdaysTerminalDepartureList = departureForTerminal.filter { item -> item.weekday }
@@ -124,9 +124,9 @@ class ShuttleStopDialog @Inject constructor() : BottomSheetDialogFragment(), OnM
                     }
                 }
                 R.string.shuttle_tab_station -> {
-                    val departureForCampus = it.first { item -> item.destination == "CAMPUS" }.entries.sortedBy { item -> item.time }
-                    val departureForTerminal = it.first { item -> item.destination == "TERMINAL" }.entries.sortedBy { item -> item.time }
-                    val departureForJungangStation = it.first { item -> item.destination == "JUNGANG" }.entries.sortedBy { item -> item.time }
+                    val departureForCampus = it.firstOrNull { item -> item.destination == "CAMPUS" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
+                    val departureForTerminal = it.firstOrNull { item -> item.destination == "TERMINAL" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
+                    val departureForJungangStation = it.firstOrNull { item -> item.destination == "JUNGANG" }?.entries?.sortedBy { item -> item.time } ?: emptyList()
                     val weekdaysDormitoryDepartureList = departureForCampus.filter { item -> item.weekday }
                     val weekendsDormitoryDepartureList = departureForCampus.filter { item -> !item.weekday }
                     val weekdaysTerminalDepartureList = departureForTerminal.filter { item -> item.weekday }
@@ -161,7 +161,7 @@ class ShuttleStopDialog @Inject constructor() : BottomSheetDialogFragment(), OnM
                     }
                 }
                 else -> {
-                    val departureList = it.first().entries.sortedBy { item -> item.time }
+                    val departureList = it.firstOrNull()?.entries?.sortedBy { item -> item.time } ?: emptyList()
                     val weekdaysDepartureList = departureList.filter { item -> item.weekday }
                     val weekendsDepartureList = departureList.filter { item -> !item.weekday }
                     binding.apply {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
@@ -55,10 +55,10 @@ class SubwayRealtimeViewModel @Inject constructor(private val apolloClient: Apol
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.subway != null) {
-                _campusYellow.value = response.data?.subway?.first { it.stationID == "K251" }
-                _campusBlue.value = response.data?.subway?.first { it.stationID == "K449" }
-                _oidoYellow.value = response.data?.subway?.first { it.stationID == "K258" }
-                _oidoBlue.value = response.data?.subway?.first { it.stationID == "K456" }
+                _campusYellow.value = response.data?.subway?.firstOrNull { it.stationID == "K251" }
+                _campusBlue.value = response.data?.subway?.firstOrNull { it.stationID == "K449" }
+                _oidoYellow.value = response.data?.subway?.firstOrNull { it.stationID == "K258" }
+                _oidoBlue.value = response.data?.subway?.firstOrNull { it.stationID == "K456" }
                 _queryError.value = null
             } else {
                 _queryError.value = QueryError.UNKNOWN_ERROR

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayTabTransferFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayTabTransferFragment.kt
@@ -54,7 +54,7 @@ class SubwayTabTransferFragment @Inject constructor() : Fragment() {
             if (it.oidoBlue == null || it.oidoYellow == null || it.campusBlue == null || it.campusYellow == null) {
                 return@observe
             }
-            val upRealtimeWithoutTransfer = it.oidoYellow.arrival.first { arrival -> arrival.direction == "up" }.entries.filter {
+            val upRealtimeWithoutTransfer = (it.oidoYellow.arrival.firstOrNull { arrival -> arrival.direction == "up" }?.entries ?: emptyList()).filter {
                 entry -> entry.terminal.stationID < "K251" && entry.isRealtime
             }.map {
                 entry -> SubwayTransferItem(
@@ -62,8 +62,8 @@ class SubwayTabTransferFragment @Inject constructor() : Fragment() {
                     transfer = null
                 )
             }
-            val upTimetableToTransfer = it.oidoBlue.arrival.first { arrival -> arrival.direction == "up" }.entries
-            val upRealtimeWithTransfer = it.oidoYellow.arrival.first { arrival -> arrival.direction == "up" }.entries.filter {
+            val upTimetableToTransfer = it.oidoBlue.arrival.firstOrNull { arrival -> arrival.direction == "up" }?.entries ?: emptyList()
+            val upRealtimeWithTransfer = (it.oidoYellow.arrival.firstOrNull { arrival -> arrival.direction == "up" }?.entries ?: emptyList()).filter {
                     entry -> entry.terminal.stationID >= "K251" && entry.isRealtime
             }.map {
                 entry -> SubwayTransferItem(
@@ -71,7 +71,7 @@ class SubwayTabTransferFragment @Inject constructor() : Fragment() {
                     transfer = upTimetableToTransfer.firstOrNull { transfer -> transfer.minutes > entry.minutes }
                 )
             }
-            val downRealtimeWithoutTransfer = it.campusYellow.arrival.first { arrival -> arrival.direction == "down" }.entries.filter {
+            val downRealtimeWithoutTransfer = (it.campusYellow.arrival.firstOrNull { arrival -> arrival.direction == "down" }?.entries ?: emptyList()).filter {
                 entry -> entry.terminal.stationID > "K258" && entry.isRealtime && entry.terminal.stationID.startsWith("K2")
             }.map {
                 entry -> SubwayTransferItem(
@@ -79,10 +79,10 @@ class SubwayTabTransferFragment @Inject constructor() : Fragment() {
                     transfer = null
                 )
             }
-            val downTimetableToTransfer = it.oidoYellow.arrival.first { arrival -> arrival.direction == "down" }.entries.filter {
+            val downTimetableToTransfer = (it.oidoYellow.arrival.firstOrNull { arrival -> arrival.direction == "down" }?.entries ?: emptyList()).filter {
                     entry -> entry.origin?.stationID == "K258"
             }
-            val downRealtimeWithTransfer = it.campusBlue.arrival.first { arrival -> arrival.direction == "down" }.entries.filter {
+            val downRealtimeWithTransfer = (it.campusBlue.arrival.firstOrNull { arrival -> arrival.direction == "down" }?.entries ?: emptyList()).filter {
                 entry -> entry.terminal.stationID == "K456"
             }.map {
                 entry ->

--- a/app/src/main/java/app/kobuggi/hyuabot/widget/CafeteriaWidgetProvider.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/widget/CafeteriaWidgetProvider.kt
@@ -18,8 +18,10 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -54,13 +56,16 @@ class CafeteriaWidgetProvider : AppWidgetProvider() {
         val pendingResult = goAsync()
         scope.launch {
             try {
-                val appContext = context.applicationContext
-                val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
-                val meal = WidgetMeal.current(now.toLocalTime())
-                val items = loadItems(appContext, meal, now.toLocalDate())
-                appWidgetIds.forEach {
-                    appWidgetManager.updateAppWidget(it, buildWidget(appContext, it, meal, now, items))
+                withTimeout(WIDGET_TIMEOUT_MS) {
+                    val appContext = context.applicationContext
+                    val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+                    val meal = WidgetMeal.current(now.toLocalTime())
+                    val items = loadItems(appContext, meal, now.toLocalDate())
+                    appWidgetIds.forEach {
+                        appWidgetManager.updateAppWidget(it, buildWidget(appContext, it, meal, now, items))
+                    }
                 }
+            } catch (_: TimeoutCancellationException) {
             } finally {
                 pendingResult.finish()
             }
@@ -241,6 +246,7 @@ class CafeteriaWidgetProvider : AppWidgetProvider() {
 
     companion object {
         const val ACTION_REFRESH = "app.kobuggi.hyuabot.widget.ACTION_REFRESH_CAFETERIA"
+        private const val WIDGET_TIMEOUT_MS = 8_000L
     }
 }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleWidgetProvider.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleWidgetProvider.kt
@@ -19,7 +19,9 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -53,12 +55,15 @@ abstract class ShuttleWidgetProvider : AppWidgetProvider() {
         val pendingResult = goAsync()
         scope.launch {
             try {
-                val appContext = context.applicationContext
-                val data = loadData(appContext)
-                val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
-                appWidgetIds.forEach {
-                    appWidgetManager.updateAppWidget(it, buildWidget(appContext, it, now, data))
+                withTimeout(WIDGET_TIMEOUT_MS) {
+                    val appContext = context.applicationContext
+                    val data = loadData(appContext)
+                    val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+                    appWidgetIds.forEach {
+                        appWidgetManager.updateAppWidget(it, buildWidget(appContext, it, now, data))
+                    }
                 }
+            } catch (_: TimeoutCancellationException) {
             } finally {
                 pendingResult.finish()
             }
@@ -261,6 +266,7 @@ abstract class ShuttleWidgetProvider : AppWidgetProvider() {
 
     companion object {
         const val ACTION_REFRESH = "app.kobuggi.hyuabot.widget.ACTION_REFRESH_SHUTTLE"
+        private const val WIDGET_TIMEOUT_MS = 8_000L
         private const val MAX_COMPACT_GROUPS = 2
         private const val MAX_COMPACT_TIMES = 2
 


### PR DESCRIPTION
## Changes
- 버스 실시간 데이터가 없을 때 앱 크래시 수정 (`first` → `firstOrNull`)
- 지하철 실시간 데이터가 없을 때 앱 크래시 수정
- 조회 결과(셔틀 등)가 비어있을 때 발생하는 크래시 수정
- 언어 변경 시 중복 액티비티 재생성으로 인한 크래시 수정
- 위젯 갱신 작업에 타임아웃(8초) 추가로 `goAsync` 미완료 ANR 방어 (학식·셔틀 위젯)
- 셔틀 정류장 다이얼로그 지도 상태 저장(`onSaveInstanceState`) 누락 보완