### PR TITLE
chore: Enable release minification and symbol artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,18 +39,20 @@ jobs:
 
       - name: Create local.properties
         run: |
+          : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+          : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+          : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+          : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
           echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
           echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
           echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
           echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
-          echo "MAP_API_KEY=\"$MAP_KEY\"" >> local.properties
-          echo "API_URL=\"$RELEASE_API_URL\"" >> local.properties
+          echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
         env:
           SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
           SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
           SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
-          MAP_KEY: ${{ secrets.MAP_KEY }}
-          API_URL: ${{ secrets.API_URL }}
+          MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
       - name: Create google-services.json
         run: |
             echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json
@@ -63,5 +65,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release
-          path: app/build/outputs/bundle/release/app-release.aab
+          path: app/build/outputs/bundle/productionRelease/app-production-release.aab
           retention-days: 3

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -32,18 +32,20 @@ jobs:
 
       - name: Create local.properties
         run: |
+            : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+            : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+            : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+            : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
             echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
             echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
             echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
             echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
-            echo "MAP_API_KEY=\"$MAP_KEY\"" >> local.properties
-            echo "API_URL=\"$RELEASE_API_URL\"" >> local.properties
+            echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
         env:
             SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
             SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
             SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
-            MAP_KEY: ${{ secrets.MAP_KEY }}
-            API_URL: ${{ secrets.API_URL }}
+            MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
 
       - name: Create google-services.json
         run: echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,10 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE"
+            }
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("config")
         }
@@ -68,17 +71,6 @@ android {
     bundle {
         language {
             enableSplit = false
-        }
-    }
-
-    packaging {
-        jniLibs {
-            keepDebugSymbols.addAll(
-                listOf(
-                    "**/libdatastore_shared_counter.so",
-                    "**/libnavermap.so",
-                )
-            )
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,7 +14,8 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable,*Annotation*,Signature,InnerClasses,EnclosingMethod
+-dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.hiltPlugin) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.secretsGradlePlugin) apply false
+    alias(libs.plugins.googleServicesPlugin) apply false
     alias(libs.plugins.crashlyticsPlugin) apply false
     alias(libs.plugins.apollo) apply false
     alias(libs.plugins.composeCompiler) apply false

--- a/watch/build.gradle.kts
+++ b/watch/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/watch/proguard-rules.pro
+++ b/watch/proguard-rules.pro
@@ -14,7 +14,8 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable,*Annotation*,Signature,InnerClasses,EnclosingMethod
+-dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.


### PR DESCRIPTION
## Changes

- Enable R8 minification for app and watch release builds
- Preserve source and line metadata in ProGuard rules for crash analysis
- Add the release native debug symbol level configuration
- Register the Google Services plugin at the root so Crashlytics mapping upload tasks are created correctly
- Remove manual JNI keep-debug-symbol packaging so the standard strip and symbol extraction path can run

## Checks

- ./gradlew assembleProductionRelease :app:bundleProductionRelease
- Installed the minified production release APK on emulator and checked startup logs for fatal/runtime class resolution errors
- Confirmed the production release AAB contains the ProGuard mapping metadata

## Notes

- The local SDK does not include NDK/symbol tools, so native debug symbol metadata could not be generated locally; the Gradle config now opts into the standard symbol table path for environments with those tools installed.