### PR TITLE
feat: Add shuttle notices and stabilize Android UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 517000000
-        versionName = "5.1.7"
+        versionCode = 518000000
+        versionName = "5.1.8"
         signingConfig = signingConfigs.getByName("config")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,10 @@
             android:enabled="true"
             android:exported="false" />
         <receiver
+            android:name=".service.alarm.ShuttleServiceNoticeReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
             android:name=".widget.CafeteriaWidgetProvider"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
@@ -15,12 +15,12 @@ query HomePageQuery(
     }
     shuttle(input: {
         stops: [
-            { name: "dormitory_o", limit: { destination: 8 } },
-            { name: "shuttlecock_o", limit: { destination: 8 } },
-            { name: "station", limit: { destination: 8 } },
-            { name: "terminal", limit: { destination: 8 } },
-            { name: "jungang_stn", limit: { destination: 8 } },
-            { name: "shuttlecock_i", limit: { destination: 8 } },
+            { name: "dormitory_o", limit: { destination: 100 } },
+            { name: "shuttlecock_o", limit: { destination: 100 } },
+            { name: "station", limit: { destination: 100 } },
+            { name: "terminal", limit: { destination: 100 } },
+            { name: "jungang_stn", limit: { destination: 100 } },
+            { name: "shuttlecock_i", limit: { destination: 100 } },
         ],
         after: $after
     }) {
@@ -30,6 +30,7 @@ query HomePageQuery(
                 destination {
                     destination
                     entries {
+                        seq
                         route {
                             tag
                             name

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
@@ -8,12 +8,12 @@ query ShuttleRealtimePageQuery($language: String!, $after: LocalTime, $weekday: 
     },
     shuttle(input: {
         stops: [
-            { name: "dormitory_o", limit: { order: 8, destination: 3 } },
-            { name: "shuttlecock_o", limit: { order: 8, destination: 3 } },
-            { name: "station", limit: { order: 8, destination: 3 } },
-            { name: "terminal", limit: { order: 8, destination: 8 } },
-            { name: "jungang_stn", limit: { order: 8, destination: 8 } },
-            { name: "shuttlecock_i", limit: { order: 8, destination: 8 } },
+            { name: "dormitory_o", limit: { order: 100, destination: 100 } },
+            { name: "shuttlecock_o", limit: { order: 100, destination: 100 } },
+            { name: "station", limit: { order: 100, destination: 100 } },
+            { name: "terminal", limit: { order: 100, destination: 100 } },
+            { name: "jungang_stn", limit: { order: 100, destination: 100 } },
+            { name: "shuttlecock_i", limit: { order: 100, destination: 100 } },
         ],
         after: $after
     }) {

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleServiceNoticeQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleServiceNoticeQuery.graphql
@@ -1,0 +1,15 @@
+query ShuttleServiceNoticeQuery($start: Date!, $end: Date!) {
+    shuttle(input: {}) {
+        serviceNotices(start: $start, end: $end) {
+            id
+            kind
+            date
+            period {
+                type
+            }
+            holiday {
+                type
+            }
+        }
+    }
+}

--- a/app/src/main/graphql/schema.graphqls
+++ b/app/src/main/graphql/schema.graphqls
@@ -719,7 +719,21 @@ type Shuttle {
 
   holiday: ShuttleHoliday
 
+  serviceNotices(end: Date!, start: Date!): [ShuttleServiceNotice!]!
+
   stops: [ShuttleStop!]!
+}
+
+type ShuttleServiceNotice {
+  id: String!
+
+  kind: String!
+
+  date: Date!
+
+  period: ShuttlePeriod
+
+  holiday: ShuttleHoliday
 }
 
 type ShuttleArrival {

--- a/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeReceiver.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeReceiver.kt
@@ -1,0 +1,50 @@
+package app.kobuggi.hyuabot.service.alarm
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.ui.MainActivity
+
+class ShuttleServiceNoticeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+        val noticeId = intent.getStringExtra(EXTRA_NOTICE_ID).orEmpty()
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: context.getString(R.string.shuttle_service_notice_title)
+        val body = intent.getStringExtra(EXTRA_BODY).orEmpty()
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val notification = NotificationCompat.Builder(context, context.getString(R.string.shuttle_alarm_channel_id))
+            .setSmallIcon(R.drawable.ic_notification_shuttle)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setContentIntent(
+                PendingIntent.getActivity(
+                    context,
+                    noticeId.hashCode(),
+                    launchIntent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                ),
+            )
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(noticeId.hashCode(), notification)
+    }
+
+    companion object {
+        const val EXTRA_NOTICE_ID = "notice_id"
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_BODY = "body"
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeScheduler.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeScheduler.kt
@@ -1,10 +1,10 @@
 package app.kobuggi.hyuabot.service.alarm
 
-import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleServiceNoticeQuery
 import com.apollographql.apollo.ApolloClient
@@ -49,7 +49,6 @@ class ShuttleServiceNoticeScheduler @Inject constructor(
         prefs.edit().putStringSet(KEY_NOTICE_IDS, notices.map { it.id }.toSet()).apply()
     }
 
-    @SuppressLint("ScheduleExactAlarm")
     private fun schedule(notice: ShuttleServiceNoticeQuery.ServiceNotice) {
         val triggerAt = triggerTime(notice.date) ?: return
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
@@ -58,11 +57,13 @@ class ShuttleServiceNoticeScheduler @Inject constructor(
             putExtra(ShuttleServiceNoticeReceiver.EXTRA_TITLE, context.getString(R.string.shuttle_service_notice_title))
             putExtra(ShuttleServiceNoticeReceiver.EXTRA_BODY, notice.bodyText())
         }
-        alarmManager.setExactAndAllowWhileIdle(
-            AlarmManager.RTC_WAKEUP,
-            triggerAt.toInstant().toEpochMilli(),
-            pendingIntent(notice.id, intent),
-        )
+        val pendingIntent = pendingIntent(notice.id, intent)
+        val triggerAtMillis = triggerAt.toInstant().toEpochMilli()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || alarmManager.canScheduleExactAlarms()) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        } else {
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        }
     }
 
     private fun cancel(noticeId: String) {

--- a/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeScheduler.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/alarm/ShuttleServiceNoticeScheduler.kt
@@ -1,0 +1,127 @@
+package app.kobuggi.hyuabot.service.alarm
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.ShuttleServiceNoticeQuery
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.fetchPolicy
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ShuttleServiceNoticeScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val apolloClient: ApolloClient,
+) {
+    suspend fun sync() = withContext(Dispatchers.IO) {
+        val today = LocalDate.now(SERVICE_ZONE)
+        val response =
+            try {
+                apolloClient.query(
+                    ShuttleServiceNoticeQuery(
+                        start = today,
+                        end = today.plusDays(LOOKAHEAD_DAYS),
+                    ),
+                ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+            } catch (_: Exception) {
+                return@withContext
+            }
+        if (response.exception != null || response.hasErrors()) return@withContext
+        val notices = response.data?.shuttle?.serviceNotices ?: return@withContext
+
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        prefs.getStringSet(KEY_NOTICE_IDS, emptySet()).orEmpty().forEach(::cancel)
+        notices.forEach(::schedule)
+        prefs.edit().putStringSet(KEY_NOTICE_IDS, notices.map { it.id }.toSet()).apply()
+    }
+
+    @SuppressLint("ScheduleExactAlarm")
+    private fun schedule(notice: ShuttleServiceNoticeQuery.ServiceNotice) {
+        val triggerAt = triggerTime(notice.date) ?: return
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, ShuttleServiceNoticeReceiver::class.java).apply {
+            putExtra(ShuttleServiceNoticeReceiver.EXTRA_NOTICE_ID, notice.id)
+            putExtra(ShuttleServiceNoticeReceiver.EXTRA_TITLE, context.getString(R.string.shuttle_service_notice_title))
+            putExtra(ShuttleServiceNoticeReceiver.EXTRA_BODY, notice.bodyText())
+        }
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAt.toInstant().toEpochMilli(),
+            pendingIntent(notice.id, intent),
+        )
+    }
+
+    private fun cancel(noticeId: String) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent(noticeId, Intent(context, ShuttleServiceNoticeReceiver::class.java)))
+    }
+
+    private fun pendingIntent(
+        noticeId: String,
+        intent: Intent,
+    ): PendingIntent = PendingIntent.getBroadcast(
+        context,
+        noticeId.hashCode(),
+        intent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+    )
+
+    private fun triggerTime(date: LocalDate): ZonedDateTime? {
+        val now = ZonedDateTime.now(SERVICE_ZONE)
+        val preferred = date.minusDays(1).atTime(LocalTime.of(9, 0)).atZone(SERVICE_ZONE)
+        val fallback = date.atTime(LocalTime.of(8, 0)).atZone(SERVICE_ZONE)
+        return when {
+            preferred.isAfter(now) -> preferred
+            fallback.isAfter(now) -> fallback
+            else -> null
+        }
+    }
+
+    private fun ShuttleServiceNoticeQuery.ServiceNotice.bodyText(): String {
+        val dateText = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(date)
+        return when (kind) {
+            "period" -> context.getString(
+                R.string.shuttle_service_notice_period_body,
+                dateText,
+                period?.type?.let(::periodName) ?: context.getString(R.string.shuttle_service_notice_period_unknown),
+            )
+            "holiday" -> context.getString(
+                if (holiday?.type == "halt") {
+                    R.string.shuttle_service_notice_halt_body
+                } else {
+                    R.string.shuttle_service_notice_holiday_body
+                },
+                dateText,
+            )
+            else -> context.getString(R.string.shuttle_service_notice_generic_body, dateText)
+        }
+    }
+
+    private fun periodName(type: String): String = when (type) {
+        "semester" -> context.getString(R.string.shuttle_service_notice_period_semester)
+        "vacation" -> context.getString(R.string.shuttle_service_notice_period_vacation)
+        "vacation_session" -> context.getString(R.string.shuttle_service_notice_period_session)
+        else -> type
+    }
+
+    companion object {
+        private val SERVICE_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        private const val LOOKAHEAD_DAYS = 30L
+        private const val PREF_NAME = "shuttle_service_notice"
+        private const val KEY_NOTICE_IDS = "notice_ids"
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.ActivityMainBinding
+import app.kobuggi.hyuabot.service.alarm.ShuttleServiceNoticeScheduler
 import app.kobuggi.hyuabot.util.AnalyticsContentType
 import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
@@ -63,6 +64,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     @Inject
     lateinit var inAppReviewManager: InAppReviewManager
 
+    @Inject
+    lateinit var shuttleServiceNoticeScheduler: ShuttleServiceNoticeScheduler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -91,6 +95,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         checkLocationPermission()
         openBirthDayDialog()
         requestInAppReview()
+        syncShuttleServiceNotices()
         navController.handleDeepLink(intent)
     }
 
@@ -208,6 +213,12 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     private fun requestInAppReview() {
         lifecycleScope.launch {
             inAppReviewManager.maybeRequestReview(this@MainActivity)
+        }
+    }
+
+    private fun syncShuttleServiceNotices() {
+        lifecycleScope.launch {
+            shuttleServiceNoticeScheduler.sync()
         }
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -73,6 +73,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         applyStatusBarStyle()
         firebaseAnalytics = Firebase.analytics
         binding.bottomNavigation.apply {
+            populateBottomNavigationMenu()
             setupWithNavController(navController)
             updateBottomNavigationLabels()
             setOnItemSelectedListener(this@MainActivity)
@@ -97,6 +98,15 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         requestInAppReview()
         syncShuttleServiceNotices()
         navController.handleDeepLink(intent)
+    }
+
+    private fun NavigationBarView.populateBottomNavigationMenu() {
+        if (menu.size() > 0) return
+        menu.add(0, R.id.homeFragment, 0, R.string.home).setIcon(R.drawable.ic_home)
+        menu.add(0, R.id.busRealtimeFragment, 1, R.string.bus).setIcon(R.drawable.ic_bus)
+        menu.add(0, R.id.subwayRealtimeFragment, 2, R.string.subway).setIcon(R.drawable.ic_subway)
+        menu.add(0, R.id.cafeteriaFragment, 3, R.string.cafeteria).setIcon(R.drawable.ic_cafeteria)
+        menu.add(0, R.id.menuFragment, 4, R.string.menu).setIcon(R.drawable.ic_more)
     }
 
     private fun applyStatusBarStyle() {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
@@ -15,6 +15,7 @@ import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import kotlinx.coroutines.launch
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -52,15 +53,8 @@ class BusRealtimeViewModel @Inject constructor(
     fun fetchData() {
         if (_result.value == null) _isLoading.value = true
         val locale = AppCompatDelegate.getApplicationLocales().get(0)
-        val language = if (locale == null) {
-            "KOREAN"
-        } else {
-            when (locale.language) {
-                "ko" -> "KOREAN"
-                "en", "ja", "zh" -> "ENGLISH"
-                else -> "KOREAN"
-            }
-        }
+        val appLanguage = locale?.language ?: Locale.getDefault().language
+        val language = if (appLanguage == Locale.KOREAN.language) "KOREAN" else "ENGLISH"
         viewModelScope.launch {
             val response = apolloClient.query(BusRealtimePageQuery(language)).fetchPolicy(FetchPolicy.NetworkOnly).execute()
             if (response.data == null || response.exception != null) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -63,6 +63,7 @@ class HomeFragment : Fragment() {
     private var debugSubwayTransferDestination: HomeSubwayTransferDestination? = null
     private var noticePosition = 0
     private var noticeManuallyScrolled = false
+    private var locationCancellationTokenSource: CancellationTokenSource? = null
     private lateinit var noticeAutoScrollRunnable: Runnable
     private val refreshHandler = Handler(Looper.getMainLooper())
     private val noticeScrollHandler = Handler(Looper.getMainLooper())
@@ -166,6 +167,8 @@ class HomeFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        locationCancellationTokenSource?.cancel()
+        locationCancellationTokenSource = null
         binding.noticeViewPager.adapter = null
         super.onDestroyView()
     }
@@ -273,9 +276,11 @@ class HomeFragment : Fragment() {
     private fun selectLastKnownLocation(client: FusedLocationProviderClient) {
         client.lastLocation
             .addOnSuccessListener { location ->
+                if (!isAdded || view == null) return@addOnSuccessListener
                 if (location != null && isFresh(location)) selectNearestDeparture(location)
             }
             .addOnFailureListener {
+                if (!isAdded || view == null) return@addOnFailureListener
                 Log.e("HomeFragment", "Failed to get last known location", it)
             }
     }
@@ -294,9 +299,15 @@ class HomeFragment : Fragment() {
     @SuppressLint("MissingPermission")
     private fun requestCurrentLocation(client: FusedLocationProviderClient) {
         if (!hasLocationPermission()) return
+        locationCancellationTokenSource?.cancel()
         val tokenSource = CancellationTokenSource()
+        locationCancellationTokenSource = tokenSource
         client.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, tokenSource.token)
             .addOnSuccessListener { location ->
+                if (locationCancellationTokenSource === tokenSource) {
+                    locationCancellationTokenSource = null
+                }
+                if (!isAdded || view == null) return@addOnSuccessListener
                 if (location != null) {
                     selectNearestDeparture(location)
                 } else {
@@ -304,12 +315,17 @@ class HomeFragment : Fragment() {
                 }
             }
             .addOnFailureListener {
+                if (locationCancellationTokenSource === tokenSource) {
+                    locationCancellationTokenSource = null
+                }
+                if (!isAdded || view == null) return@addOnFailureListener
                 Log.e("HomeFragment", "Failed to get user location", it)
                 selectLastKnownLocation(client)
             }
     }
 
     private fun selectNearestDeparture(location: Location) {
+        if (!isAdded || view == null) return
         if (lockDepartureSelection) return
         val nearestDeparture = HomeDeparture.entries.minByOrNull { it.distanceTo(location) } ?: return
         if (nearestDeparture == selectedDeparture) return

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -360,11 +360,18 @@ class HomeFragment : Fragment() {
         val transferGroups = shuttleCandidates.map { transferConnections(data, route, it) }
         val shuttleRows = displayCandidates.mapIndexed { index, entry ->
             val routeDisplay = routeDisplay(route, entry)
+            val subtitle = routeSubtitle(entry).let {
+                if (entry.seq == shuttleCandidates.lastOrNull()?.seq) {
+                    getString(R.string.home_shuttle_last_run_subtitle, it)
+                } else {
+                    it
+                }
+            }
             HomeShuttleMovement(
                 HomeRow(
                     badge = routeDisplay.badge,
                     title = getString(R.string.home_departure_format, compactTime(entry.time)),
-                    subtitle = routeSubtitle(entry),
+                    subtitle = subtitle,
                     trailing = minutesUntil(entry.time)?.let { getString(R.string.home_minutes, it) } ?: getString(R.string.home_check),
                     tint = routeDisplay.tint,
                 ),

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -225,7 +225,7 @@ class HomeFragment : Fragment() {
         val strokeColor = ContextCompat.getColorStateList(requireContext(), R.color.home_destination_button_stroke)
         selectedDeparture.destinations.forEach { destination ->
             val button = MaterialButton(buttonContext, null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
-                id = View.generateViewId()
+                id = destination.buttonIdRes
                 text = getString(destination.titleRes)
                 minHeight = resources.getDimensionPixelSize(R.dimen.home_destination_button_min_height)
                 minWidth = 0
@@ -1325,11 +1325,14 @@ private enum class HomeDeparture(
     }
 }
 
-private enum class HomeDestination(val titleRes: Int) {
-    STATION(R.string.home_destination_station),
-    TERMINAL(R.string.home_destination_terminal),
-    JUNGANG(R.string.home_destination_jungang),
-    DORMITORY(R.string.home_destination_dormitory);
+private enum class HomeDestination(
+    val titleRes: Int,
+    val buttonIdRes: Int,
+) {
+    STATION(R.string.home_destination_station, R.id.home_destination_station),
+    TERMINAL(R.string.home_destination_terminal, R.id.home_destination_terminal),
+    JUNGANG(R.string.home_destination_jungang, R.id.home_destination_jungang),
+    DORMITORY(R.string.home_destination_dormitory, R.id.home_destination_dormitory);
 
     val debugValue: String
         get() = when (this) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.appcompat.app.AppCompatDelegate
 import app.kobuggi.hyuabot.BusDepartureLogDialogQuery
 import app.kobuggi.hyuabot.HomePageQuery
+import app.kobuggi.hyuabot.service.alarm.ShuttleServiceNoticeScheduler
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.type.BusRouteStopInput
 import app.kobuggi.hyuabot.util.QueryError
@@ -28,6 +29,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val apolloClient: ApolloClient,
     private val userPreferencesRepository: UserPreferencesRepository,
+    private val shuttleServiceNoticeScheduler: ShuttleServiceNoticeScheduler,
 ) : ViewModel() {
     private val _isLoading = MutableLiveData(false)
     private val _data = MutableLiveData<HomePageQuery.Data?>()
@@ -88,6 +90,7 @@ class HomeViewModel @Inject constructor(
                 } else {
                     _data.value = response.data
                     _bus50TerminalLogTimes.value = fetchBus50TerminalLogTimes(now.toLocalDate())
+                    shuttleServiceNoticeScheduler.sync()
                     _queryError.value = null
                 }
             } catch (_: Exception) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -23,6 +23,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -133,11 +134,8 @@ class HomeViewModel @Inject constructor(
 
     private fun currentNoticeLanguage(): String {
         val locale = AppCompatDelegate.getApplicationLocales().get(0)
-        return when (locale?.language) {
-            "ko" -> "KOREAN"
-            "en", "ja", "zh" -> "ENGLISH"
-            else -> "KOREAN"
-        }
+        val language = locale?.language ?: Locale.getDefault().language
+        return if (language == Locale.KOREAN.language) "KOREAN" else "ENGLISH"
     }
 
     private fun homeBusInput(): List<BusRouteStopInput> = listOf(

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
@@ -7,6 +7,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
@@ -34,6 +35,7 @@ class ShuttleRealtimeByDestinationListAdapter(
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Entry) {
             val isLastRun = item.seq in lastRunSeqs
+            binding.lastRunBadge.visibility = if (isLastRun) View.VISIBLE else View.GONE
             if ((stopID == R.string.shuttle_tab_dormitory_out || stopID == R.string.shuttle_tab_shuttlecock_out)) {
                 if (headerID == R.string.shuttle_header_bound_for_station || headerID == R.string.shuttle_header_bound_for_jungang_station) {
                     when (item.route.tag) {
@@ -162,18 +164,15 @@ class ShuttleRealtimeByDestinationListAdapter(
             shuttleRealtimeViewModel.showDepartureTime.observe(lifecycleOwner) {
                 if (!it) {
                     val remainingTime = item.time.minusHours(now.hour.toLong()).minusMinutes(now.minute.toLong() + 1)
-                    binding.shuttleTimeText.text = formatTimeText(
-                        context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString()),
-                        isLastRun
+                    binding.shuttleTimeText.text = context.getString(
+                        R.string.shuttle_time_type_2,
+                        (remainingTime.hour * 60 + remainingTime.minute).toString()
                     )
                 } else {
-                    binding.shuttleTimeText.text = formatTimeText(
-                        context.getString(
-                            R.string.shuttle_time_type_1,
-                            item.time.hour.toString().padStart(2, '0'),
-                            item.time.minute.toString().padStart(2, '0')
-                        ),
-                        isLastRun
+                    binding.shuttleTimeText.text = context.getString(
+                        R.string.shuttle_time_type_1,
+                        item.time.hour.toString().padStart(2, '0'),
+                        item.time.minute.toString().padStart(2, '0')
                     )
                 }
             }
@@ -237,6 +236,4 @@ class ShuttleRealtimeByDestinationListAdapter(
         }
     }
 
-    private fun formatTimeText(timeText: String, isLastRun: Boolean): String =
-        if (isLastRun) "$timeText · ${context.getString(R.string.shuttle_last_run)}" else timeText
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
@@ -27,10 +27,13 @@ class ShuttleRealtimeByDestinationListAdapter(
     private var shuttleList: List<ShuttleRealtimePageQuery.Entry>,
     private val onAlarmClick: ((ShuttleRealtimePageQuery.Entry) -> Unit)? = null,
 ) : RecyclerView.Adapter<ShuttleRealtimeByDestinationListAdapter.ViewHolder>() {
+    private var lastRunSeqs: Set<Int> = emptySet()
+
     inner class ViewHolder(private val binding: ItemShuttleRealtimeBinding) : RecyclerView.ViewHolder(binding.root) {
         val darkMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK == android.content.res.Configuration.UI_MODE_NIGHT_YES
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Entry) {
+            binding.lastRunView.visibility = if (item.seq in lastRunSeqs) ViewGroup.VISIBLE else ViewGroup.GONE
             if ((stopID == R.string.shuttle_tab_dormitory_out || stopID == R.string.shuttle_tab_shuttlecock_out)) {
                 if (headerID == R.string.shuttle_header_bound_for_station || headerID == R.string.shuttle_header_bound_for_jungang_station) {
                     when (item.route.tag) {
@@ -209,7 +212,11 @@ class ShuttleRealtimeByDestinationListAdapter(
 
     override fun getItemCount(): Int = shuttleList.size
 
-    fun updateData(newData: List<ShuttleRealtimePageQuery.Entry>) {
+    fun updateData(
+        newData: List<ShuttleRealtimePageQuery.Entry>,
+        lastRunSeqs: Set<Int> = emptySet(),
+    ) {
+        this.lastRunSeqs = lastRunSeqs
         if (shuttleList.size > newData.size) {
             shuttleList = newData
             notifyItemRangeChanged(0, shuttleList.size)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
@@ -33,7 +33,7 @@ class ShuttleRealtimeByDestinationListAdapter(
         val darkMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK == android.content.res.Configuration.UI_MODE_NIGHT_YES
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Entry) {
-            binding.lastRunView.visibility = if (item.seq in lastRunSeqs) ViewGroup.VISIBLE else ViewGroup.GONE
+            val isLastRun = item.seq in lastRunSeqs
             if ((stopID == R.string.shuttle_tab_dormitory_out || stopID == R.string.shuttle_tab_shuttlecock_out)) {
                 if (headerID == R.string.shuttle_header_bound_for_station || headerID == R.string.shuttle_header_bound_for_jungang_station) {
                     when (item.route.tag) {
@@ -162,12 +162,18 @@ class ShuttleRealtimeByDestinationListAdapter(
             shuttleRealtimeViewModel.showDepartureTime.observe(lifecycleOwner) {
                 if (!it) {
                     val remainingTime = item.time.minusHours(now.hour.toLong()).minusMinutes(now.minute.toLong() + 1)
-                    binding.shuttleTimeText.text = context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString())
+                    binding.shuttleTimeText.text = formatTimeText(
+                        context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString()),
+                        isLastRun
+                    )
                 } else {
-                    binding.shuttleTimeText.text = context.getString(
-                        R.string.shuttle_time_type_1,
-                        item.time.hour.toString().padStart(2, '0'),
-                        item.time.minute.toString().padStart(2, '0')
+                    binding.shuttleTimeText.text = formatTimeText(
+                        context.getString(
+                            R.string.shuttle_time_type_1,
+                            item.time.hour.toString().padStart(2, '0'),
+                            item.time.minute.toString().padStart(2, '0')
+                        ),
+                        isLastRun
                     )
                 }
             }
@@ -230,4 +236,7 @@ class ShuttleRealtimeByDestinationListAdapter(
             notifyItemRangeChanged(0, shuttleList.size)
         }
     }
+
+    private fun formatTimeText(timeText: String, isLastRun: Boolean): String =
+        if (isLastRun) "$timeText · ${context.getString(R.string.shuttle_last_run)}" else timeText
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
@@ -29,10 +29,13 @@ class ShuttleRealtimeByTimeListAdapter(
     private var shuttleList: List<ShuttleRealtimePageQuery.Order>,
     private val onAlarmClick: ((ShuttleRealtimePageQuery.Order) -> Unit)? = null,
 ) : RecyclerView.Adapter<ShuttleRealtimeByTimeListAdapter.ViewHolder>() {
+    private var lastRunSeqs: Set<Int> = emptySet()
+
     inner class ViewHolder(private val binding: ItemShuttleRealtimeBinding) : RecyclerView.ViewHolder(binding.root) {
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Order) {
             setStopText(context, binding.shuttleTypeText, binding.warningView, stopID, item)
+            binding.lastRunView.visibility = if (item.seq in lastRunSeqs) View.VISIBLE else View.GONE
             val now = LocalTime.now()
             shuttleRealtimeViewModel.showDepartureTime.observe(lifecycleOwner) {
                 if (!it) {
@@ -87,7 +90,11 @@ class ShuttleRealtimeByTimeListAdapter(
 
     override fun getItemCount(): Int = shuttleList.size
 
-    fun updateData(newData: List<ShuttleRealtimePageQuery.Order>) {
+    fun updateData(
+        newData: List<ShuttleRealtimePageQuery.Order>,
+        lastRunSeqs: Set<Int> = emptySet(),
+    ) {
+        this.lastRunSeqs = lastRunSeqs
         if (shuttleList.size > newData.size) {
             shuttleList = newData
             notifyItemRangeChanged(0, shuttleList.size)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
@@ -35,17 +35,23 @@ class ShuttleRealtimeByTimeListAdapter(
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Order) {
             setStopText(context, binding.shuttleTypeText, binding.warningView, stopID, item)
-            binding.lastRunView.visibility = if (item.seq in lastRunSeqs) View.VISIBLE else View.GONE
+            val isLastRun = item.seq in lastRunSeqs
             val now = LocalTime.now()
             shuttleRealtimeViewModel.showDepartureTime.observe(lifecycleOwner) {
                 if (!it) {
                     val remainingTime = item.time.minusHours(now.hour.toLong()).minusMinutes(now.minute.toLong() + 1)
-                    binding.shuttleTimeText.text = context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString())
+                    binding.shuttleTimeText.text = formatTimeText(
+                        context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString()),
+                        isLastRun
+                    )
                 } else {
-                    binding.shuttleTimeText.text = context.getString(
-                        R.string.shuttle_time_type_1,
-                        item.time.hour.toString().padStart(2, '0'),
-                        item.time.minute.toString().padStart(2, '0')
+                    binding.shuttleTimeText.text = formatTimeText(
+                        context.getString(
+                            R.string.shuttle_time_type_1,
+                            item.time.hour.toString().padStart(2, '0'),
+                            item.time.minute.toString().padStart(2, '0')
+                        ),
+                        isLastRun
                     )
                 }
             }
@@ -108,6 +114,9 @@ class ShuttleRealtimeByTimeListAdapter(
             notifyItemRangeChanged(0, shuttleList.size)
         }
     }
+
+    private fun formatTimeText(timeText: String, isLastRun: Boolean): String =
+        if (isLastRun) "$timeText · ${context.getString(R.string.shuttle_last_run)}" else timeText
 
     private fun setStopText(context: Context, textView: TextView, warningView: MaterialCardView, stopID: Int, item: ShuttleRealtimePageQuery.Order) {
         val darkMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK == android.content.res.Configuration.UI_MODE_NIGHT_YES

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
@@ -36,22 +36,20 @@ class ShuttleRealtimeByTimeListAdapter(
         fun bind(item: ShuttleRealtimePageQuery.Order) {
             setStopText(context, binding.shuttleTypeText, binding.warningView, stopID, item)
             val isLastRun = item.seq in lastRunSeqs
+            binding.lastRunBadge.visibility = if (isLastRun) View.VISIBLE else View.GONE
             val now = LocalTime.now()
             shuttleRealtimeViewModel.showDepartureTime.observe(lifecycleOwner) {
                 if (!it) {
                     val remainingTime = item.time.minusHours(now.hour.toLong()).minusMinutes(now.minute.toLong() + 1)
-                    binding.shuttleTimeText.text = formatTimeText(
-                        context.getString(R.string.shuttle_time_type_2, (remainingTime.hour * 60 + remainingTime.minute).toString()),
-                        isLastRun
+                    binding.shuttleTimeText.text = context.getString(
+                        R.string.shuttle_time_type_2,
+                        (remainingTime.hour * 60 + remainingTime.minute).toString()
                     )
                 } else {
-                    binding.shuttleTimeText.text = formatTimeText(
-                        context.getString(
-                            R.string.shuttle_time_type_1,
-                            item.time.hour.toString().padStart(2, '0'),
-                            item.time.minute.toString().padStart(2, '0')
-                        ),
-                        isLastRun
+                    binding.shuttleTimeText.text = context.getString(
+                        R.string.shuttle_time_type_1,
+                        item.time.hour.toString().padStart(2, '0'),
+                        item.time.minute.toString().padStart(2, '0')
                     )
                 }
             }
@@ -114,9 +112,6 @@ class ShuttleRealtimeByTimeListAdapter(
             notifyItemRangeChanged(0, shuttleList.size)
         }
     }
-
-    private fun formatTimeText(timeText: String, isLastRun: Boolean): String =
-        if (isLastRun) "$timeText · ${context.getString(R.string.shuttle_last_run)}" else timeText
 
     private fun setStopText(context: Context, textView: TextView, warningView: MaterialCardView, stopID: Int, item: ShuttleRealtimePageQuery.Order) {
         val darkMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK == android.content.res.Configuration.UI_MODE_NIGHT_YES

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import java.time.LocalTime
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -80,15 +81,8 @@ class ShuttleRealtimeViewModel @Inject constructor(
     fun fetchData() {
         if (_result.value == null) _isLoading.value = true
         val locale = AppCompatDelegate.getApplicationLocales().get(0)
-        val language = if (locale == null) {
-            "KOREAN"
-        } else {
-            when (locale.language) {
-                "ko" -> "KOREAN"
-                "en", "ja", "zh" -> "ENGLISH"
-                else -> "KOREAN"
-            }
-        }
+        val appLanguage = locale?.language ?: Locale.getDefault().language
+        val language = if (appLanguage == Locale.KOREAN.language) "KOREAN" else "ENGLISH"
         viewModelScope.launch {
             val response = apolloClient.query(ShuttleRealtimePageQuery(
                 language,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabDormitoryFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabDormitoryFragment.kt
@@ -327,7 +327,7 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
             if (shuttleForStation.isEmpty()) {
                 binding.noRealtimeDataBoundForStation.visibility = View.VISIBLE
@@ -335,7 +335,7 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForStation.visibility = View.GONE
                 binding.realtimeViewBoundForStation.visibility = View.VISIBLE
-                shuttleStationAdapter.updateData(shuttleForStation.subList(0, min(3, shuttleForStation.size)))
+                shuttleStationAdapter.updateData(shuttleForStation.subList(0, min(3, shuttleForStation.size)), setOfNotNull(shuttleForStation.lastOrNull()?.seq))
             }
             if (shuttleForTerminal.isEmpty()) {
                 binding.noRealtimeDataBoundForTerminal.visibility = View.VISIBLE
@@ -343,7 +343,7 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForTerminal.visibility = View.GONE
                 binding.realtimeViewBoundForTerminal.visibility = View.VISIBLE
-                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)))
+                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)), setOfNotNull(shuttleForTerminal.lastOrNull()?.seq))
             }
             if (shuttleForJungangStation.isEmpty()) {
                 binding.noRealtimeDataBoundForJungangStation.visibility = View.VISIBLE
@@ -351,7 +351,7 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForJungangStation.visibility = View.GONE
                 binding.realtimeViewBoundForJungangStation.visibility = View.VISIBLE
-                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)))
+                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)), setOfNotNull(shuttleForJungangStation.lastOrNull()?.seq))
             }
         }
         parentViewModel.busAlternativeDormitory.observe(viewLifecycleOwner) { busMinutes ->

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabJungangStationFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabJungangStationFragment.kt
@@ -154,7 +154,7 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
             if (shuttleForCampus.isEmpty()) {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.VISIBLE
@@ -162,7 +162,7 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.GONE
                 binding.realtimeViewBoundForDormitory.visibility = View.VISIBLE
-                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)))
+                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)), setOfNotNull(shuttleForCampus.lastOrNull()?.seq))
             }
         }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockInFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockInFragment.kt
@@ -148,7 +148,7 @@ class ShuttleTabShuttlecockInFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
             if (shuttleForCampus.isEmpty()) {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.VISIBLE
@@ -156,7 +156,7 @@ class ShuttleTabShuttlecockInFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.GONE
                 binding.realtimeViewBoundForDormitory.visibility = View.VISIBLE
-                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)))
+                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)), setOfNotNull(shuttleForCampus.lastOrNull()?.seq))
             }
         }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockOutFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockOutFragment.kt
@@ -326,7 +326,7 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
             if (shuttleForStation.isEmpty()) {
                 binding.noRealtimeDataBoundForStation.visibility = View.VISIBLE
@@ -334,7 +334,7 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForStation.visibility = View.GONE
                 binding.realtimeViewBoundForStation.visibility = View.VISIBLE
-                shuttleStationAdapter.updateData(shuttleForStation.subList(0, min(3, shuttleForStation.size)))
+                shuttleStationAdapter.updateData(shuttleForStation.subList(0, min(3, shuttleForStation.size)), setOfNotNull(shuttleForStation.lastOrNull()?.seq))
             }
             if (shuttleForTerminal.isEmpty()) {
                 binding.noRealtimeDataBoundForTerminal.visibility = View.VISIBLE
@@ -342,7 +342,7 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForTerminal.visibility = View.GONE
                 binding.realtimeViewBoundForTerminal.visibility = View.VISIBLE
-                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)))
+                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)), setOfNotNull(shuttleForTerminal.lastOrNull()?.seq))
             }
             if (shuttleForJungangStation.isEmpty()) {
                 binding.noRealtimeDataBoundForJungangStation.visibility = View.VISIBLE
@@ -350,7 +350,7 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForJungangStation.visibility = View.GONE
                 binding.realtimeViewBoundForJungangStation.visibility = View.VISIBLE
-                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)))
+                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)), setOfNotNull(shuttleForJungangStation.lastOrNull()?.seq))
             }
         }
         parentViewModel.busAlternativeShuttlecock.observe(viewLifecycleOwner) { busMinutes ->

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabStationFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabStationFragment.kt
@@ -392,7 +392,7 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(3, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(3, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
 
             if (shuttleForCampus.isEmpty()) {
@@ -401,7 +401,7 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.GONE
                 binding.realtimeViewBoundForDormitory.visibility = View.VISIBLE
-                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(3, shuttleForCampus.size)))
+                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(3, shuttleForCampus.size)), setOfNotNull(shuttleForCampus.lastOrNull()?.seq))
             }
 
             if (shuttleForTerminal.isEmpty()) {
@@ -410,7 +410,7 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForTerminal.visibility = View.GONE
                 binding.realtimeViewBoundForTerminal.visibility = View.VISIBLE
-                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)))
+                shuttleTerminalAdapter.updateData(shuttleForTerminal.subList(0, min(3, shuttleForTerminal.size)), setOfNotNull(shuttleForTerminal.lastOrNull()?.seq))
             }
 
             if (shuttleForJungangStation.isEmpty()) {
@@ -419,7 +419,7 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForJungangStation.visibility = View.GONE
                 binding.realtimeViewBoundForJungangStation.visibility = View.VISIBLE
-                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)))
+                shuttleJungangStationAdapter.updateData(shuttleForJungangStation.subList(0, min(3, shuttleForJungangStation.size)), setOfNotNull(shuttleForJungangStation.lastOrNull()?.seq))
             }
         }
         parentViewModel.busAlternativeStation.observe(viewLifecycleOwner) { busMinutes ->

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabTerminalFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabTerminalFragment.kt
@@ -165,7 +165,7 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeData.visibility = View.GONE
                 binding.realtimeView.visibility = View.VISIBLE
-                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)))
+                shuttleAdapter.updateData(shuttleByOrder.subList(0, min(8, shuttleByOrder.size)), setOfNotNull(shuttleByOrder.lastOrNull()?.seq))
             }
             if (shuttleForCampus.isEmpty()) {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.VISIBLE
@@ -173,7 +173,7 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
             } else {
                 binding.noRealtimeDataBoundForDormitory.visibility = View.GONE
                 binding.realtimeViewBoundForDormitory.visibility = View.VISIBLE
-                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)))
+                shuttleCampusAdapter.updateData(shuttleForCampus.subList(0, min(8, shuttleForCampus.size)), setOfNotNull(shuttleForCampus.lastOrNull()?.seq))
             }
         }
 

--- a/app/src/main/res/drawable/bg_shuttle_last_run_badge.xml
+++ b/app/src/main/res/drawable/bg_shuttle_last_run_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/hanyang_orange" />
+    <corners android:radius="5dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,5 @@
         app:layout_constraintStart_toStartOf="parent"
         app:itemIconTint="@color/bottom_navigation_item"
         app:itemTextColor="@color/bottom_navigation_item"
-        app:labelVisibilityMode="labeled"
-        app:menu="@menu/bottom_navigation_menu" />
+        app:labelVisibilityMode="labeled" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_shuttle_realtime_tab.xml
+++ b/app/src/main/res/layout/fragment_shuttle_realtime_tab.xml
@@ -79,7 +79,6 @@
                 android:id="@+id/realtime_view_bound_for_station"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/help_bound_for_station" />
             <TextView
@@ -97,7 +96,6 @@
                 android:id="@+id/bus_alternative_station"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginEnd="16dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/no_realtime_data_bound_for_station">
                 <View
@@ -211,7 +209,6 @@
                 android:id="@+id/realtime_view_bound_for_dormitory"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/help_bound_for_dormitory" />
             <TextView
@@ -229,7 +226,6 @@
                 android:id="@+id/bus_alternative_dormitory"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginEnd="16dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/no_realtime_data_bound_for_dormitory">
                 <View
@@ -280,7 +276,6 @@
                 android:id="@+id/bus_alternative_dormitory_2"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginEnd="16dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/bus_alternative_dormitory">
                 <View
@@ -393,7 +388,6 @@
                 android:id="@+id/realtime_view_bound_for_terminal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/help_bound_for_terminal" />
             <TextView
@@ -411,7 +405,6 @@
                 android:id="@+id/bus_alternative_terminal"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginEnd="16dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/no_realtime_data_bound_for_terminal">
                 <View
@@ -524,7 +517,6 @@
                 android:id="@+id/realtime_view_bound_for_jungang_station"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/help_bound_for_jungang_station" />
             <TextView
@@ -542,7 +534,6 @@
                 android:id="@+id/bus_alternative_jungang_station"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginEnd="16dp"
                 android:visibility="gone"
                 app:layout_constraintTop_toBottomOf="@id/no_realtime_data_bound_for_jungang_station">
                 <View
@@ -661,7 +652,6 @@
                 android:id="@+id/realtime_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toTopOf="parent"/>
             <TextView

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -4,70 +4,113 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/shuttle_item"
     android:layout_width="match_parent"
-    android:layout_height="50dp" >
-    <LinearLayout
-        android:id="@+id/shuttle_label_group"
+    android:layout_height="50dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/shuttle_content"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="8dp"
+        android:layout_height="50dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/shuttle_time_text"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
-        <TextView
-            android:id="@+id/shuttle_type_text"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/shuttle_label_group"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:textColor="@color/primary_text"
-            android:textFontWeight="700"
-            android:textSize="18sp" />
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/warning_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:visibility="gone"
-            app:strokeColor="@color/hanyang_orange"
-            app:strokeWidth="1dp"
-            app:cardCornerRadius="4dp">
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/shuttle_time_text"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
             <TextView
-                android:id="@+id/warning_text"
+                android:id="@+id/shuttle_type_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="14sp"
-                android:textColor="@color/hanyang_orange"
-                android:paddingHorizontal="8dp"
-                android:paddingVertical="4dp"
-                android:text="@string/shuttle_warning_text"
-            />
-        </com.google.android.material.card.MaterialCardView>
-    </LinearLayout>
-    <TextView
-        android:id="@+id/shuttle_time_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="4dp"
-        android:textSize="18sp"
-        android:textColor="@color/primary_text"
-        app:layout_constraintEnd_toStartOf="@id/shuttle_alarm_button"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
-    <ImageButton
-        android:id="@+id/shuttle_alarm_button"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:src="@drawable/ic_alarm"
-        android:contentDescription="@string/shuttle_alarm_button_desc"
-        android:visibility="invisible"
-        app:tint="?attr/colorControlNormal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/primary_text"
+                android:textFontWeight="700"
+                android:textSize="18sp"
+                app:layout_constrainedWidth="true"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/last_run_badge"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/last_run_badge"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_marginStart="8dp"
+                android:background="@drawable/bg_shuttle_last_run_badge"
+                android:gravity="center"
+                android:paddingHorizontal="9dp"
+                android:text="@string/shuttle_last_run"
+                android:textColor="@android:color/white"
+                android:textFontWeight="700"
+                android:textSize="12sp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/warning_view"
+                app:layout_constraintStart_toEndOf="@id/shuttle_type_text"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/warning_view"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_marginStart="8dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/hanyang_orange"
+                app:cardCornerRadius="5dp"
+                app:cardElevation="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/last_run_badge"
+                app:layout_constraintTop_toTopOf="parent"
+                app:strokeWidth="0dp">
+
+                <TextView
+                    android:id="@+id/warning_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:paddingHorizontal="9dp"
+                    android:text="@string/shuttle_warning_text"
+                    android:textColor="@android:color/white"
+                    android:textFontWeight="700"
+                    android:textSize="12sp" />
+            </com.google.android.material.card.MaterialCardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <TextView
+            android:id="@+id/shuttle_time_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:textColor="@color/primary_text"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/shuttle_alarm_button"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/shuttle_alarm_button"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/shuttle_alarm_button_desc"
+            android:src="@drawable/ic_alarm"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorControlNormal" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -5,31 +5,16 @@
     android:id="@+id/shuttle_item"
     android:layout_width="match_parent"
     android:layout_height="50dp" >
-    <TextView
-        android:id="@+id/last_run_view"
-        android:layout_width="36dp"
-        android:layout_height="0dp"
-        android:background="@color/hanyang_blue"
-        android:gravity="center"
-        android:text="@string/shuttle_last_run"
-        android:textColor="@android:color/white"
-        android:textFontWeight="700"
-        android:textSize="12sp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
     <LinearLayout
         android:id="@+id/shuttle_label_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:layout_marginStart="12dp"
+        android:layout_marginStart="16dp"
         android:layout_marginEnd="8dp"
-        app:layout_constraintStart_toEndOf="@id/last_run_view"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/shuttle_time_text"
-        app:layout_goneMarginStart="20dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
         <TextView

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -5,12 +5,22 @@
     android:id="@+id/shuttle_item"
     android:layout_width="match_parent"
     android:layout_height="50dp" >
+    <View
+        android:id="@+id/last_run_view"
+        android:layout_width="4dp"
+        android:layout_height="0dp"
+        android:background="@color/hanyang_blue"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
     <LinearLayout
         android:id="@+id/shuttle_label_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
+        android:layout_marginStart="20dp"
         android:layout_marginEnd="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/shuttle_time_text"
@@ -45,25 +55,6 @@
                 android:paddingVertical="4dp"
                 android:text="@string/shuttle_warning_text"
             />
-        </com.google.android.material.card.MaterialCardView>
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/last_run_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:visibility="gone"
-            app:cardCornerRadius="4dp"
-            app:strokeColor="@color/hanyang_blue"
-            app:strokeWidth="1dp">
-            <TextView
-                android:id="@+id/last_run_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingHorizontal="8dp"
-                android:paddingVertical="4dp"
-                android:text="@string/shuttle_last_run"
-                android:textColor="@color/hanyang_blue"
-                android:textSize="14sp" />
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
     <TextView

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -46,6 +46,25 @@
                 android:text="@string/shuttle_warning_text"
             />
         </com.google.android.material.card.MaterialCardView>
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/last_run_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:visibility="gone"
+            app:cardCornerRadius="4dp"
+            app:strokeColor="@color/hanyang_blue"
+            app:strokeWidth="1dp">
+            <TextView
+                android:id="@+id/last_run_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="4dp"
+                android:text="@string/shuttle_last_run"
+                android:textColor="@color/hanyang_blue"
+                android:textSize="14sp" />
+        </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
     <TextView
         android:id="@+id/shuttle_time_text"

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -5,11 +5,16 @@
     android:id="@+id/shuttle_item"
     android:layout_width="match_parent"
     android:layout_height="50dp" >
-    <View
+    <TextView
         android:id="@+id/last_run_view"
-        android:layout_width="4dp"
+        android:layout_width="36dp"
         android:layout_height="0dp"
         android:background="@color/hanyang_blue"
+        android:gravity="center"
+        android:text="@string/shuttle_last_run"
+        android:textColor="@android:color/white"
+        android:textFontWeight="700"
+        android:textSize="12sp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -20,10 +25,11 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:layout_marginStart="20dp"
+        android:layout_marginStart="12dp"
         android:layout_marginEnd="8dp"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/last_run_view"
         app:layout_constraintEnd_toStartOf="@id/shuttle_time_text"
+        app:layout_goneMarginStart="20dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
         <TextView

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -50,6 +50,7 @@
     <string name="home_departure_format">Departs %1$s</string>
     <string name="home_minutes">%1$d min</string>
     <string name="home_check">Check</string>
+    <string name="home_shuttle_last_run_subtitle">Last run · %1$s</string>
     <string name="home_no_data_title">No shuttle available now</string>
     <string name="home_no_data_message">Check again later or use an alternative route below.</string>
     <string name="home_bus_title_format">Bus %1$s</string>
@@ -491,6 +492,16 @@
     <string name="shuttle_type_school_terminal">Terminal</string>
     <string name="shuttle_type_school_station">Station</string>
     <string name="shuttle_warning_text">Check Destination</string>
+    <string name="shuttle_last_run">Last</string>
+    <string name="shuttle_service_notice_title">Shuttle service notice</string>
+    <string name="shuttle_service_notice_period_body">From %1$s, shuttle service changes to %2$s.</string>
+    <string name="shuttle_service_notice_halt_body">Shuttle service will be suspended on %1$s.</string>
+    <string name="shuttle_service_notice_holiday_body">Shuttles will run on the weekend/holiday schedule on %1$s.</string>
+    <string name="shuttle_service_notice_generic_body">Check shuttle service information for %1$s.</string>
+    <string name="shuttle_service_notice_period_semester">semester</string>
+    <string name="shuttle_service_notice_period_vacation">vacation</string>
+    <string name="shuttle_service_notice_period_session">session</string>
+    <string name="shuttle_service_notice_period_unknown">a new period</string>
     <string name="info_button_shuttle">Information button for shuttle</string>
     <string name="analytics_settings">App Analytics</string>
     <string name="analytics_settings_description">We collect anonymous usage data and your Advertising ID (AD ID) to improve the app. You can disable this at any time.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -170,7 +170,7 @@
     <string name="shuttle_period">Period</string>
     <string name="shuttle_period_semester">Semester</string>
     <string name="shuttle_period_vacation">Vacation</string>
-    <string name="shuttle_period_vacation_session">Seasonal</string>
+    <string name="shuttle_period_vacation_session">Seasonal Semester</string>
     <string name="confirm">Apply</string>
     <string name="location_permission_nearest_stop">Location permission is required to find the nearest stop.</string>
     <!-- 셔틀버스 등하교 팝업 -->
@@ -494,13 +494,13 @@
     <string name="shuttle_warning_text">Check Destination</string>
     <string name="shuttle_last_run">Last</string>
     <string name="shuttle_service_notice_title">Shuttle service notice</string>
-    <string name="shuttle_service_notice_period_body">From %1$s, shuttle service changes to %2$s.</string>
+    <string name="shuttle_service_notice_period_body">From %1$s, shuttles will follow the %2$s schedule.</string>
     <string name="shuttle_service_notice_halt_body">Shuttle service will be suspended on %1$s.</string>
     <string name="shuttle_service_notice_holiday_body">Shuttles will run on the weekend/holiday schedule on %1$s.</string>
     <string name="shuttle_service_notice_generic_body">Check shuttle service information for %1$s.</string>
     <string name="shuttle_service_notice_period_semester">semester</string>
     <string name="shuttle_service_notice_period_vacation">vacation</string>
-    <string name="shuttle_service_notice_period_session">session</string>
+    <string name="shuttle_service_notice_period_session">seasonal semester</string>
     <string name="shuttle_service_notice_period_unknown">a new period</string>
     <string name="info_button_shuttle">Information button for shuttle</string>
     <string name="analytics_settings">App Analytics</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,6 +49,7 @@
     <string name="home_departure_format">%1$s 発</string>
     <string name="home_minutes">%1$d分</string>
     <string name="home_check">確認</string>
+    <string name="home_shuttle_last_run_subtitle">終車 · %1$s</string>
     <string name="home_no_data_title">今乗れるシャトルがありません</string>
     <string name="home_no_data_message">しばらくしてから再確認するか、下の代替ルートを確認してください。</string>
     <string name="home_bus_title_format">%1$s番バス</string>
@@ -470,6 +471,16 @@
     <string name="shuttle_type_school_terminal">芸術人村直行</string>
     <string name="shuttle_type_school_station">韓大前駅直行</string>
     <string name="shuttle_warning_text">乗車位置確認</string>
+    <string name="shuttle_last_run">終車</string>
+    <string name="shuttle_service_notice_title">シャトルバス運行案内</string>
+    <string name="shuttle_service_notice_period_body">%1$sからシャトルバスの運行期間が%2$sに変わります。</string>
+    <string name="shuttle_service_notice_halt_body">%1$sはシャトルバスを運休します。</string>
+    <string name="shuttle_service_notice_holiday_body">%1$sは週末/祝日ダイヤで運行します。</string>
+    <string name="shuttle_service_notice_generic_body">%1$sのシャトルバス運行情報を確認してください。</string>
+    <string name="shuttle_service_notice_period_semester">学期</string>
+    <string name="shuttle_service_notice_period_vacation">休暇</string>
+    <string name="shuttle_service_notice_period_session">季節学期</string>
+    <string name="shuttle_service_notice_period_unknown">新しい期間</string>
     <string name="info_button_shuttle">シャトル情報ボタン</string>
     <string name="analytics_settings">アプリ分析データの収集</string>
     <string name="analytics_settings_description">アプリ改善のため、匿名の使用データおよび広告識別子（AD ID）を収集します。いつでも無効にできます。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -158,7 +158,7 @@
     <string name="shuttle_period">運行期間</string>
     <string name="shuttle_period_semester">学期中</string>
     <string name="shuttle_period_vacation">休暇中</string>
-    <string name="shuttle_period_vacation_session">集中講義期間中</string>
+    <string name="shuttle_period_vacation_session">季節学期中</string>
     <string name="confirm">確認</string>
     <string name="location_permission_nearest_stop">最寄りのバス停を探すには位置情報の権限が必要です。</string>
     <string name="shuttle_realtime_toast">通学ラッシュ時は、シャトルコックから一部シャトルが運行しない場合があります。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -49,6 +49,7 @@
     <string name="home_departure_format">%1$s 出发</string>
     <string name="home_minutes">%1$d分</string>
     <string name="home_check">确认</string>
+    <string name="home_shuttle_last_run_subtitle">末班 · %1$s</string>
     <string name="home_no_data_title">现在暂无可乘坐的校车</string>
     <string name="home_no_data_message">请稍后再确认，或查看下方替代路线。</string>
     <string name="home_bus_title_format">%1$s路公交</string>
@@ -470,6 +471,16 @@
     <string name="shuttle_type_school_terminal">艺术人村直达</string>
     <string name="shuttle_type_school_station">汉大前站直达</string>
     <string name="shuttle_warning_text">确认乘车位置</string>
+    <string name="shuttle_last_run">末班</string>
+    <string name="shuttle_service_notice_title">校车运行通知</string>
+    <string name="shuttle_service_notice_period_body">自%1$s起，校车运行期间将变更为%2$s。</string>
+    <string name="shuttle_service_notice_halt_body">%1$s校车暂停运行。</string>
+    <string name="shuttle_service_notice_holiday_body">%1$s将按周末/节假日时刻表运行。</string>
+    <string name="shuttle_service_notice_generic_body">请确认%1$s的校车运行信息。</string>
+    <string name="shuttle_service_notice_period_semester">学期</string>
+    <string name="shuttle_service_notice_period_vacation">假期</string>
+    <string name="shuttle_service_notice_period_session">季节学期</string>
+    <string name="shuttle_service_notice_period_unknown">新期间</string>
     <string name="info_button_shuttle">校车信息按钮</string>
     <string name="analytics_settings">应用分析数据收集</string>
     <string name="analytics_settings_description">为改善应用，将收集匿名使用数据及广告标识符（AD ID）。可随时关闭。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -158,7 +158,7 @@
     <string name="shuttle_period">运行期间</string>
     <string name="shuttle_period_semester">学期中</string>
     <string name="shuttle_period_vacation">假期中</string>
-    <string name="shuttle_period_vacation_session">暑期课程期间</string>
+    <string name="shuttle_period_vacation_session">季节学期中</string>
     <string name="confirm">确认</string>
     <string name="location_permission_nearest_stop">需要位置权限才能查找最近的站点。</string>
     <string name="shuttle_realtime_toast">上下学高峰时段，部分校车可能不从羽毛球场出发。</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="dynamic_translation_source_text" type="id" />
+    <item name="home_destination_station" type="id" />
+    <item name="home_destination_terminal" type="id" />
+    <item name="home_destination_jungang" type="id" />
+    <item name="home_destination_dormitory" type="id" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -552,7 +552,7 @@
     <string name="shuttle_warning_text">탑승 위치 확인</string>
     <string name="shuttle_last_run">막차</string>
     <string name="shuttle_service_notice_title">셔틀버스 운행 안내</string>
-    <string name="shuttle_service_notice_period_body">%1$s부터 셔틀버스 운행 기간이 %2$s로 변경됩니다.</string>
+    <string name="shuttle_service_notice_period_body">%1$s부터 셔틀버스 운행이 %2$s 일정으로 변경됩니다.</string>
     <string name="shuttle_service_notice_halt_body">%1$s에는 셔틀버스가 운행하지 않습니다.</string>
     <string name="shuttle_service_notice_holiday_body">%1$s에는 주말/공휴일 시간표로 운행합니다.</string>
     <string name="shuttle_service_notice_generic_body">%1$s 셔틀버스 운행 정보를 확인해 주세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="home_departure_format">%1$s 출발</string>
     <string name="home_minutes">%1$d분</string>
     <string name="home_check">확인 필요</string>
+    <string name="home_shuttle_last_run_subtitle">막차 · %1$s</string>
     <string name="home_no_data_title">지금 탈 수 있는 셔틀이 없어요</string>
     <string name="home_no_data_message">잠시 후 다시 확인하거나 아래 대체 노선을 확인해요.</string>
     <string name="home_bus_title_format">%1$s번 버스</string>
@@ -549,6 +550,16 @@
     <string name="shuttle_type_school_terminal">예술인 직행</string>
     <string name="shuttle_type_school_station">한대앞 직행</string>
     <string name="shuttle_warning_text">탑승 위치 확인</string>
+    <string name="shuttle_last_run">막차</string>
+    <string name="shuttle_service_notice_title">셔틀버스 운행 안내</string>
+    <string name="shuttle_service_notice_period_body">%1$s부터 셔틀버스 운행 기간이 %2$s로 변경됩니다.</string>
+    <string name="shuttle_service_notice_halt_body">%1$s에는 셔틀버스가 운행하지 않습니다.</string>
+    <string name="shuttle_service_notice_holiday_body">%1$s에는 주말/공휴일 시간표로 운행합니다.</string>
+    <string name="shuttle_service_notice_generic_body">%1$s 셔틀버스 운행 정보를 확인해 주세요.</string>
+    <string name="shuttle_service_notice_period_semester">학기</string>
+    <string name="shuttle_service_notice_period_vacation">방학</string>
+    <string name="shuttle_service_notice_period_session">계절학기</string>
+    <string name="shuttle_service_notice_period_unknown">새 기간</string>
     <string name="info_button_shuttle">셔틀 정보 버튼</string>
     <string name="analytics_settings">앱 분석 데이터 수집</string>
     <string name="analytics_settings_description">앱 개선을 위해 익명의 사용 데이터 및 광고 식별자(AD ID)를 수집합니다. 언제든지 해제할 수 있습니다.</string>


### PR DESCRIPTION
## Changes

### Shuttle Notices
- Query upcoming shuttle service notices from the backend
- Schedule local notifications for upcoming period and holiday service changes
- Cancel previously scheduled notice notifications before rescheduling from fresh data

### Shuttle UI
- Add last-run badges to shuttle realtime rows
- Unify last-run and boarding-location status badges for direct shuttle rows
- Keep destinations left-aligned while preserving the existing time and alarm layout
- Show last-run text on the new Home shuttle card when the remaining option is the final run
- Expand shuttle query limits so last-run detection has the full remaining timetable

### Stability
- Guard asynchronous home location callbacks after the Fragment view is destroyed
- Use stable IDs for dynamic home destination buttons during state restoration
- Populate bottom navigation after view inflation to avoid startup menu inflation failures

### Release
- Update app version to 5.1.8

## Checks
- `./gradlew :app:bundleProductionRelease`
- `./gradlew :app:assembleDevDebug :app:testDevDebugUnitTest`
- GitHub Actions: Kotlin style, unit tests, connected Android tests, Maestro E2E smoke tests, and release bundle build
