### PR TITLE
feat: Add Android test automation checks

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -8,10 +8,15 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   ktlint:
     name: Check Kotlin code style
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, android-gradle]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,6 +25,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -57,7 +68,7 @@ jobs:
 
   unit-test:
     name: Run unit tests
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, android-gradle]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,7 +132,7 @@ jobs:
 
   connected-android-test:
     name: Run connected Android tests
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, android-emulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -170,6 +181,7 @@ jobs:
             GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
       - name: Enable KVM
+        if: runner.os == 'Linux'
         run: |
             echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
             sudo udevadm control --reload-rules
@@ -180,7 +192,7 @@ jobs:
         with:
           api-level: 35
           target: google_apis
-          arch: x86_64
+          arch: ${{ runner.arch == 'ARM64' && 'arm64-v8a' || 'x86_64' }}
           profile: pixel_6
           disable-animations: true
           disable-linux-hw-accel: false
@@ -198,7 +210,7 @@ jobs:
 
   maestro-e2e:
     name: Run Maestro E2E smoke tests
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, android-emulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -257,6 +269,7 @@ jobs:
             maestro check-syntax .maestro/menu-destinations.yaml
 
       - name: Enable KVM
+        if: runner.os == 'Linux'
         run: |
             echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
             sudo udevadm control --reload-rules
@@ -267,7 +280,7 @@ jobs:
         with:
           api-level: 35
           target: google_apis
-          arch: x86_64
+          arch: ${{ runner.arch == 'ARM64' && 'arm64-v8a' || 'x86_64' }}
           profile: pixel_6
           disable-animations: true
           disable-linux-hw-accel: false
@@ -285,7 +298,7 @@ jobs:
 
   release-build:
     name: Build release bundle
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, android-gradle]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -54,3 +54,66 @@ jobs:
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck
+
+  unit-test:
+    name: Run unit tests
+    runs-on: [self-hosted, X64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get sign key
+        run: |
+            echo $BASE64_KEYSTORE | base64 --decode > app/release-key.jks
+        env:
+            BASE64_KEYSTORE: ${{ secrets.BASE64_KEYSTORE }}
+
+      - name: Create local.properties
+        run: |
+            : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+            : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+            : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+            : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
+            echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
+            echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
+            echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
+            echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
+            echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
+        env:
+            SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
+            SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
+            SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
+            MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
+
+      - name: Create google-services.json
+        run: echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json
+        env:
+            GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      - name: Run unit tests
+        run: ./gradlew testDevDebugUnitTest
+
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-reports
+          path: |
+            **/build/reports/tests/testDevDebugUnitTest/
+            **/build/test-results/testDevDebugUnitTest/
+          if-no-files-found: ignore

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -106,7 +106,7 @@ jobs:
             GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
       - name: Run unit tests
-        run: ./gradlew testDevDebugUnitTest
+        run: ./gradlew testDevDebugUnitTest app:koverVerifyDevDebug app:koverHtmlReportDevDebug app:koverXmlReportDevDebug
 
       - name: Upload unit test reports
         if: always()
@@ -116,4 +116,5 @@ jobs:
           path: |
             **/build/reports/tests/testDevDebugUnitTest/
             **/build/test-results/testDevDebugUnitTest/
+            **/build/reports/kover/
           if-no-files-found: ignore

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   ktlint:

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -169,6 +169,12 @@ jobs:
         env:
             GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
+      - name: Enable KVM
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
       - name: Run connected Android tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -177,6 +183,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           disable-animations: true
+          disable-linux-hw-accel: false
           script: ./gradlew app:connectedAndroidTest
 
       - name: Upload connected Android test reports
@@ -249,6 +256,12 @@ jobs:
             maestro check-syntax .maestro/main-navigation.yaml
             maestro check-syntax .maestro/menu-destinations.yaml
 
+      - name: Enable KVM
+        run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+
       - name: Run Maestro flows
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -257,6 +270,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           disable-animations: true
+          disable-linux-hw-accel: false
           script: |
             ./gradlew app:installDevDebug
             maestro test .maestro

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -132,7 +132,7 @@ jobs:
 
   connected-android-test:
     name: Run connected Android tests
-    runs-on: [self-hosted, android-emulator]
+    runs-on: [self-hosted, Linux, X64, android-emulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -183,9 +183,8 @@ jobs:
       - name: Enable KVM
         if: runner.os == 'Linux'
         run: |
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+            test -r /dev/kvm
+            test -w /dev/kvm
 
       - name: Run connected Android tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -271,9 +270,8 @@ jobs:
       - name: Enable KVM
         if: runner.os == 'Linux'
         run: |
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+            test -r /dev/kvm
+            test -w /dev/kvm
 
       - name: Run Maestro flows
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -118,3 +118,218 @@ jobs:
             **/build/test-results/testDevDebugUnitTest/
             **/build/reports/kover/
           if-no-files-found: ignore
+
+  connected-android-test:
+    name: Run connected Android tests
+    runs-on: [self-hosted, X64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get sign key
+        run: |
+            echo $BASE64_KEYSTORE | base64 --decode > app/release-key.jks
+        env:
+            BASE64_KEYSTORE: ${{ secrets.BASE64_KEYSTORE }}
+
+      - name: Create local.properties
+        run: |
+            : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+            : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+            : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+            : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
+            echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
+            echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
+            echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
+            echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
+            echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
+        env:
+            SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
+            SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
+            SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
+            MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
+
+      - name: Create google-services.json
+        run: echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json
+        env:
+            GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      - name: Run connected Android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: ./gradlew app:connectedAndroidTest
+
+      - name: Upload connected Android test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: connected-android-test-reports
+          path: |
+            **/build/reports/androidTests/connected/
+            **/build/outputs/androidTest-results/connected/
+          if-no-files-found: ignore
+
+  maestro-e2e:
+    name: Run Maestro E2E smoke tests
+    runs-on: [self-hosted, X64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get sign key
+        run: |
+            echo $BASE64_KEYSTORE | base64 --decode > app/release-key.jks
+        env:
+            BASE64_KEYSTORE: ${{ secrets.BASE64_KEYSTORE }}
+
+      - name: Create local.properties
+        run: |
+            : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+            : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+            : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+            : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
+            echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
+            echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
+            echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
+            echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
+            echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
+        env:
+            SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
+            SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
+            SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
+            MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
+
+      - name: Create google-services.json
+        run: echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json
+        env:
+            GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      - name: Install Maestro
+        run: |
+            curl -Ls "https://get.maestro.mobile.dev" | bash
+            echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Check Maestro flow syntax
+        run: |
+            maestro check-syntax .maestro/main-navigation.yaml
+            maestro check-syntax .maestro/menu-destinations.yaml
+
+      - name: Run Maestro flows
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            ./gradlew app:installDevDebug
+            maestro test .maestro
+
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-artifacts
+          path: ~/.maestro/tests/
+          if-no-files-found: ignore
+
+  release-build:
+    name: Build release bundle
+    runs-on: [self-hosted, X64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Get sign key
+        run: |
+            echo $BASE64_KEYSTORE | base64 --decode > app/release-key.jks
+            echo $BASE64_KEYSTORE | base64 --decode > watch/release-key.jks
+        env:
+            BASE64_KEYSTORE: ${{ secrets.BASE64_KEYSTORE }}
+
+      - name: Create local.properties
+        run: |
+            : "${SIGNED_KEY_ALIAS:?SIGNED_KEY_ALIAS is required}"
+            : "${SIGNED_KEY_PASSWORD:?SIGNED_KEY_PASSWORD is required}"
+            : "${SIGNED_STORE_PASSWORD:?SIGNED_STORE_PASSWORD is required}"
+            : "${MAP_CLIENT_ID:?MAP_CLIENT_ID is required}"
+            echo "SIGNED_KEY_ALIAS=$SIGNED_KEY_ALIAS" > local.properties
+            echo "SIGNED_KEY_PASSWORD=$SIGNED_KEY_PASSWORD" >> local.properties
+            echo "SIGNED_STORE_PASSWORD=$SIGNED_STORE_PASSWORD" >> local.properties
+            echo "SIGNING_KEY_FILE=./release-key.jks" >> local.properties
+            echo "MAP_CLIENT_ID=$MAP_CLIENT_ID" >> local.properties
+        env:
+            SIGNED_KEY_ALIAS: ${{ secrets.SIGNED_KEY_ALIAS }}
+            SIGNED_KEY_PASSWORD: ${{ secrets.SIGNED_KEY_PASSWORD }}
+            SIGNED_STORE_PASSWORD: ${{ secrets.SIGNED_STORE_PASSWORD }}
+            MAP_CLIENT_ID: ${{ secrets.MAP_CLIENT_ID || secrets.MAP_KEY }}
+
+      - name: Create google-services.json
+        run: |
+            echo $GOOGLE_SERVICES_JSON | base64 --decode > app/google-services.json
+            echo $GOOGLE_SERVICES_JSON | base64 --decode > watch/google-services.json
+        env:
+            GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      - name: Build release bundle
+        run: ./gradlew bundleRelease
+
+      - name: Upload app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/bundle/productionRelease/app-production-release.aab
+          retention-days: 3

--- a/.maestro/main-navigation.yaml
+++ b/.maestro/main-navigation.yaml
@@ -1,0 +1,50 @@
+appId: app.kobuggi.hyuabot
+name: Main navigation smoke
+tags:
+  - smoke
+---
+- launchApp:
+    permissions:
+      all: allow
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Shuttle"
+- assertVisible: "Dormitory"
+- tapOn: "Bus"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Sangnoksu"
+- assertVisible: "Gangnam"
+- tapOn: "Subway"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Line 4"
+- assertVisible: "Suin-Bundang Line"
+- tapOn: "Cafeteria"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Breakfast"
+- assertVisible: "Lunch"
+- tapOn: "Menu"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Reading Room Seat Lookup"
+- assertVisible: "Campus Map"
+- assertVisible: "Campus Contacts"
+- assertVisible: "Academic Calendar"
+- assertVisible: "Settings"

--- a/.maestro/menu-destinations.yaml
+++ b/.maestro/menu-destinations.yaml
@@ -1,0 +1,49 @@
+appId: app.kobuggi.hyuabot
+name: Menu destinations smoke
+tags:
+  - smoke
+---
+- launchApp:
+    permissions:
+      all: allow
+- tapOn: "Menu"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- tapOn: "Reading Room Seat Lookup"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Reading Room Extension Reminder"
+- back
+- tapOn: "Menu"
+- tapOn: "Campus Map"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible: "Enter a room to search"
+- back
+- tapOn: "Menu"
+- tapOn: "Campus Contacts"
+- assertVisible: "Enter a contact to search"
+- back
+- tapOn: "Menu"
+- tapOn: "Academic Calendar"
+- assertVisible:
+    id: "app.kobuggi.hyuabot:id/calendar_view"
+- back
+- tapOn: "Menu"
+- tapOn: "Settings"
+- runFlow:
+    when:
+      visible: "Skip"
+    commands:
+      - tapOn: "Skip"
+- assertVisible:
+    id: "app.kobuggi.hyuabot:id/setting_campus"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.secretsGradlePlugin)
     alias(libs.plugins.googleServicesPlugin)
     alias(libs.plugins.crashlyticsPlugin)
+    alias(libs.plugins.kover)
 }
 
 val props = Properties()
@@ -104,6 +105,10 @@ android {
             ),
         )
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -112,6 +117,10 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.junit)
+    testImplementation(libs.androidx.core.testing)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     // Hilt
@@ -168,4 +177,30 @@ dependencies {
 
 hilt {
     enableAggregatingTask = true
+}
+
+kover {
+    reports {
+        variant("devDebug") {
+            filters {
+                includes {
+                    classes(
+                        "app.kobuggi.hyuabot.service.query.LocalDateAdapter",
+                        "app.kobuggi.hyuabot.service.query.LocalTimeAdapter",
+                        "app.kobuggi.hyuabot.service.query.ZonedDateTimeAdapter",
+                        "app.kobuggi.hyuabot.ui.setting.CampusSettingDialogViewModel",
+                        "app.kobuggi.hyuabot.ui.setting.LanguageSettingDialogViewModel",
+                        "app.kobuggi.hyuabot.ui.setting.ThemeSettingDialogViewModel",
+                        "app.kobuggi.hyuabot.util.UIUtility",
+                        "app.kobuggi.hyuabot.widget.WidgetMeal",
+                    )
+                }
+            }
+            verify {
+                rule("logic line coverage") {
+                    minBound(100)
+                }
+            }
+        }
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,7 +122,9 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.espresso.contrib)
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
+++ b/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
@@ -1,0 +1,124 @@
+package app.kobuggi.hyuabot.ui
+
+import android.Manifest
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.service.preferences.userDataStore
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppNavigationSmokeTest {
+    @get:Rule
+    val permissions: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.POST_NOTIFICATIONS,
+    )
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun prepareAppState() {
+        context.getSharedPreferences("pref", Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("languageSuggestionShown", true)
+            .apply()
+
+        runBlocking {
+            context.userDataStore.edit { preferences ->
+                preferences[booleanPreferencesKey("coachmark_initialized")] = true
+                preferences[stringSetPreferencesKey("coachmarks_seen")] = setOf(
+                    "shuttle",
+                    "shuttle_realtime_updates",
+                    "shuttle_timetable",
+                    "shuttle_bus_alternative",
+                    "bus",
+                    "subway",
+                    "cafeteria",
+                    "menu",
+                    "reading_room",
+                    "map",
+                    "setting",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun topLevelTabsRender() {
+        ActivityScenario.launch(MainActivity::class.java).use {
+            onView(withId(R.id.bottom_navigation)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.shuttleRealtimeFragment)
+            onView(withId(R.id.viewPager)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.busRealtimeFragment)
+            onView(withId(R.id.viewPager)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.subwayRealtimeFragment)
+            onView(withId(R.id.viewPager)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.cafeteriaFragment)
+            onView(withId(R.id.date_picker_layout)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.menuFragment)
+            onView(withId(R.id.menu_recycler_view)).check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    fun menuDestinationsRender() {
+        ActivityScenario.launch(MainActivity::class.java).use {
+            openMenuDestination(R.string.menu_book)
+            onView(withId(R.id.reading_room_swipe_refresh_layout)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.menuFragment)
+            openMenuDestination(R.string.menu_contact)
+            onView(withId(R.id.contact_list_view)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.menuFragment)
+            openMenuDestination(R.string.menu_calendar)
+            onView(withId(R.id.calendar_view)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.menuFragment)
+            openMenuDestination(R.string.menu_settings)
+            onView(withId(R.id.setting_campus)).check(matches(isDisplayed()))
+            onView(withId(R.id.setting_language)).check(matches(isDisplayed()))
+            onView(withId(R.id.setting_theme)).check(matches(isDisplayed()))
+        }
+    }
+
+    private fun selectBottomTab(itemId: Int) {
+        onView(withId(itemId)).perform(click())
+    }
+
+    private fun openMenuDestination(titleRes: Int) {
+        selectBottomTab(R.id.menuFragment)
+        onView(withId(R.id.menu_recycler_view)).perform(
+            actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(titleRes)),
+                click(),
+            ),
+        )
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/service/query/ScalarAdaptersTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/service/query/ScalarAdaptersTest.kt
@@ -1,0 +1,48 @@
+package app.kobuggi.hyuabot.service.query
+
+import com.apollographql.apollo.api.CustomScalarAdapters
+import com.apollographql.apollo.api.json.MapJsonReader
+import com.apollographql.apollo.api.json.MapJsonWriter
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScalarAdaptersTest {
+    @Test
+    fun localDateAdapterReadsAndWritesIsoDate() {
+        val value = LocalDateAdapter.fromJson(MapJsonReader("2026-06-24"), CustomScalarAdapters.Empty)
+        val writer = MapJsonWriter()
+
+        LocalDateAdapter.toJson(writer, CustomScalarAdapters.Empty, value)
+
+        assertEquals(LocalDate.of(2026, 6, 24), value)
+        assertEquals("2026-06-24", writer.root())
+    }
+
+    @Test
+    fun localTimeAdapterReadsAndWritesIsoTime() {
+        val value = LocalTimeAdapter.fromJson(MapJsonReader("09:30:15"), CustomScalarAdapters.Empty)
+        val writer = MapJsonWriter()
+
+        LocalTimeAdapter.toJson(writer, CustomScalarAdapters.Empty, value)
+
+        assertEquals(LocalTime.of(9, 30, 15), value)
+        assertEquals("09:30:15", writer.root())
+    }
+
+    @Test
+    fun zonedDateTimeAdapterReadsAndWritesIsoDateTime() {
+        val value = ZonedDateTimeAdapter.fromJson(
+            MapJsonReader("2026-06-24T12:30:00+09:00[Asia/Seoul]"),
+            CustomScalarAdapters.Empty,
+        )
+        val writer = MapJsonWriter()
+
+        ZonedDateTimeAdapter.toJson(writer, CustomScalarAdapters.Empty, value)
+
+        assertEquals(ZonedDateTime.parse("2026-06-24T12:30:00+09:00[Asia/Seoul]"), value)
+        assertEquals("2026-06-24T12:30+09:00[Asia/Seoul]", writer.root())
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/test/LiveDataTestExt.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/test/LiveDataTestExt.kt
@@ -1,0 +1,22 @@
+package app.kobuggi.hyuabot.test
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+fun <T> LiveData<T>.valueForTest(): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(value: T) {
+            data = value
+            latch.countDown()
+            removeObserver(this)
+        }
+    }
+    observeForever(observer)
+    check(latch.await(2, TimeUnit.SECONDS)) { "LiveData value was never set." }
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/test/MainDispatcherRule.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/test/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package app.kobuggi.hyuabot.test
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/test/UserPreferencesRepositoryTestFactory.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/test/UserPreferencesRepositoryTestFactory.kt
@@ -1,0 +1,36 @@
+package app.kobuggi.hyuabot.test
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+
+class UserPreferencesRepositoryTestFactory(
+    private val testScope: TestScope,
+) {
+    private val dataStoreScopes = mutableListOf<CoroutineScope>()
+    private val files = mutableListOf<File>()
+
+    fun create(): UserPreferencesRepository {
+        val file = File.createTempFile("user-preferences", ".preferences_pb")
+        file.delete()
+        files += file
+        val dataStoreScope = CoroutineScope(testScope.coroutineContext + Job())
+        dataStoreScopes += dataStoreScope
+        return UserPreferencesRepository(
+            PreferenceDataStoreFactory.create(
+                scope = dataStoreScope,
+                produceFile = { file },
+            ),
+        )
+    }
+
+    fun cleanUp() {
+        dataStoreScopes.forEach { it.cancel() }
+        files.forEach { it.delete() }
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/ui/setting/CampusSettingDialogViewModelTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/ui/setting/CampusSettingDialogViewModelTest.kt
@@ -1,0 +1,37 @@
+package app.kobuggi.hyuabot.ui.setting
+
+import app.kobuggi.hyuabot.test.MainDispatcherRule
+import app.kobuggi.hyuabot.test.UserPreferencesRepositoryTestFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CampusSettingDialogViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var repositoryFactory: UserPreferencesRepositoryTestFactory
+
+    @After
+    fun tearDown() {
+        repositoryFactory.cleanUp()
+    }
+
+    @Test
+    fun setCampusIDPersistsCampusID() = runTest {
+        repositoryFactory = UserPreferencesRepositoryTestFactory(this)
+        val repository = repositoryFactory.create()
+        val viewModel = CampusSettingDialogViewModel(repository)
+
+        viewModel.setCampusID(1)
+        advanceUntilIdle()
+
+        assertEquals(1, repository.campusID.first())
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/ui/setting/LanguageSettingDialogViewModelTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/ui/setting/LanguageSettingDialogViewModelTest.kt
@@ -1,0 +1,20 @@
+package app.kobuggi.hyuabot.ui.setting
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class LanguageSettingDialogViewModelTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun setLocaleCodeUpdatesLocaleCode() {
+        val viewModel = LanguageSettingDialogViewModel()
+
+        viewModel.setLocaleCode("ko")
+
+        assertEquals("ko", viewModel.localeCode.value)
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/ui/setting/ThemeSettingDialogViewModelTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/ui/setting/ThemeSettingDialogViewModelTest.kt
@@ -1,0 +1,63 @@
+package app.kobuggi.hyuabot.ui.setting
+
+import app.kobuggi.hyuabot.test.MainDispatcherRule
+import app.kobuggi.hyuabot.test.UserPreferencesRepositoryTestFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThemeSettingDialogViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var repositoryFactory: UserPreferencesRepositoryTestFactory
+
+    @After
+    fun tearDown() {
+        repositoryFactory.cleanUp()
+    }
+
+    @Test
+    fun setDarkModePersistsDarkThemeWhenEnabled() = runTest {
+        repositoryFactory = UserPreferencesRepositoryTestFactory(this)
+        val repository = repositoryFactory.create()
+        val viewModel = ThemeSettingDialogViewModel(repository)
+
+        viewModel.setDarkMode(true)
+        advanceUntilIdle()
+
+        assertEquals("dark", repository.theme.first())
+    }
+
+    @Test
+    fun setDarkModePersistsLightThemeWhenDisabled() = runTest {
+        repositoryFactory = UserPreferencesRepositoryTestFactory(this)
+        val repository = repositoryFactory.create()
+        val viewModel = ThemeSettingDialogViewModel(repository)
+
+        viewModel.setDarkMode(false)
+        advanceUntilIdle()
+
+        assertEquals("light", repository.theme.first())
+    }
+
+    @Test
+    fun setDarkModeSystemClearsTheme() = runTest {
+        repositoryFactory = UserPreferencesRepositoryTestFactory(this)
+        val repository = repositoryFactory.create()
+        val viewModel = ThemeSettingDialogViewModel(repository)
+
+        viewModel.setDarkMode(true)
+        viewModel.setDarkModeSystem()
+        advanceUntilIdle()
+
+        assertNull(repository.theme.first())
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/util/UIUtilityTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/UIUtilityTest.kt
@@ -11,7 +11,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = Application::class, sdk = [36])
+@Config(application = Application::class, sdk = [35])
 class UIUtilityTest {
     @Test
     fun isDarkModeOnReturnsTrueForNightMode() {

--- a/app/src/test/java/app/kobuggi/hyuabot/util/UIUtilityTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/UIUtilityTest.kt
@@ -1,0 +1,33 @@
+package app.kobuggi.hyuabot.util
+
+import android.app.Application
+import android.content.res.Configuration
+import android.content.res.Resources
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+class UIUtilityTest {
+    @Test
+    fun isDarkModeOnReturnsTrueForNightMode() {
+        assertTrue(UIUtility.isDarkModeOn(resources(Configuration.UI_MODE_NIGHT_YES)))
+    }
+
+    @Test
+    fun isDarkModeOnReturnsFalseForNonNightModes() {
+        assertFalse(UIUtility.isDarkModeOn(resources(Configuration.UI_MODE_NIGHT_NO)))
+        assertFalse(UIUtility.isDarkModeOn(resources(Configuration.UI_MODE_NIGHT_UNDEFINED)))
+    }
+
+    private fun resources(nightMode: Int): Resources {
+        val resources = Resources.getSystem()
+        resources.configuration.uiMode =
+            (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or nightMode
+        return resources
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/widget/ShuttleWidgetSupportTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/widget/ShuttleWidgetSupportTest.kt
@@ -1,0 +1,137 @@
+package app.kobuggi.hyuabot.widget
+
+import android.app.Application
+import android.content.Context
+import android.location.Location
+import androidx.test.core.app.ApplicationProvider
+import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.ShuttleWidgetQuery
+import java.time.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+class ShuttleWidgetSupportTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun distanceToReturnsSquaredCoordinateDistance() {
+        val stop = ShuttleWidgetQuery.Stop(
+            __typename = "ShuttleStop",
+            latitude = 2.0,
+            longitude = 5.0,
+            name = "station",
+            timetable = timetable(),
+        )
+        val location = Location("test").apply {
+            latitude = -1.0
+            longitude = 1.0
+        }
+
+        assertEquals(25.0, ShuttleWidgetSupport.distanceTo(stop, location), 0.0)
+    }
+
+    @Test
+    fun makeGroupsFormatsFirstFiveTimesAndDropsEmptyDestinations() {
+        val groups = ShuttleWidgetSupport.makeGroups(
+            context,
+            timetable(
+                destination("STATION", 8, 9, 10, 11, 12, 13),
+                destination("UNKNOWN", 7),
+                destination("TERMINAL"),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                ShuttleGroup(
+                    context.getString(R.string.shuttle_bound_for_station),
+                    listOf("08:00", "09:00", "10:00", "11:00", "12:00"),
+                ),
+                ShuttleGroup("UNKNOWN", listOf("07:00")),
+            ),
+            groups,
+        )
+    }
+
+    @Test
+    fun stopDisplayNameMapsKnownStopCodesAndKeepsUnknownCode() {
+        assertEquals(
+            context.getString(R.string.shuttle_tab_dormitory_out),
+            ShuttleWidgetSupport.stopDisplayName(context, "dormitory_o"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_dormitory_out),
+            ShuttleWidgetSupport.stopDisplayName(context, "dormitory_i"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_shuttlecock_out),
+            ShuttleWidgetSupport.stopDisplayName(context, "shuttlecock_o"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_station),
+            ShuttleWidgetSupport.stopDisplayName(context, "station"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_terminal),
+            ShuttleWidgetSupport.stopDisplayName(context, "terminal"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_jungang_station),
+            ShuttleWidgetSupport.stopDisplayName(context, "jungang_stn"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_tab_shuttlecock_in),
+            ShuttleWidgetSupport.stopDisplayName(context, "shuttlecock_i"),
+        )
+        assertEquals("unknown", ShuttleWidgetSupport.stopDisplayName(context, "unknown"))
+    }
+
+    @Test
+    fun destinationDisplayNameMapsKnownDestinationCodesAndKeepsUnknownCode() {
+        assertEquals(
+            context.getString(R.string.shuttle_bound_for_station),
+            ShuttleWidgetSupport.destinationDisplayName(context, "STATION"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_bound_for_terminal),
+            ShuttleWidgetSupport.destinationDisplayName(context, "TERMINAL"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_bound_for_jungang_station),
+            ShuttleWidgetSupport.destinationDisplayName(context, "JUNGANG"),
+        )
+        assertEquals(
+            context.getString(R.string.shuttle_bound_for_dormitory),
+            ShuttleWidgetSupport.destinationDisplayName(context, "CAMPUS"),
+        )
+        assertEquals("UNKNOWN", ShuttleWidgetSupport.destinationDisplayName(context, "UNKNOWN"))
+    }
+
+    private fun timetable(
+        vararg destinations: ShuttleWidgetQuery.Destination,
+    ): ShuttleWidgetQuery.Timetable =
+        ShuttleWidgetQuery.Timetable(
+            __typename = "ShuttleTimetable",
+            destination = destinations.toList(),
+        )
+
+    private fun destination(
+        code: String,
+        vararg hours: Int,
+    ): ShuttleWidgetQuery.Destination =
+        ShuttleWidgetQuery.Destination(
+            __typename = "ShuttleDestination",
+            destination = code,
+            entries = hours.map {
+                ShuttleWidgetQuery.Entry(
+                    __typename = "ShuttleTimetableEntry",
+                    time = LocalTime.of(it, 0),
+                )
+            },
+        )
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/widget/ShuttleWidgetSupportTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/widget/ShuttleWidgetSupportTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = Application::class, sdk = [36])
+@Config(application = Application::class, sdk = [35])
 class ShuttleWidgetSupportTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/app/src/test/java/app/kobuggi/hyuabot/widget/WidgetMealTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/widget/WidgetMealTest.kt
@@ -1,0 +1,31 @@
+package app.kobuggi.hyuabot.widget
+
+import java.time.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WidgetMealTest {
+    @Test
+    fun currentReturnsBreakfastBeforeTen() {
+        assertEquals(WidgetMeal.BREAKFAST, WidgetMeal.current(LocalTime.of(0, 0)))
+        assertEquals(WidgetMeal.BREAKFAST, WidgetMeal.current(LocalTime.of(9, 59)))
+    }
+
+    @Test
+    fun currentReturnsLunchFromTenToBeforeFifteen() {
+        assertEquals(WidgetMeal.LUNCH, WidgetMeal.current(LocalTime.of(10, 0)))
+        assertEquals(WidgetMeal.LUNCH, WidgetMeal.current(LocalTime.of(14, 59)))
+    }
+
+    @Test
+    fun currentReturnsDinnerFromFifteenToBeforeTwenty() {
+        assertEquals(WidgetMeal.DINNER, WidgetMeal.current(LocalTime.of(15, 0)))
+        assertEquals(WidgetMeal.DINNER, WidgetMeal.current(LocalTime.of(19, 59)))
+    }
+
+    @Test
+    fun currentReturnsClosedFromTwenty() {
+        assertEquals(WidgetMeal.CLOSED, WidgetMeal.current(LocalTime.of(20, 0)))
+        assertEquals(WidgetMeal.CLOSED, WidgetMeal.current(LocalTime.of(23, 59)))
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinKsp) apply false
     alias(libs.plugins.hiltPlugin) apply false
     alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.kover) apply false
     alias(libs.plugins.secretsGradlePlugin) apply false
     alias(libs.plugins.googleServicesPlugin) apply false
     alias(libs.plugins.crashlyticsPlugin) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,9 @@ coreKtx = "1.19.0"
 coreTesting = "2.2.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
+testRules = "1.7.0"
 espressoCore = "3.7.0"
+espressoContrib = "3.7.0"
 appcompat = "1.7.1"
 material = "1.14.0"
 ksp = "2.3.8"
@@ -61,7 +63,9 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "testRules" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "espressoContrib" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.2.1"
 hilt = "2.59.2"
 kotlin = "2.3.21"
 coreKtx = "1.19.0"
+coreTesting = "2.2.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
@@ -10,9 +11,12 @@ appcompat = "1.7.1"
 material = "1.14.0"
 ksp = "2.3.8"
 ktlint = "14.2.0"
+kover = "0.9.8"
 navigation = "2.9.8"
+robolectric = "4.16.1"
 rxJava = "3.1.12"
 rxAndroid = "3.0.2"
+coroutinesTest = "1.10.2"
 gson = "2.14.0"
 okhttp = "5.4.0"
 apollo = "5.0.0"
@@ -52,11 +56,13 @@ naverMap = "3.23.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "coreTesting" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 materialCompose = { group = "androidx.compose.material3", name = "material3", version.ref = "materialCompose" }
@@ -65,6 +71,7 @@ navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx",
 navigation-dynamic-features-fragment = { group = "androidx.navigation", name = "navigation-dynamic-features-fragment", version.ref = "navigation" }
 rxJava = { group = "io.reactivex.rxjava3", name = "rxjava", version.ref = "rxJava" }
 rxAndroid = { group = "io.reactivex.rxjava3", name = "rxandroid", version.ref = "rxAndroid" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttpLogging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
@@ -119,6 +126,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinKsp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hiltPlugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 apollo = { id = "com.apollographql.apollo", version.ref = "apollo" }
 safeArgs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation" }
 secretsGradlePlugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }

--- a/watch/build.gradle.kts
+++ b/watch/build.gradle.kts
@@ -34,6 +34,7 @@ android {
         targetSdk = 34
         versionCode = 500100000
         versionName = "5.0.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     }
 
@@ -116,6 +117,8 @@ dependencies {
     implementation(libs.rxAndroid)
     implementation(libs.androidx.runtime.livedata)
     androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/watch/src/androidTest/java/app/kobuggi/hyuabot/presentation/WatchNavigationSmokeTest.kt
+++ b/watch/src/androidTest/java/app/kobuggi/hyuabot/presentation/WatchNavigationSmokeTest.kt
@@ -1,0 +1,35 @@
+package app.kobuggi.hyuabot.presentation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.kobuggi.hyuabot.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WatchNavigationSmokeTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun mainStopListRenders() {
+        composeTestRule.onNodeWithText(text(R.string.stop_dormitory)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_shuttlecock)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_station)).assertIsDisplayed()
+    }
+
+    @Test
+    fun stopDetailRendersAfterStopClick() {
+        composeTestRule.onNodeWithText(text(R.string.stop_dormitory)).performClick()
+
+        composeTestRule.onNodeWithText(text(R.string.stop_station)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_terminal)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_jungang)).assertIsDisplayed()
+    }
+
+    private fun text(resId: Int): String = composeTestRule.activity.getString(resId)
+}


### PR DESCRIPTION
## Changes

### 테스트 인프라
- GitHub Actions에 unit test, connected Android test, Maestro E2E, release bundle checks 추가
- Kover 기반 devDebug 로직 커버리지 검증 및 리포트 생성 추가
- app/watch UI smoke instrumentation 테스트 추가

### 로직 유닛 테스트
- query scalar adapter와 widget/domain utility 로직 테스트 추가
- 설정 ViewModel 로직 테스트 추가

### E2E smoke
- Maestro flow로 하단 탭과 메뉴 주요 화면 진입 경로 검증 추가

## Checks
- ./gradlew ktlintCheck
- ./gradlew testDevDebugUnitTest app:koverVerifyDevDebug app:koverHtmlReportDevDebug app:koverXmlReportDevDebug
- ./gradlew app:connectedAndroidTest
- maestro check-syntax .maestro/main-navigation.yaml
- maestro check-syntax .maestro/menu-destinations.yaml
- ./gradlew app:installDevDebug && maestro test .maestro
- ./gradlew bundleRelease
