### PR TITLE
fix: Reduce realtime refresh interval to 15 seconds

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
@@ -76,7 +76,7 @@ class BusRealtimeViewModel @Inject constructor(
 
     fun start() {
         _disposable.add(
-            Observable.interval(0, 1, TimeUnit.MINUTES)
+            Observable.interval(0, 15, TimeUnit.SECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe{
                     try {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -98,7 +98,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
 
     fun start() {
         _disposable.add(
-            Observable.interval(0, 1, TimeUnit.MINUTES)
+            Observable.interval(0, 15, TimeUnit.SECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe{
                     try {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
@@ -69,7 +69,7 @@ class SubwayRealtimeViewModel @Inject constructor(private val apolloClient: Apol
 
     fun start() {
         _disposable.add(
-            Observable.interval(0, 1, TimeUnit.MINUTES)
+            Observable.interval(0, 15, TimeUnit.SECONDS)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe{
                     try {


### PR DESCRIPTION
## Summary
Reduce the auto-refresh polling interval for the realtime screens from 60s to **15s**, so arrival data updates more frequently.

Affected view models (`Observable.interval`):
- Bus realtime (`BusRealtimeViewModel`)
- Shuttle realtime (`ShuttleRealtimeViewModel`)
- Subway realtime (`SubwayRealtimeViewModel`)

## Notes
- Pairs with the backend updater changes that refresh realtime data sub-minute (bus ~10s, subway ~20s during service hours).