### PR TITLE
feat: Bump Version 5.1.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 514000000
-        versionName = "5.1.4"
+        versionCode = 515000000
+        versionName = "5.1.5"
         signingConfig = signingConfigs.getByName("config")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
@@ -311,6 +311,8 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             userDataStorePreferences.edit { preferences ->
                 val current = preferences[COACHMARKS_SEEN_KEY] ?: emptySet()
                 preferences[COACHMARKS_SEEN_KEY] = current + screen
+                val resetKeys = preferences[COACHMARK_RESET_KEYS_KEY] ?: emptySet()
+                preferences[COACHMARK_RESET_KEYS_KEY] = resetKeys - screen
             }
         }
     }
@@ -320,6 +322,8 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             userDataStorePreferences.edit { preferences ->
                 val current = preferences[COACHMARKS_SEEN_KEY] ?: emptySet()
                 preferences[COACHMARKS_SEEN_KEY] = current - screen
+                val resetKeys = preferences[COACHMARK_RESET_KEYS_KEY] ?: emptySet()
+                preferences[COACHMARK_RESET_KEYS_KEY] = resetKeys + screen
             }
         }
     }
@@ -329,6 +333,7 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             userDataStorePreferences.edit { preferences ->
                 preferences.remove(COACHMARKS_SEEN_KEY)
                 preferences.remove(COACHMARK_INITIALIZED_KEY)
+                preferences.remove(COACHMARK_RESET_KEYS_KEY)
             }
         }
     }
@@ -338,7 +343,8 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             userDataStorePreferences.edit { preferences ->
                 if (!isFreshInstall) {
                     val current = preferences[COACHMARKS_SEEN_KEY] ?: emptySet()
-                    preferences[COACHMARKS_SEEN_KEY] = current + allCoachmarkKeys
+                    val resetKeys = preferences[COACHMARK_RESET_KEYS_KEY] ?: emptySet()
+                    preferences[COACHMARKS_SEEN_KEY] = current + (allCoachmarkKeys - resetKeys)
                     return@edit
                 }
                 if (preferences[COACHMARK_INITIALIZED_KEY] != true) {
@@ -363,5 +369,6 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
         private val REVIEW_REQUESTED_AT_KEY = longPreferencesKey("review_requested_at")
         private val COACHMARKS_SEEN_KEY = stringSetPreferencesKey("coachmarks_seen")
         private val COACHMARK_INITIALIZED_KEY = booleanPreferencesKey("coachmark_initialized")
+        private val COACHMARK_RESET_KEYS_KEY = stringSetPreferencesKey("coachmark_reset_keys")
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
@@ -333,14 +333,16 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
         }
     }
 
-    override suspend fun initCoachmarkBaselineIfNeeded(isFreshInstall: Boolean, existingFeatureKeys: Set<String>) {
+    override suspend fun syncCoachmarkEligibility(isFreshInstall: Boolean, allCoachmarkKeys: Set<String>) {
         Result.runCatching {
             userDataStorePreferences.edit { preferences ->
-                if (preferences[COACHMARK_INITIALIZED_KEY] == true) return@edit
-                preferences[COACHMARK_INITIALIZED_KEY] = true
                 if (!isFreshInstall) {
                     val current = preferences[COACHMARKS_SEEN_KEY] ?: emptySet()
-                    preferences[COACHMARKS_SEEN_KEY] = current + existingFeatureKeys
+                    preferences[COACHMARKS_SEEN_KEY] = current + allCoachmarkKeys
+                    return@edit
+                }
+                if (preferences[COACHMARK_INITIALIZED_KEY] != true) {
+                    preferences[COACHMARK_INITIALIZED_KEY] = true
                 }
             }
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
@@ -25,5 +25,5 @@ interface UserPreferencesRepositoryImpl {
     suspend fun markCoachmarkSeen(screen: String)
     suspend fun resetCoachmark(screen: String)
     suspend fun resetCoachmarks()
-    suspend fun initCoachmarkBaselineIfNeeded(isFreshInstall: Boolean, existingFeatureKeys: Set<String>)
+    suspend fun syncCoachmarkEligibility(isFreshInstall: Boolean, allCoachmarkKeys: Set<String>)
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/CoachmarkController.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/CoachmarkController.kt
@@ -2,20 +2,42 @@ package app.kobuggi.hyuabot.ui.common.coachmark
 
 import android.app.Activity
 import android.view.ViewGroup
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 
 object CoachmarkController {
     private const val OVERLAY_TAG = "coachmark_overlay"
 
-    fun show(activity: Activity, steps: List<CoachmarkStep>, onFinish: () -> Unit = {}) {
+    fun show(
+        activity: Activity,
+        steps: List<CoachmarkStep>,
+        lifecycleOwner: LifecycleOwner? = null,
+        onFinish: () -> Unit = {},
+    ) {
         if (steps.isEmpty()) {
             onFinish()
             return
         }
+        if (lifecycleOwner?.lifecycle?.currentState == Lifecycle.State.DESTROYED) return
+
         val root = activity.findViewById<ViewGroup>(android.R.id.content) ?: return
         if (root.findViewWithTag<CoachmarkOverlayView>(OVERLAY_TAG) != null) return
 
         val overlay = CoachmarkOverlayView(activity)
         overlay.tag = OVERLAY_TAG
+        var finished = false
+        val lifecycleObserver = lifecycleOwner?.let {
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    if (finished) return
+                    finished = true
+                    root.removeView(overlay)
+                }
+            }
+        }
+        lifecycleObserver?.let { lifecycleOwner.lifecycle.addObserver(it) }
+
         root.addView(
             overlay,
             ViewGroup.LayoutParams(
@@ -24,6 +46,9 @@ object CoachmarkController {
             )
         )
         overlay.setSteps(steps) {
+            if (finished) return@setSteps
+            finished = true
+            lifecycleObserver?.let { lifecycleOwner.lifecycle.removeObserver(it) }
             root.removeView(overlay)
             onFinish()
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/Coachmarks.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/Coachmarks.kt
@@ -2,6 +2,7 @@ package app.kobuggi.hyuabot.ui.common.coachmark
 
 import android.content.Context
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import kotlinx.coroutines.flow.first
@@ -59,13 +60,17 @@ fun Fragment.showCoachmarkOnce(
     key: String,
     steps: () -> List<CoachmarkStep>,
 ) {
-    viewLifecycleOwner.lifecycleScope.launch {
+    val owner = viewLifecycleOwner
+    owner.lifecycleScope.launch {
         requireContext().ensureCoachmarkBaseline(repository)
         if (repository.coachmarkSeen(key).first()) return@launch
-        view?.post {
-            if (!isAdded) return@post
-            CoachmarkController.show(requireActivity(), steps()) {
-                viewLifecycleOwner.lifecycleScope.launch {
+        val rootView = view ?: return@launch
+        rootView.post {
+            if (!isAdded || view == null || !owner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+                return@post
+            }
+            CoachmarkController.show(requireActivity(), steps(), owner) {
+                lifecycleScope.launch {
                     repository.markCoachmarkSeen(key)
                 }
             }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/Coachmarks.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/common/coachmark/Coachmarks.kt
@@ -21,19 +21,6 @@ object Coachmarks {
     const val MAP = "map"
     const val SETTING = "setting"
 
-    val EXISTING_FEATURE_KEYS = setOf(
-        SHUTTLE,
-        SHUTTLE_TIMETABLE,
-        SHUTTLE_BUS_ALTERNATIVE,
-        BUS,
-        SUBWAY,
-        CAFETERIA,
-        MENU,
-        READING_ROOM,
-        MAP,
-        SETTING,
-    )
-
     val USER_VISIBLE_KEYS = setOf(
         SHUTTLE,
         SHUTTLE_REALTIME_UPDATES,
@@ -49,10 +36,10 @@ object Coachmarks {
     )
 }
 
-suspend fun Context.ensureCoachmarkBaseline(repository: UserPreferencesRepository) {
+suspend fun Context.ensureCoachmarkEligibility(repository: UserPreferencesRepository) {
     val packageInfo = packageManager.getPackageInfo(packageName, 0)
     val isFreshInstall = packageInfo.firstInstallTime == packageInfo.lastUpdateTime
-    repository.initCoachmarkBaselineIfNeeded(isFreshInstall, Coachmarks.EXISTING_FEATURE_KEYS)
+    repository.syncCoachmarkEligibility(isFreshInstall, Coachmarks.USER_VISIBLE_KEYS)
 }
 
 fun Fragment.showCoachmarkOnce(
@@ -62,7 +49,7 @@ fun Fragment.showCoachmarkOnce(
 ) {
     val owner = viewLifecycleOwner
     owner.lifecycleScope.launch {
-        requireContext().ensureCoachmarkBaseline(repository)
+        requireContext().ensureCoachmarkEligibility(repository)
         if (repository.coachmarkSeen(key).first()) return@launch
         val rootView = view ?: return@launch
         rootView.post {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -26,7 +26,7 @@ import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkController
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkShape
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
-import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkBaseline
+import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkEligibility
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -252,7 +252,7 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
         coachmarkShown = true
         val owner = viewLifecycleOwner
         owner.lifecycleScope.launch {
-            requireContext().ensureCoachmarkBaseline(viewModel.userPreferencesRepository)
+            requireContext().ensureCoachmarkEligibility(viewModel.userPreferencesRepository)
             val showMainCoachmark = !viewModel.userPreferencesRepository.coachmarkSeen(COACHMARK_KEY).first()
             val showRealtimeUpdatesCoachmark =
                 !viewModel.userPreferencesRepository.coachmarkSeen(REALTIME_UPDATES_COACHMARK_KEY).first()

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.fragment.navArgs
@@ -249,7 +250,8 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
     private fun maybeShowCoachmark() {
         if (coachmarkShown) return
         coachmarkShown = true
-        viewLifecycleOwner.lifecycleScope.launch {
+        val owner = viewLifecycleOwner
+        owner.lifecycleScope.launch {
             requireContext().ensureCoachmarkBaseline(viewModel.userPreferencesRepository)
             val showMainCoachmark = !viewModel.userPreferencesRepository.coachmarkSeen(COACHMARK_KEY).first()
             val showRealtimeUpdatesCoachmark =
@@ -260,15 +262,18 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
             val originalDepartureTime = viewModel.userPreferencesRepository.getShowShuttleDepartureTime().first()
             setClosestStop = true
             binding.viewPager.setCurrentItem(0, false)
-            view?.post {
-                if (!isAdded) return@post
-                CoachmarkController.show(requireActivity(), buildShuttleCoachmarkSteps()) {
-                    if (isAdded) {
+            val rootView = view ?: return@launch
+            rootView.post {
+                if (!isAdded || view == null || !owner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+                    return@post
+                }
+                CoachmarkController.show(requireActivity(), buildShuttleCoachmarkSteps(), owner) {
+                    if (owner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
                         binding.showByDestination.isChecked = originalByDestination
                         binding.showDepartureTime.isChecked = originalDepartureTime
                     }
                     viewModel.setForceShowBusAlternative(false)
-                    viewLifecycleOwner.lifecycleScope.launch {
+                    lifecycleScope.launch {
                         viewModel.userPreferencesRepository.markCoachmarkSeen(COACHMARK_KEY)
                         viewModel.userPreferencesRepository.markCoachmarkSeen(REALTIME_UPDATES_COACHMARK_KEY)
                     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/timetable/ShuttleTimetableFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/timetable/ShuttleTimetableFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import app.kobuggi.hyuabot.R
@@ -190,13 +191,17 @@ class ShuttleTimetableFragment @Inject constructor() : Fragment() {
     }
 
     private fun maybeShowCoachmark() {
-        viewLifecycleOwner.lifecycleScope.launch {
+        val owner = viewLifecycleOwner
+        owner.lifecycleScope.launch {
             requireContext().ensureCoachmarkBaseline(userPreferencesRepository)
             if (userPreferencesRepository.coachmarkSeen(Coachmarks.SHUTTLE_TIMETABLE).first()) return@launch
-            view?.post {
-                if (!isAdded) return@post
-                CoachmarkController.show(requireActivity(), buildCoachmarkSteps()) {
-                    viewLifecycleOwner.lifecycleScope.launch {
+            val rootView = view ?: return@launch
+            rootView.post {
+                if (!isAdded || view == null || !owner.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+                    return@post
+                }
+                CoachmarkController.show(requireActivity(), buildCoachmarkSteps(), owner) {
+                    lifecycleScope.launch {
                         userPreferencesRepository.markCoachmarkSeen(Coachmarks.SHUTTLE_TIMETABLE)
                     }
                 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/timetable/ShuttleTimetableFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/timetable/ShuttleTimetableFragment.kt
@@ -21,7 +21,7 @@ import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkController
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkShape
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
-import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkBaseline
+import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkEligibility
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
@@ -193,7 +193,7 @@ class ShuttleTimetableFragment @Inject constructor() : Fragment() {
     private fun maybeShowCoachmark() {
         val owner = viewLifecycleOwner
         owner.lifecycleScope.launch {
-            requireContext().ensureCoachmarkBaseline(userPreferencesRepository)
+            requireContext().ensureCoachmarkEligibility(userPreferencesRepository)
             if (userPreferencesRepository.coachmarkSeen(Coachmarks.SHUTTLE_TIMETABLE).first()) return@launch
             val rootView = view ?: return@launch
             rootView.post {


### PR DESCRIPTION
## Changes

### 코치마크 안정성
- Fragment view가 사라진 뒤 코치마크 종료 콜백에서 viewLifecycleOwner에 접근하며 발생하던 크래시 수정
- 코치마크 overlay를 Fragment view lifecycle에 연결해 화면이 파괴되면 함께 제거되도록 개선
- 셔틀 실시간/시간표 화면의 직접 코치마크 호출부도 동일한 lifecycle 방어 적용

### 코치마크 노출 정책
- 코치마크는 최초 설치 사용자에게만 기본 노출되도록 변경
- 업데이트 사용자는 새 기능 코치마크가 자동으로 노출되지 않도록 처리
- 설정에서 코치마크를 reset한 경우에는 업데이트 사용자도 다시 볼 수 있도록 reset key 예외 처리 추가

### 버전
- 앱 버전을 5.1.5로 갱신

## Checks
- ./gradlew :app:compileDevDebugKotlin
- ./gradlew :app:tasks --quiet
