### PR TITLE
feat: Bump Version 5.1.9

### DIFF
--- a/.maestro/main-navigation.yaml
+++ b/.maestro/main-navigation.yaml
@@ -56,7 +56,7 @@ tags:
       visible: "Skip"
     commands:
       - tapOn: "Skip"
-- assertVisible: "Reading Room Seat Lookup"
+- assertVisible: "Reading Room"
 - assertVisible: "Campus Map"
 - assertVisible: "Campus Contacts"
 - assertVisible: "Academic Calendar"

--- a/.maestro/menu-destinations.yaml
+++ b/.maestro/menu-destinations.yaml
@@ -22,7 +22,7 @@ tags:
       visible: "Skip"
     commands:
       - tapOn: "Skip"
-- tapOn: "Reading Room Seat Lookup"
+- tapOn: "Reading Room"
 - runFlow:
     when:
       visible: "Skip"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,8 +47,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 518000000
-        versionName = "5.1.8"
+        versionCode = 519000000
+        versionName = "5.1.9"
         signingConfig = signingConfigs.getByName("config")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""

--- a/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
+++ b/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
@@ -2,6 +2,7 @@ package app.kobuggi.hyuabot.ui
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.view.View
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -25,8 +26,10 @@ import androidx.test.rule.GrantPermissionRule
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.service.preferences.userDataStore
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.button.MaterialButtonToggleGroup
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.Matcher
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -89,6 +92,24 @@ class AppNavigationSmokeTest {
 
             selectBottomTab(R.id.menuFragment)
             onView(withId(R.id.menu_recycler_view)).check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    fun homeDestinationGroupKeepsStableChildren() {
+        val intent = Intent(context, MainActivity::class.java)
+            .putExtra("homeDebugDeparture", "terminal")
+
+        ActivityScenario.launch<MainActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val group = activity.findViewById<MaterialButtonToggleGroup>(R.id.destination_group)
+                val visibleChildCount = (0 until group.childCount).count { index ->
+                    group.getChildAt(index).visibility == View.VISIBLE
+                }
+
+                assertEquals(4, group.childCount)
+                assertEquals(1, visibleChildCount)
+            }
         }
     }
 

--- a/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
+++ b/app/src/androidTest/java/app/kobuggi/hyuabot/ui/AppNavigationSmokeTest.kt
@@ -91,7 +91,7 @@ class AppNavigationSmokeTest {
             onView(withId(R.id.date_picker_layout)).check(matches(isDisplayed()))
 
             selectBottomTab(R.id.menuFragment)
-            onView(withId(R.id.menu_recycler_view)).check(matches(isDisplayed()))
+            onView(withId(R.id.campus_tools_grid)).check(matches(isDisplayed()))
         }
     }
 
@@ -116,15 +116,19 @@ class AppNavigationSmokeTest {
     @Test
     fun menuDestinationsRender() {
         ActivityScenario.launch(MainActivity::class.java).use {
-            openMenuDestination(R.string.menu_book)
+            openCampusTool(R.id.campus_map_card)
+            onView(withId(R.id.search_bar)).check(matches(isDisplayed()))
+
+            selectBottomTab(R.id.menuFragment)
+            openCampusTool(R.id.campus_reading_room_card)
             onView(withId(R.id.reading_room_swipe_refresh_layout)).check(matches(isDisplayed()))
 
             selectBottomTab(R.id.menuFragment)
-            openMenuDestination(R.string.menu_contact)
+            openCampusTool(R.id.campus_contact_card)
             onView(withId(R.id.contact_list_view)).check(matches(isDisplayed()))
 
             selectBottomTab(R.id.menuFragment)
-            openMenuDestination(R.string.menu_calendar)
+            openCampusTool(R.id.campus_calendar_card)
             onView(withId(R.id.calendar_timeline_view)).check(matches(isDisplayed()))
 
             selectBottomTab(R.id.menuFragment)
@@ -158,5 +162,10 @@ class AppNavigationSmokeTest {
                 click(),
             ),
         )
+    }
+
+    private fun openCampusTool(cardId: Int) {
+        selectBottomTab(R.id.menuFragment)
+        onView(withId(cardId)).perform(click())
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,9 @@
             android:name="firebase_analytics_collection_enabled"
             android:value="false" />
         <meta-data
+            android:name="google_analytics_automatic_screen_reporting_enabled"
+            android:value="false" />
+        <meta-data
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />
         <meta-data

--- a/app/src/main/java/app/kobuggi/hyuabot/GlobalApplication.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/GlobalApplication.kt
@@ -5,7 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
-import com.google.firebase.analytics.FirebaseAnalytics
+import app.kobuggi.hyuabot.util.AnalyticsManager
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -31,7 +31,7 @@ class GlobalApplication : Application() {
         createNotificationChannels()
         applicationScope.launch {
             val enabled = userPreferencesRepository.analyticsConsent.first()
-            FirebaseAnalytics.getInstance(applicationContext).setAnalyticsCollectionEnabled(enabled)
+            AnalyticsManager.setCollectionEnabled(enabled)
             FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = enabled
         }
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         navController.addOnDestinationChangedListener { _, destination, _ ->
             updatePrimaryNavigationItem(destination.id)
             screenForDestination(destination.id)?.let {
-                AnalyticsManager.logScreen(it, destination.label?.toString())
+                AnalyticsManager.logScreen(it, it.id)
             }
         }
         viewModel.theme.observe(this) {
@@ -327,7 +327,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
 
     /** Maps a nav-graph destination id to its analytics screen (null = not tracked as a screen). */
     private fun screenForDestination(destinationId: Int): AnalyticsScreen? = when (destinationId) {
-        R.id.homeFragment -> AnalyticsScreen.SHUTTLE_REALTIME
+        R.id.homeFragment -> AnalyticsScreen.HOME
         R.id.shuttleRealtimeFragment -> AnalyticsScreen.SHUTTLE_REALTIME
         R.id.shuttleTimetableFragment -> AnalyticsScreen.SHUTTLE_TIMETABLE
         R.id.shuttleStopDialogFragment -> AnalyticsScreen.SHUTTLE_STOP_INFO
@@ -359,7 +359,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
 
     /** Maps a bottom-navigation item id to its analytics tab item. */
     private fun tabItemForDestination(destinationId: Int): AnalyticsItem? = when (destinationId) {
-        R.id.homeFragment -> AnalyticsItem.TAB_SHUTTLE
+        R.id.homeFragment -> AnalyticsItem.TAB_HOME
         R.id.busRealtimeFragment -> AnalyticsItem.TAB_BUS
         R.id.subwayRealtimeFragment -> AnalyticsItem.TAB_SUBWAY
         R.id.cafeteriaFragment -> AnalyticsItem.TAB_CAFETERIA
@@ -368,6 +368,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     }
 
     override fun onNavigationItemReselected(item: MenuItem) {
+        tabItemForDestination(item.itemId)?.let {
+            AnalyticsManager.logSelect(it, AnalyticsContentType.TAB)
+        }
         val reselectedDestinationId = item.itemId
         navController.popBackStack(reselectedDestinationId, false)
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -106,7 +106,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         menu.add(0, R.id.busRealtimeFragment, 1, R.string.bus).setIcon(R.drawable.ic_bus)
         menu.add(0, R.id.subwayRealtimeFragment, 2, R.string.subway).setIcon(R.drawable.ic_subway)
         menu.add(0, R.id.cafeteriaFragment, 3, R.string.cafeteria).setIcon(R.drawable.ic_cafeteria)
-        menu.add(0, R.id.menuFragment, 4, R.string.menu).setIcon(R.drawable.ic_more)
+        menu.add(0, R.id.menuFragment, 4, R.string.tabbar_campus).setIcon(R.drawable.ic_campus)
     }
 
     private fun applyStatusBarStyle() {
@@ -147,7 +147,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         binding.bottomNavigation.menu.findItem(R.id.busRealtimeFragment)?.title = getString(R.string.tabbar_bus)
         binding.bottomNavigation.menu.findItem(R.id.subwayRealtimeFragment)?.title = getString(R.string.subway)
         binding.bottomNavigation.menu.findItem(R.id.cafeteriaFragment)?.title = getString(R.string.cafeteria)
-        binding.bottomNavigation.menu.findItem(R.id.menuFragment)?.title = getString(R.string.tabbar_more)
+        binding.bottomNavigation.menu.findItem(R.id.menuFragment)?.title = getString(R.string.tabbar_campus)
     }
 
     private fun updatePrimaryNavigationItem(destinationId: Int?) {
@@ -349,7 +349,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         R.id.noticeWebViewFragment -> AnalyticsScreen.WEB_VIEW
         R.id.contactFragment -> AnalyticsScreen.CONTACT
         R.id.calendarFragment -> AnalyticsScreen.CALENDAR
-        R.id.menuFragment -> AnalyticsScreen.MENU
+        R.id.menuFragment -> AnalyticsScreen.CAMPUS
         R.id.languageSettingDialogFragment -> AnalyticsScreen.SETTING_LANGUAGE
         R.id.campusSettingDialogFragment -> AnalyticsScreen.SETTING_CAMPUS
         R.id.themeSettingDialogFragment -> AnalyticsScreen.SETTING_THEME
@@ -363,7 +363,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         R.id.busRealtimeFragment -> AnalyticsItem.TAB_BUS
         R.id.subwayRealtimeFragment -> AnalyticsItem.TAB_SUBWAY
         R.id.cafeteriaFragment -> AnalyticsItem.TAB_CAFETERIA
-        R.id.menuFragment -> AnalyticsItem.TAB_MENU
+        R.id.menuFragment -> AnalyticsItem.TAB_CAMPUS
         else -> null
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -37,6 +37,7 @@ import app.kobuggi.hyuabot.util.AnalyticsContentType
 import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
 import app.kobuggi.hyuabot.util.AnalyticsScreen
+import app.kobuggi.hyuabot.util.AnalyticsScreenDispatcher
 import app.kobuggi.hyuabot.util.InAppReviewManager
 import app.kobuggi.hyuabot.ui.common.applyGodoTypography
 import app.kobuggi.hyuabot.widget.ShuttleWidgetProvider
@@ -47,9 +48,6 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import javax.inject.Inject
 import androidx.core.content.edit
-import com.google.firebase.Firebase
-import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.analytics
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedListener, NavigationBarView.OnItemSelectedListener, DialogInterface.OnDismissListener {
@@ -59,7 +57,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         val navHostFragment = supportFragmentManager.findFragmentById(binding.navHostFragment.id)!! as NavHostFragment
         navHostFragment.navController
     }
-    private lateinit var firebaseAnalytics: FirebaseAnalytics
+    private val analyticsScreenDispatcher = AnalyticsScreenDispatcher {
+        AnalyticsManager.logScreen(it, it.id)
+    }
 
     @Inject
     lateinit var inAppReviewManager: InAppReviewManager
@@ -71,7 +71,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         applyStatusBarStyle()
-        firebaseAnalytics = Firebase.analytics
         binding.bottomNavigation.apply {
             populateBottomNavigationMenu()
             setupWithNavController(navController)
@@ -82,7 +81,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         navController.addOnDestinationChangedListener { _, destination, _ ->
             updatePrimaryNavigationItem(destination.id)
             screenForDestination(destination.id)?.let {
-                AnalyticsManager.logScreen(it, it.id)
+                analyticsScreenDispatcher.onDestinationChanged(it)
             }
         }
         viewModel.theme.observe(this) {
@@ -98,6 +97,16 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         requestInAppReview()
         syncShuttleServiceNotices()
         navController.handleDeepLink(intent)
+    }
+
+    override fun onPostResume() {
+        super.onPostResume()
+        analyticsScreenDispatcher.onResumed()
+    }
+
+    override fun onPause() {
+        analyticsScreenDispatcher.onPaused()
+        super.onPause()
     }
 
     private fun NavigationBarView.populateBottomNavigationMenu() {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -239,6 +239,7 @@ class HomeFragment : Fragment() {
                 AnalyticsItem.HOME_SELECT_DESTINATION,
                 type = AnalyticsContentType.TAB,
                 name = destination.debugValue,
+                destinationId = destination.debugValue,
             )
             render(viewModel.data.value)
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -218,12 +218,28 @@ class HomeFragment : Fragment() {
 
     private fun setupDestinationButtons() {
         binding.destinationGroup.clearOnButtonCheckedListeners()
-        binding.destinationGroup.removeAllViews()
+        ensureDestinationButtons()
+        HomeDestination.entries.forEach { destination ->
+            binding.destinationGroup.findViewById<View>(destination.buttonIdRes).visibility =
+                if (destination in selectedDeparture.destinations) View.VISIBLE else View.GONE
+        }
+        binding.destinationGroup.check(selectedDestination.buttonIdRes)
+        binding.destinationGroup.addOnButtonCheckedListener { group, checkedId, isChecked ->
+            if (!isChecked) return@addOnButtonCheckedListener
+            val destination = group.findViewById<View>(checkedId)?.tag as? HomeDestination ?: return@addOnButtonCheckedListener
+            selectedDestination = destination
+            render(viewModel.data.value)
+        }
+    }
+
+    private fun ensureDestinationButtons() {
+        if (binding.destinationGroup.childCount > 0) return
+
         val buttonContext = ContextThemeWrapper(requireContext(), R.style.Widget_App_SegmentedButton)
         val textColor = ContextCompat.getColorStateList(requireContext(), R.color.home_destination_button_text)
         val backgroundColor = ContextCompat.getColorStateList(requireContext(), R.color.home_destination_button_background)
         val strokeColor = ContextCompat.getColorStateList(requireContext(), R.color.home_destination_button_stroke)
-        selectedDeparture.destinations.forEach { destination ->
+        HomeDestination.entries.forEach { destination ->
             val button = MaterialButton(buttonContext, null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
                 id = destination.buttonIdRes
                 text = getString(destination.titleRes)
@@ -243,13 +259,6 @@ class HomeFragment : Fragment() {
                 tag = destination
             }
             binding.destinationGroup.addView(button)
-            if (destination == selectedDestination) binding.destinationGroup.check(button.id)
-        }
-        binding.destinationGroup.addOnButtonCheckedListener { group, checkedId, isChecked ->
-            if (!isChecked) return@addOnButtonCheckedListener
-            val destination = group.findViewById<View>(checkedId)?.tag as? HomeDestination ?: return@addOnButtonCheckedListener
-            selectedDestination = destination
-            render(viewModel.data.value)
         }
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -36,6 +36,9 @@ import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentHomeBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeRowBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeTransferRowBinding
+import app.kobuggi.hyuabot.util.AnalyticsContentType
+import app.kobuggi.hyuabot.util.AnalyticsItem
+import app.kobuggi.hyuabot.util.AnalyticsManager
 import app.kobuggi.hyuabot.util.localizedSubwayStationName
 import app.kobuggi.hyuabot.util.setSkeletonLoading
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -83,10 +86,12 @@ class HomeFragment : Fragment() {
         binding.dateText.text = DateFormat.getDateInstance(DateFormat.FULL).format(Date())
         setupDestinationButtons()
         binding.homeSwipeRefreshLayout.setOnRefreshListener {
+            AnalyticsManager.logSelect(AnalyticsItem.HOME_REFRESH)
             refreshHome()
         }
         binding.homeSwipeRefreshLayout.setColorSchemeResources(R.color.hanyang_blue)
         binding.movementDetail.setOnClickListener {
+            AnalyticsManager.logSelect(AnalyticsItem.HOME_OPEN_SHUTTLE_DETAIL)
             findNavController().navigate(R.id.action_homeFragment_to_shuttleRealtimeFragment)
         }
         binding.legacyShuttleButton.setOnClickListener {
@@ -98,6 +103,7 @@ class HomeFragment : Fragment() {
             viewLifecycleOwner,
         ) { _, result ->
             if (result.getBoolean(HomeQuickSettingsDialog.KEY_OPEN_LEGACY_SHUTTLE, false)) {
+                AnalyticsManager.logSelect(AnalyticsItem.HOME_OPEN_LEGACY_SHUTTLE)
                 findNavController().navigate(R.id.action_homeFragment_to_shuttleRealtimeFragment)
             }
             if (result.containsKey(HomeQuickSettingsDialog.KEY_SHOW_BUS50_TRANSFER)) {
@@ -114,6 +120,7 @@ class HomeFragment : Fragment() {
             }
         }
         binding.mealDetail.setOnClickListener {
+            AnalyticsManager.logSelect(AnalyticsItem.HOME_OPEN_CAFETERIA)
             val args = Bundle().apply {
                 putString("tab", activeMealPeriod().tab)
             }
@@ -228,6 +235,11 @@ class HomeFragment : Fragment() {
             if (!isChecked) return@addOnButtonCheckedListener
             val destination = group.findViewById<View>(checkedId)?.tag as? HomeDestination ?: return@addOnButtonCheckedListener
             selectedDestination = destination
+            AnalyticsManager.logSelect(
+                AnalyticsItem.HOME_SELECT_DESTINATION,
+                type = AnalyticsContentType.TAB,
+                name = destination.debugValue,
+            )
             render(viewModel.data.value)
         }
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
@@ -118,6 +118,7 @@ class MenuFragment @Inject constructor() : Fragment() {
                 AnalyticsItem.CAMPUS_SELECT_TOOL,
                 type = AnalyticsContentType.LIST_ITEM,
                 name = analyticsName,
+                destinationId = analyticsName,
             )
             onClick()
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
@@ -11,12 +11,16 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import app.kobuggi.hyuabot.R
 import androidx.lifecycle.lifecycleScope
 import app.kobuggi.hyuabot.databinding.FragmentMenuBinding
+import app.kobuggi.hyuabot.databinding.ItemCampusToolBinding
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.service.safeNavigate
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
 import app.kobuggi.hyuabot.util.InAppReviewManager
+import app.kobuggi.hyuabot.util.AnalyticsContentType
+import app.kobuggi.hyuabot.util.AnalyticsItem
+import app.kobuggi.hyuabot.util.AnalyticsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,14 +36,10 @@ class MenuFragment @Inject constructor() : Fragment() {
     lateinit var userPreferencesRepository: UserPreferencesRepository
 
     private val menuList = listOf(
-        MenuItem(R.drawable.ic_book, R.string.menu_book, R.string.menu_section_school_life),
-        MenuItem(R.drawable.ic_map, R.string.menu_map),
-        MenuItem(R.drawable.ic_contact, R.string.menu_contact),
-        MenuItem(R.drawable.ic_calendar, R.string.menu_calendar),
-        MenuItem(R.drawable.ic_settings, R.string.menu_settings, R.string.menu_section_support),
-        MenuItem(R.drawable.ic_chat, R.string.menu_chat, R.string.menu_section_external),
-        MenuItem(R.drawable.ic_donate, R.string.menu_donate),
-        MenuItem(R.drawable.ic_star, R.string.menu_review),
+        MenuItem(R.drawable.ic_settings, R.string.menu_settings, "settings"),
+        MenuItem(R.drawable.ic_chat, R.string.menu_chat, "inquiry"),
+        MenuItem(R.drawable.ic_donate, R.string.menu_donate, "donate"),
+        MenuItem(R.drawable.ic_star, R.string.menu_review, "review"),
     )
 
     override fun onCreateView(
@@ -49,6 +49,7 @@ class MenuFragment @Inject constructor() : Fragment() {
     ): View {
         val menuAdapter = MenuListAdapter(requireContext(), menuList, ::onClickMenu)
         val decoration = DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
+        setupCampusTools()
 
         binding.menuRecyclerView.apply {
             adapter = menuAdapter
@@ -59,12 +60,67 @@ class MenuFragment @Inject constructor() : Fragment() {
         showCoachmarkOnce(userPreferencesRepository, Coachmarks.MENU) {
             listOf(
                 CoachmarkStep(
-                    { binding.menuRecyclerView },
+                    { binding.campusToolsGrid },
                     R.string.coachmark_menu_title, R.string.coachmark_menu_desc
                 ),
             )
         }
         return binding.root
+    }
+
+    private fun setupCampusTools() {
+        bindCampusTool(
+            binding.campusMapCard,
+            R.drawable.ic_map,
+            R.string.campus_map_title,
+            R.string.campus_map_subtitle,
+            "map",
+        ) { onClickMenu(MenuItem(R.drawable.ic_map, R.string.menu_map, "map")) }
+        bindCampusTool(
+            binding.campusReadingRoomCard,
+            R.drawable.ic_book,
+            R.string.campus_reading_room_title,
+            R.string.campus_reading_room_subtitle,
+            "reading_room",
+        ) { onClickMenu(MenuItem(R.drawable.ic_book, R.string.menu_book, "reading_room")) }
+        bindCampusTool(
+            binding.campusCalendarCard,
+            R.drawable.ic_calendar,
+            R.string.campus_calendar_title,
+            R.string.campus_calendar_subtitle,
+            "calendar",
+        ) { onClickMenu(MenuItem(R.drawable.ic_calendar, R.string.menu_calendar, "calendar")) }
+        bindCampusTool(
+            binding.campusContactCard,
+            R.drawable.ic_contact,
+            R.string.campus_contact_title,
+            R.string.campus_contact_subtitle,
+            "contact",
+        ) { onClickMenu(MenuItem(R.drawable.ic_contact, R.string.menu_contact, "contact")) }
+    }
+
+    private fun bindCampusTool(
+        binding: ItemCampusToolBinding,
+        iconRes: Int,
+        titleRes: Int,
+        subtitleRes: Int,
+        analyticsName: String,
+        onClick: () -> Unit,
+    ) {
+        val title = getString(titleRes)
+        val subtitle = getString(subtitleRes)
+        binding.toolIcon.setImageResource(iconRes)
+        binding.toolTitle.text = title
+        binding.toolSubtitle.text = subtitle
+        binding.toolCard.contentDescription = "$title. $subtitle"
+        binding.toolCard.setOnClickListener {
+            AnalyticsManager.logSelect(
+                AnalyticsItem.CAMPUS_SELECT_TOOL,
+                type = AnalyticsContentType.LIST_ITEM,
+                name = analyticsName,
+            )
+            onClick()
+        }
     }
 
     private fun onClickMenu(menuItem: MenuItem) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuItem.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuItem.kt
@@ -3,5 +3,6 @@ package app.kobuggi.hyuabot.ui.menu
 data class MenuItem(
     val iconResource: Int,
     val titleResource: Int,
-    val sectionTitleResource: Int? = null
+    val analyticsName: String,
+    val sectionTitleResource: Int? = null,
 )

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuListAdapter.kt
@@ -19,7 +19,14 @@ class MenuListAdapter(
     inner class ViewHolder(private val binding: ItemMainMenuBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(menuItem: MenuItem) {
             binding.apply {
-                menuItemView.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.MENU_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM); onClickListener(menuItem) }
+                menuItemView.setOnClickListener {
+                    AnalyticsManager.logSelect(
+                        AnalyticsItem.CAMPUS_SELECT_TOOL,
+                        type = AnalyticsContentType.LIST_ITEM,
+                        name = menuItem.analyticsName,
+                    )
+                    onClickListener(menuItem)
+                }
                 menuIconView.setImageResource(menuItem.iconResource)
                 menuTextView.text = context.getString(menuItem.titleResource)
                 if (menuItem.sectionTitleResource == null) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuListAdapter.kt
@@ -24,6 +24,7 @@ class MenuListAdapter(
                         AnalyticsItem.CAMPUS_SELECT_TOOL,
                         type = AnalyticsContentType.LIST_ITEM,
                         name = menuItem.analyticsName,
+                        destinationId = menuItem.analyticsName,
                     )
                     onClickListener(menuItem)
                 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
@@ -23,7 +23,6 @@ import app.kobuggi.hyuabot.ui.MainActivity
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -70,7 +69,7 @@ class SettingFragment @Inject constructor() : Fragment(), DialogInterface.OnDism
             if (!updatingSwitch) {
                 viewLifecycleOwner.lifecycleScope.launch {
                     userPreferencesRepository.setAnalyticsConsent(isChecked)
-                    FirebaseAnalytics.getInstance(requireContext()).setAnalyticsCollectionEnabled(isChecked)
+                    AnalyticsManager.setCollectionEnabled(isChecked)
                     FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = isChecked
                 }
             }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
@@ -36,6 +36,9 @@ class ShuttleRealtimeByDestinationListAdapter(
         fun bind(item: ShuttleRealtimePageQuery.Entry) {
             val isLastRun = item.seq in lastRunSeqs
             binding.lastRunBadge.visibility = if (isLastRun) View.VISIBLE else View.GONE
+            binding.warningView.visibility = if (
+                stopID == R.string.shuttle_tab_shuttlecock_out && item.route.tag == "DY"
+            ) View.VISIBLE else View.GONE
             if ((stopID == R.string.shuttle_tab_dormitory_out || stopID == R.string.shuttle_tab_shuttlecock_out)) {
                 if (headerID == R.string.shuttle_header_bound_for_station || headerID == R.string.shuttle_header_bound_for_jungang_station) {
                     when (item.route.tag) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByTimeListAdapter.kt
@@ -126,7 +126,7 @@ class ShuttleRealtimeByTimeListAdapter(
                         }
                     }
                     "DY" -> {
-                        warningView.visibility = View.VISIBLE
+                        warningView.visibility = if (stopID == R.string.shuttle_tab_shuttlecock_out) View.VISIBLE else View.GONE
                         textView.apply {
                             text = context.getString(R.string.shuttle_type_school_terminal)
                             setTextColor(context.getColor(R.color.hanyang_orange))

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/TransitTimelineView.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/TransitTimelineView.kt
@@ -49,7 +49,7 @@ class TransitTimelineView @JvmOverloads constructor(
         color = android.graphics.Color.WHITE
     }
     private val bubbleFillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = android.graphics.Color.WHITE
+        color = ContextCompat.getColor(context, R.color.dialog_background)
         style = Paint.Style.FILL
     }
     private val bubbleStrokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {

--- a/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
@@ -25,6 +25,9 @@ import com.google.firebase.analytics.logEvent
 
 /** Every user-visible screen. [id] == GA4 `screen_name` (shared with iOS). */
 enum class AnalyticsScreen(val id: String) {
+    // Home
+    HOME("home"),
+
     // Shuttle
     SHUTTLE_REALTIME("shuttle_realtime"),
     SHUTTLE_TIMETABLE("shuttle_timetable"),
@@ -82,11 +85,21 @@ enum class AnalyticsContentType(val id: String) {
 /** Every tappable element. [id] == GA4 `item_id` (shared with iOS). */
 enum class AnalyticsItem(val id: String) {
     // Tab bar (bottom navigation)
+    TAB_HOME("tab_home"),
     TAB_SHUTTLE("tab_shuttle"),
     TAB_BUS("tab_bus"),
     TAB_SUBWAY("tab_subway"),
     TAB_CAFETERIA("tab_cafeteria"),
     TAB_MENU("tab_menu"), // Android 5th tab
+
+    // Home
+    HOME_TRY("home_try"),
+    HOME_DISMISS_PROMPT("home_dismiss_prompt"),
+    HOME_OPEN_LEGACY_SHUTTLE("home_open_legacy_shuttle"),
+    HOME_OPEN_SHUTTLE_DETAIL("home_open_shuttle_detail"),
+    HOME_OPEN_CAFETERIA("home_open_cafeteria"),
+    HOME_REFRESH("home_refresh"),
+    HOME_SELECT_DESTINATION("home_select_destination"),
 
     // Shuttle
     SHUTTLE_OPEN_HELP("shuttle_open_help"),

--- a/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
@@ -83,6 +83,16 @@ enum class AnalyticsContentType(val id: String) {
     DATE_CONTROL("date_control"),
 }
 
+/** Event-scoped parameters registered as GA4 custom dimensions. */
+object AnalyticsParameter {
+    const val SCHEMA_VERSION = "analytics_schema_version"
+    const val ELEMENT_ID = "element_id"
+    const val ELEMENT_TYPE = "element_type"
+    const val DESTINATION_ID = "destination_id"
+}
+
+const val ANALYTICS_SCHEMA_VERSION = "2"
+
 /** Every tappable element. [id] == GA4 `item_id` (shared with iOS). */
 enum class AnalyticsItem(val id: String) {
     // Tab bar (bottom navigation)
@@ -156,12 +166,25 @@ enum class AnalyticsItem(val id: String) {
 /** Thin wrapper over Firebase Analytics. The only place that calls `logEvent`. */
 object AnalyticsManager {
     private val analytics: FirebaseAnalytics by lazy { Firebase.analytics }
+    private val collectionGate = AnalyticsCollectionGate()
+
+    /**
+     * Applies the user's collection preference and flushes events that arrived
+     * while DataStore was still loading the preference at app startup.
+     */
+    fun setCollectionEnabled(enabled: Boolean) {
+        analytics.setAnalyticsCollectionEnabled(enabled)
+        collectionGate.setEnabled(enabled)
+    }
 
     /** Logs a GA4 `screen_view` event. */
     fun logScreen(screen: AnalyticsScreen, screenClass: String? = null) {
-        analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
-            param(FirebaseAnalytics.Param.SCREEN_NAME, screen.id)
-            screenClass?.let { param(FirebaseAnalytics.Param.SCREEN_CLASS, it) }
+        collectionGate.runWhenEnabled {
+            analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+                param(FirebaseAnalytics.Param.SCREEN_NAME, screen.id)
+                screenClass?.let { param(FirebaseAnalytics.Param.SCREEN_CLASS, it) }
+                param(AnalyticsParameter.SCHEMA_VERSION, ANALYTICS_SCHEMA_VERSION)
+            }
         }
     }
 
@@ -172,16 +195,66 @@ object AnalyticsManager {
      * @param type the kind of element (becomes `content_type`).
      * @param name optional contextual label (becomes `item_name`), e.g. the
      *   selected stop, contact name, building name, campus, or theme.
+     * @param destinationId optional low-cardinality destination identifier for
+     *   funnel analysis. Unlike [name], this value is reportable in GA4.
      */
     fun logSelect(
         item: AnalyticsItem,
         type: AnalyticsContentType = AnalyticsContentType.BUTTON,
         name: String? = null,
+        destinationId: String? = null,
     ) {
-        analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT) {
-            param(FirebaseAnalytics.Param.CONTENT_TYPE, type.id)
-            param(FirebaseAnalytics.Param.ITEM_ID, item.id)
-            name?.let { param(FirebaseAnalytics.Param.ITEM_NAME, it) }
+        val parameters = selectionParameters(item, type, name, destinationId)
+        collectionGate.runWhenEnabled {
+            analytics.logEvent(FirebaseAnalytics.Event.SELECT_CONTENT) {
+                parameters.forEach { (key, value) -> param(key, value) }
+            }
         }
+    }
+}
+
+internal fun selectionParameters(
+    item: AnalyticsItem,
+    type: AnalyticsContentType,
+    name: String?,
+    destinationId: String?,
+): Map<String, String> = buildMap {
+    put(FirebaseAnalytics.Param.CONTENT_TYPE, type.id)
+    put(FirebaseAnalytics.Param.ITEM_ID, item.id)
+    name?.let { put(FirebaseAnalytics.Param.ITEM_NAME, it) }
+    put(AnalyticsParameter.SCHEMA_VERSION, ANALYTICS_SCHEMA_VERSION)
+    put(AnalyticsParameter.ELEMENT_ID, item.id)
+    put(AnalyticsParameter.ELEMENT_TYPE, type.id)
+    destinationId?.let { put(AnalyticsParameter.DESTINATION_ID, it) }
+}
+
+/** Thread-safe startup gate for consent-aware Analytics events. */
+internal class AnalyticsCollectionGate {
+    private val lock = Any()
+    private var enabled: Boolean? = null
+    private val pendingEvents = mutableListOf<() -> Unit>()
+
+    fun setEnabled(isEnabled: Boolean) {
+        val eventsToRun = synchronized(lock) {
+            enabled = isEnabled
+            val pending = if (isEnabled) pendingEvents.toList() else emptyList()
+            pendingEvents.clear()
+            pending
+        }
+        eventsToRun.forEach { it() }
+    }
+
+    fun runWhenEnabled(event: () -> Unit) {
+        val shouldRun = synchronized(lock) {
+            when (enabled) {
+                true -> true
+                false -> false
+                null -> {
+                    pendingEvents += event
+                    false
+                }
+            }
+        }
+        if (shouldRun) event()
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsManager.kt
@@ -65,6 +65,7 @@ enum class AnalyticsScreen(val id: String) {
 
     // Android-only screens
     MENU("menu"),                       // bottom-nav "more" hub
+    CAMPUS("campus"),
     NOTICE("notice"),                   // notice list
     SETTING_CAMPUS("setting_campus"),   // campus picker dialog
     SETTING_THEME("setting_theme"),     // theme picker dialog
@@ -91,6 +92,7 @@ enum class AnalyticsItem(val id: String) {
     TAB_SUBWAY("tab_subway"),
     TAB_CAFETERIA("tab_cafeteria"),
     TAB_MENU("tab_menu"), // Android 5th tab
+    TAB_CAMPUS("tab_campus"),
 
     // Home
     HOME_TRY("home_try"),
@@ -144,6 +146,7 @@ enum class AnalyticsItem(val id: String) {
     // Notice (Android-only)
     NOTICE_OPEN("notice_open"),
     MENU_SELECT_ROW("menu_select_row"),
+    CAMPUS_SELECT_TOOL("campus_select_tool"),
 
     // Birthday dialog
     BIRTHDAY_DO_NOT_SHOW("birthday_do_not_show"),

--- a/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsScreenDispatcher.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/AnalyticsScreenDispatcher.kt
@@ -1,0 +1,30 @@
+package app.kobuggi.hyuabot.util
+
+/**
+ * Delays manual screen events until the Activity is resumed. Firebase rejects
+ * screen views emitted from NavController callbacks during Activity.onCreate.
+ */
+class AnalyticsScreenDispatcher(
+    private val logScreen: (AnalyticsScreen) -> Unit,
+) {
+    private var isResumed = false
+    private var pendingScreen: AnalyticsScreen? = null
+
+    fun onDestinationChanged(screen: AnalyticsScreen) {
+        if (isResumed) {
+            logScreen(screen)
+        } else {
+            pendingScreen = screen
+        }
+    }
+
+    fun onResumed() {
+        isResumed = true
+        pendingScreen?.let(logScreen)
+        pendingScreen = null
+    }
+
+    fun onPaused() {
+        isResumed = false
+    }
+}

--- a/app/src/main/res/drawable-anydpi/ic_campus.xml
+++ b/app/src/main/res/drawable-anydpi/ic_campus.xml
@@ -1,11 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="#333333"
-    android:alpha="0.6">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M5,13.18v4L12,21l7,-3.82v-4L12,17l-7,-3.82zM12,3L1,9l11,6 9,-4.91V17h2V9L12,3z"/>
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,3h8v8H3zM13,3h8v8h-8zM3,13h8v8H3zM13,13h8v8h-8z" />
 </vector>

--- a/app/src/main/res/drawable/bg_campus_tool_icon.xml
+++ b/app/src/main/res/drawable/bg_campus_tool_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/campus_icon_background" />
+</shape>

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -1,19 +1,115 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/campus_scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/background">
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/menu_recycler_view"
+    android:background="@color/background"
+    android:clipToPadding="false"
+    android:fillViewport="true"
+    android:overScrollMode="never">
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="8dp"
-        android:layout_marginHorizontal="8dp"
-        android:clipToPadding="false"
-        android:clipChildren="false"
-        android:overScrollMode="never"
-        android:scrollbars="none"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:orientation="vertical"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="32dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/campus_tools_title"
+            android:textColor="@color/primary_text"
+            android:textFontWeight="700"
+            android:textSize="24sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/campus_tools_subtitle"
+            android:textColor="@color/secondary_text"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:id="@+id/campus_tools_grid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:baselineAligned="false"
+                android:orientation="horizontal">
+
+                <include
+                    android:id="@+id/campus_map_card"
+                    layout="@layout/item_campus_tool"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="6dp"
+                    android:layout_weight="1" />
+
+                <include
+                    android:id="@+id/campus_reading_room_card"
+                    layout="@layout/item_campus_tool"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:layout_weight="1" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:baselineAligned="false"
+                android:orientation="horizontal">
+
+                <include
+                    android:id="@+id/campus_calendar_card"
+                    layout="@layout/item_campus_tool"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="6dp"
+                    android:layout_weight="1" />
+
+                <include
+                    android:id="@+id/campus_contact_card"
+                    layout="@layout/item_campus_tool"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:layout_weight="1" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:layout_marginBottom="4dp"
+            android:text="@string/campus_support_title"
+            android:textColor="@color/secondary_text"
+            android:textFontWeight="700"
+            android:textSize="13sp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/menu_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:nestedScrollingEnabled="false"
+            android:overScrollMode="never"
+            android:scrollbars="none"
+            tools:itemCount="4"
+            tools:listitem="@layout/item_main_menu" />
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_campus_tool.xml
+++ b/app/src/main/res/layout/item_campus_tool.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tool_card"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minHeight="148dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:screenReaderFocusable="true"
+    app:cardBackgroundColor="@color/home_row_background"
+    app:cardCornerRadius="18dp"
+    app:cardElevation="0dp"
+    app:strokeColor="@color/app_separator"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="start"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/tool_icon"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="@drawable/bg_campus_tool_icon"
+            android:importantForAccessibility="no"
+            android:padding="9dp"
+            app:tint="@color/campus_icon_tint"
+            tools:src="@drawable/ic_map" />
+
+        <TextView
+            android:id="@+id/tool_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:importantForAccessibility="no"
+            android:maxLines="2"
+            android:textColor="@color/primary_text"
+            android:textFontWeight="700"
+            android:textSize="16sp"
+            tools:text="Campus Map" />
+
+        <TextView
+            android:id="@+id/tool_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:importantForAccessibility="no"
+            android:maxLines="3"
+            android:textColor="@color/secondary_text"
+            android:textSize="13sp"
+            tools:text="Find buildings and classrooms" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/bottom_navigation_menu.xml
+++ b/app/src/main/res/menu/bottom_navigation_menu.xml
@@ -18,6 +18,6 @@
         android:title="@string/cafeteria" />
     <item
         android:id="@+id/menuFragment"
-        android:icon="@drawable/ic_more"
-        android:title="@string/menu" />
+        android:icon="@drawable/ic_campus"
+        android:title="@string/tabbar_campus" />
 </menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -222,8 +222,10 @@
     <fragment
         android:id="@+id/menuFragment"
         android:name="app.kobuggi.hyuabot.ui.menu.MenuFragment"
-        android:label="메뉴"
+        android:label="@string/tabbar_campus"
         tools:layout="@layout/fragment_menu">
+        <deepLink app:uri="hyuabot://campus" />
+        <deepLink app:uri="https://hyuabot.app/campus" />
         <action
             android:id="@+id/action_menuFragment_to_readingRoomFragment"
             app:destination="@id/readingRoomFragment" />

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -9,6 +9,7 @@
     <string name="bus">Bus</string>
     <string name="tabbar_bus">Bus</string>
     <string name="tabbar_more">More</string>
+    <string name="tabbar_campus">Campus</string>
     <!-- Home -->
     <string name="home_hero_title">Only what you need now</string>
     <string name="home_hero_subtitle">See information that fits the moment, from transit to meals.</string>
@@ -396,6 +397,17 @@
     <string name="menu_section_support">Support and settings</string>
     <string name="menu_section_external">External links</string>
     <string name="menu_map">Campus Map</string>
+    <string name="campus_tools_title">Campus tools</string>
+    <string name="campus_tools_subtitle">Quickly find the campus services you need.</string>
+    <string name="campus_map_title">Campus Map</string>
+    <string name="campus_map_subtitle">Find buildings and classrooms</string>
+    <string name="campus_reading_room_title">Reading Room</string>
+    <string name="campus_reading_room_subtitle">Check seats and vacancy alerts</string>
+    <string name="campus_calendar_title">Academic Calendar</string>
+    <string name="campus_calendar_subtitle">View important academic dates</string>
+    <string name="campus_contact_title">Campus Contacts</string>
+    <string name="campus_contact_subtitle">Find campus offices and phone numbers</string>
+    <string name="campus_support_title">Support and settings</string>
     <string name="map_search_guide">Enter a room to search</string>
     <string name="map_external_error">No app is available to open the map.</string>
     <string name="map_current_location">Current location</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,7 @@
     <string name="bus">路線バス</string>
     <string name="tabbar_bus">バス</string>
     <string name="tabbar_more">もっと見る</string>
+    <string name="tabbar_campus">キャンパス</string>
     <string name="home_hero_title">今必要なものだけ</string>
     <string name="home_hero_subtitle">移動から食事まで、今の状況に合う情報を表示します。</string>
     <string name="home_movement_title">今の移動</string>
@@ -373,6 +374,17 @@
     <string name="menu_section_support">サポート・設定</string>
     <string name="menu_section_external">外部リンク</string>
     <string name="menu_map">キャンパスマップ</string>
+    <string name="campus_tools_title">キャンパスツール</string>
+    <string name="campus_tools_subtitle">学校生活に必要な機能をすばやく見つけられます。</string>
+    <string name="campus_map_title">キャンパスマップ</string>
+    <string name="campus_map_subtitle">建物や講義室の場所を検索</string>
+    <string name="campus_reading_room_title">閲覧室</string>
+    <string name="campus_reading_room_subtitle">空席確認と空席通知</string>
+    <string name="campus_calendar_title">学事暦</string>
+    <string name="campus_calendar_subtitle">主な学事日程を一覧で確認</string>
+    <string name="campus_contact_title">学内連絡先</string>
+    <string name="campus_contact_subtitle">学内の部署と電話番号を検索</string>
+    <string name="campus_support_title">サポートと設定</string>
     <string name="map_search_guide">検索する講義室を入力してください</string>
     <string name="map_external_error">地図を開けるアプリがありません。</string>
     <string name="map_current_location">現在地</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -17,6 +17,8 @@
     <color name="bottom_navigation_selected">#FFFFFF</color>
     <color name="bottom_navigation_unselected">#D0D0D0</color>
     <color name="plain_button_text">#FFFFFF</color>
+    <color name="campus_icon_background">#17324D</color>
+    <color name="campus_icon_tint">#D6ECFF</color>
     <color name="app_separator">#38383A</color>
     <color name="app_selection_background">#2C2C2E</color>
     <color name="skeleton_placeholder">#252525</color>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -9,6 +9,7 @@
     <string name="bus">路线公交</string>
     <string name="tabbar_bus">公交</string>
     <string name="tabbar_more">更多</string>
+    <string name="tabbar_campus">校园</string>
     <string name="home_hero_title">只看现在需要的</string>
     <string name="home_hero_subtitle">从出行到用餐，显示符合当前情况的信息。</string>
     <string name="home_movement_title">现在出行</string>
@@ -373,6 +374,17 @@
     <string name="menu_section_support">支持与设置</string>
     <string name="menu_section_external">外部链接</string>
     <string name="menu_map">校园地图</string>
+    <string name="campus_tools_title">校园工具</string>
+    <string name="campus_tools_subtitle">快速查找校园生活所需的功能。</string>
+    <string name="campus_map_title">校园地图</string>
+    <string name="campus_map_subtitle">查找建筑和教室位置</string>
+    <string name="campus_reading_room_title">阅览室</string>
+    <string name="campus_reading_room_subtitle">查看剩余座位并设置空位提醒</string>
+    <string name="campus_calendar_title">学事历</string>
+    <string name="campus_calendar_subtitle">查看重要学事日程</string>
+    <string name="campus_contact_title">校内联系方式</string>
+    <string name="campus_contact_subtitle">查找校内部门和电话号码</string>
+    <string name="campus_support_title">支持与设置</string>
     <string name="map_search_guide">请输入要搜索的教室</string>
     <string name="map_external_error">没有可打开地图的应用。</string>
     <string name="map_current_location">当前位置</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -32,6 +32,8 @@
     <color name="bottom_navigation_selected">#005BAA</color>
     <color name="bottom_navigation_unselected">#202124</color>
     <color name="plain_button_text">#0E4A84</color>
+    <color name="campus_icon_background">#E4EFF8</color>
+    <color name="campus_icon_tint">#0E4A84</color>
     <color name="app_separator">#C6C6C8</color>
     <color name="app_selection_background">#E5E5EA</color>
     <color name="skeleton_placeholder">#E0E0E0</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="bus">노선버스</string>
     <string name="tabbar_bus">버스</string>
     <string name="tabbar_more">더 보기</string>
+    <string name="tabbar_campus">캠퍼스</string>
     <!-- 홈 -->
     <string name="home_hero_title">지금 필요한 것만</string>
     <string name="home_hero_subtitle">이동부터 식사까지, 지금 상황에 맞는 정보를 보여줘요.</string>
@@ -448,6 +449,17 @@
     <string name="menu_section_support">지원 및 설정</string>
     <string name="menu_section_external">외부 링크</string>
     <string name="menu_map">캠퍼스 지도</string>
+    <string name="campus_tools_title">캠퍼스 도구</string>
+    <string name="campus_tools_subtitle">학교생활에 필요한 기능을 빠르게 찾아보세요.</string>
+    <string name="campus_map_title">캠퍼스 지도</string>
+    <string name="campus_map_subtitle">건물과 강의실 위치 찾기</string>
+    <string name="campus_reading_room_title">열람실</string>
+    <string name="campus_reading_room_subtitle">잔여 좌석 확인과 빈자리 알림</string>
+    <string name="campus_calendar_title">학사일정</string>
+    <string name="campus_calendar_subtitle">주요 학사일정 한눈에 보기</string>
+    <string name="campus_contact_title">교내 연락처</string>
+    <string name="campus_contact_subtitle">교내 부서와 전화번호 찾기</string>
+    <string name="campus_support_title">지원 및 설정</string>
     <string name="map_search_guide">검색할 강의실을 입력하세요</string>
     <string name="map_external_error">지도를 열 수 있는 앱이 없습니다.</string>
     <string name="map_current_location">현재 위치</string>

--- a/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsConfigurationTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsConfigurationTest.kt
@@ -1,0 +1,46 @@
+package app.kobuggi.hyuabot.util
+
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [35])
+class AnalyticsConfigurationTest {
+    @Test
+    fun `automatic screen reporting is disabled`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val applicationInfo = context.packageManager.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
+
+        assertFalse(applicationInfo.metaData.getBoolean("google_analytics_automatic_screen_reporting_enabled", true))
+    }
+
+    @Test
+    fun `analytics identifiers are unique and reportable`() {
+        assertTrue(AnalyticsScreen.entries.map { it.id }.all(::isReportable))
+        assertTrue(AnalyticsContentType.entries.map { it.id }.all(::isReportable))
+        assertTrue(AnalyticsItem.entries.map { it.id }.all(::isReportable))
+        assertEquals(AnalyticsScreen.entries.size, AnalyticsScreen.entries.map { it.id }.toSet().size)
+        assertEquals(AnalyticsContentType.entries.size, AnalyticsContentType.entries.map { it.id }.toSet().size)
+        assertEquals(AnalyticsItem.entries.size, AnalyticsItem.entries.map { it.id }.toSet().size)
+    }
+
+    @Test
+    fun `home uses dedicated cross platform identifiers`() {
+        assertEquals("home", AnalyticsScreen.HOME.id)
+        assertEquals("tab_home", AnalyticsItem.TAB_HOME.id)
+        assertEquals("home_open_shuttle_detail", AnalyticsItem.HOME_OPEN_SHUTTLE_DETAIL.id)
+        assertEquals("home_select_destination", AnalyticsItem.HOME_SELECT_DESTINATION.id)
+    }
+
+    private fun isReportable(id: String): Boolean =
+        id.isNotEmpty() && id.length <= 40 && id.first().isLetter() && id.all { it.isLowerCase() || it.isDigit() || it == '_' }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsConfigurationTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsConfigurationTest.kt
@@ -41,6 +41,40 @@ class AnalyticsConfigurationTest {
         assertEquals("home_select_destination", AnalyticsItem.HOME_SELECT_DESTINATION.id)
     }
 
+    @Test
+    fun `selection parameters include reportable dimensions`() {
+        val parameters = selectionParameters(
+            AnalyticsItem.CAMPUS_SELECT_TOOL,
+            AnalyticsContentType.LIST_ITEM,
+            name = "map",
+            destinationId = "map",
+        )
+
+        assertEquals(ANALYTICS_SCHEMA_VERSION, parameters[AnalyticsParameter.SCHEMA_VERSION])
+        assertEquals("campus_select_tool", parameters[AnalyticsParameter.ELEMENT_ID])
+        assertEquals("list_item", parameters[AnalyticsParameter.ELEMENT_TYPE])
+        assertEquals("map", parameters[AnalyticsParameter.DESTINATION_ID])
+    }
+
+    @Test
+    fun `collection gate flushes startup events only after consent`() {
+        val gate = AnalyticsCollectionGate()
+        var eventCount = 0
+
+        gate.runWhenEnabled { eventCount++ }
+        assertEquals(0, eventCount)
+
+        gate.setEnabled(true)
+        assertEquals(1, eventCount)
+
+        gate.runWhenEnabled { eventCount++ }
+        assertEquals(2, eventCount)
+
+        gate.setEnabled(false)
+        gate.runWhenEnabled { eventCount++ }
+        assertEquals(2, eventCount)
+    }
+
     private fun isReportable(id: String): Boolean =
         id.isNotEmpty() && id.length <= 40 && id.first().isLetter() && id.all { it.isLowerCase() || it.isDigit() || it == '_' }
 }

--- a/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsScreenDispatcherTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/AnalyticsScreenDispatcherTest.kt
@@ -1,0 +1,34 @@
+package app.kobuggi.hyuabot.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnalyticsScreenDispatcherTest {
+    @Test
+    fun `cold start screen is logged once after resume`() {
+        val screens = mutableListOf<AnalyticsScreen>()
+        val dispatcher = AnalyticsScreenDispatcher(screens::add)
+
+        dispatcher.onDestinationChanged(AnalyticsScreen.HOME)
+        assertEquals(emptyList<AnalyticsScreen>(), screens)
+
+        dispatcher.onResumed()
+        dispatcher.onResumed()
+        assertEquals(listOf(AnalyticsScreen.HOME), screens)
+    }
+
+    @Test
+    fun `latest paused destination is logged after resume`() {
+        val screens = mutableListOf<AnalyticsScreen>()
+        val dispatcher = AnalyticsScreenDispatcher(screens::add)
+
+        dispatcher.onResumed()
+        dispatcher.onDestinationChanged(AnalyticsScreen.CAMPUS)
+        dispatcher.onPaused()
+        dispatcher.onDestinationChanged(AnalyticsScreen.MAP)
+        dispatcher.onDestinationChanged(AnalyticsScreen.CONTACT)
+        dispatcher.onResumed()
+
+        assertEquals(listOf(AnalyticsScreen.CAMPUS, AnalyticsScreen.CONTACT), screens)
+    }
+}

--- a/watch/build.gradle.kts
+++ b/watch/build.gradle.kts
@@ -116,6 +116,7 @@ dependencies {
     implementation(libs.rxJava)
     implementation(libs.rxAndroid)
     implementation(libs.androidx.runtime.livedata)
+    testImplementation(libs.junit)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.rules)

--- a/watch/src/androidTest/java/app/kobuggi/hyuabot/presentation/WatchNavigationSmokeTest.kt
+++ b/watch/src/androidTest/java/app/kobuggi/hyuabot/presentation/WatchNavigationSmokeTest.kt
@@ -1,9 +1,14 @@
 package app.kobuggi.hyuabot.presentation
 
+import android.content.Intent
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.junit4.v2.AndroidComposeTestRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.kobuggi.hyuabot.R
 import org.junit.Rule
@@ -12,23 +17,36 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class WatchNavigationSmokeTest {
+    private val startIntent = Intent(
+        ApplicationProvider.getApplicationContext(),
+        MainActivity::class.java,
+    ).putExtra("stopID", "dormitory")
+
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>(
+        activityRule = ActivityScenarioRule<MainActivity>(startIntent),
+        activityProvider = { rule ->
+            var activity: MainActivity? = null
+            rule.scenario.onActivity { activity = it }
+            checkNotNull(activity)
+        },
+    )
 
     @Test
-    fun mainStopListRenders() {
-        composeTestRule.onNodeWithText(text(R.string.stop_dormitory)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(text(R.string.stop_shuttlecock)).assertIsDisplayed()
+    fun stopDetailRendersForExplicitStop() {
         composeTestRule.onNodeWithText(text(R.string.stop_station)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_terminal)).assertIsDisplayed()
     }
 
     @Test
-    fun stopDetailRendersAfterStopClick() {
-        composeTestRule.onNodeWithText(text(R.string.stop_dormitory)).performClick()
+    fun otherStopsReturnsFromDetailToStopList() {
+        composeTestRule.onNode(hasScrollAction()).performScrollToIndex(5)
+        composeTestRule.onNodeWithText(text(R.string.other_stops))
+            .performClick()
 
+        composeTestRule.onNodeWithText(text(R.string.stop_dormitory)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(text(R.string.stop_shuttlecock)).assertIsDisplayed()
         composeTestRule.onNodeWithText(text(R.string.stop_station)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(text(R.string.stop_terminal)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(text(R.string.stop_jungang)).assertIsDisplayed()
     }
 
     private fun text(resId: Int): String = composeTestRule.activity.getString(resId)

--- a/watch/src/main/AndroidManifest.xml
+++ b/watch/src/main/AndroidManifest.xml
@@ -2,9 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature android:name="android.hardware.type.watch" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <application
         android:icon="@drawable/hanyang_phone"

--- a/watch/src/main/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsEvent.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsEvent.kt
@@ -1,0 +1,38 @@
+package app.kobuggi.hyuabot.analytics
+
+internal data class WatchAnalyticsEvent(
+    val event: String,
+    val platform: String,
+    val installationId: String,
+    val appVersion: String,
+    val entryPoint: String,
+    val stopId: String? = null,
+) {
+    companion object {
+        fun appOpen(
+            installationId: String,
+            appVersion: String,
+            entryPoint: String,
+        ) = WatchAnalyticsEvent(
+            event = "watch_app_open",
+            platform = "wear_os",
+            installationId = installationId,
+            appVersion = appVersion,
+            entryPoint = entryPoint,
+        )
+
+        fun stopSelected(
+            installationId: String,
+            appVersion: String,
+            entryPoint: String,
+            stopId: String,
+        ) = WatchAnalyticsEvent(
+            event = "watch_stop_selected",
+            platform = "wear_os",
+            installationId = installationId,
+            appVersion = appVersion,
+            entryPoint = entryPoint,
+            stopId = stopId,
+        )
+    }
+}

--- a/watch/src/main/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsTracker.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsTracker.kt
@@ -1,0 +1,76 @@
+package app.kobuggi.hyuabot.analytics
+
+import android.content.Context
+import app.kobuggi.hyuabot.BuildConfig
+import com.google.gson.Gson
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.io.IOException
+import java.util.UUID
+
+class WatchAnalyticsTracker(
+    context: Context,
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    enum class EntryPoint(val value: String) {
+        APP("app"),
+        TILE("tile"),
+    }
+
+    private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val installationId =
+        preferences.getString(INSTALLATION_ID_KEY, null) ?: UUID.randomUUID().toString().also {
+            preferences.edit().putString(INSTALLATION_ID_KEY, it).apply()
+        }
+
+    fun trackAppOpen(entryPoint: EntryPoint) {
+        send(
+            WatchAnalyticsEvent.appOpen(
+                installationId = installationId,
+                appVersion = BuildConfig.VERSION_NAME,
+                entryPoint = entryPoint.value,
+            ),
+        )
+    }
+
+    fun trackStopSelected(stopId: String, entryPoint: EntryPoint) {
+        send(
+            WatchAnalyticsEvent.stopSelected(
+                installationId = installationId,
+                appVersion = BuildConfig.VERSION_NAME,
+                entryPoint = entryPoint.value,
+                stopId = stopId,
+            ),
+        )
+    }
+
+    private fun send(event: WatchAnalyticsEvent) {
+        val request =
+            Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/analytics/watch/events")
+                .post(GSON.toJson(event).toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+
+        client.newCall(request).enqueue(
+            object : Callback {
+                override fun onFailure(call: Call, e: IOException) = Unit
+
+                override fun onResponse(call: Call, response: Response) {
+                    response.close()
+                }
+            },
+        )
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "watch_analytics"
+        private const val INSTALLATION_ID_KEY = "installation_id"
+        private val GSON = Gson()
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainActivity.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainActivity.kt
@@ -1,10 +1,15 @@
 package app.kobuggi.hyuabot.presentation
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,14 +17,25 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -28,6 +44,7 @@ import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
@@ -46,16 +63,19 @@ class MainActivity : ComponentActivity() {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         setTheme(android.R.style.Theme_DeviceDefault)
-        val stopID = intent.getStringExtra("stopID")
+        val stopID = intent.getStringExtra("stopID")?.let(::normalizeStopId)
+        val stopPreferences = WatchStopPreferences(applicationContext)
         watchAnalyticsTracker = WatchAnalyticsTracker(applicationContext)
         if (stopID != null) {
             appOpenEntryPoint = WatchAnalyticsTracker.EntryPoint.TILE
+            stopPreferences.recentStopId = stopID
             if (savedInstanceState == null) {
-                watchAnalyticsTracker.trackStopSelected(normalizeStopId(stopID), WatchAnalyticsTracker.EntryPoint.TILE)
+                watchAnalyticsTracker.trackStopSelected(stopID, WatchAnalyticsTracker.EntryPoint.TILE)
             }
         }
         setContent {
-            NavHostScreen(stopID) { selectedStopID ->
+            NavHostScreen(stopID, stopPreferences.recentStopId) { selectedStopID ->
+                stopPreferences.recentStopId = selectedStopID
                 watchAnalyticsTracker.trackStopSelected(selectedStopID, WatchAnalyticsTracker.EntryPoint.APP)
             }
         }
@@ -80,8 +100,13 @@ class MainActivity : ComponentActivity() {
         @Composable
         fun NavHostScreen(
             stopID: String?,
+            recentStopID: String? = null,
             onStopSelected: (String) -> Unit = {},
         ) {
+            var isResolved by rememberSaveable(stopID) { mutableStateOf(stopID != null) }
+            var initialStopID by rememberSaveable(stopID) { mutableStateOf(stopID) }
+            var nearestStopID by rememberSaveable(stopID) { mutableStateOf<String?>(null) }
+
             HYUabotTheme {
                 Box(
                     modifier = Modifier
@@ -89,11 +114,78 @@ class MainActivity : ComponentActivity() {
                         .background(Color(0xFF000000)),
                     contentAlignment = Alignment.Center
                 ) {
-                    NavigationStack(
-                        startRoute = if (stopID != null) "detail/${normalizeStopId(stopID)}" else Screen.Main.route,
-                        onStopSelected = onStopSelected,
+                    if (!isResolved) {
+                        FindNearestStop { resolvedNearestStopID ->
+                            nearestStopID = resolvedNearestStopID
+                            initialStopID = resolvedNearestStopID ?: recentStopID
+                            isResolved = true
+                        }
+                    } else {
+                        NavigationStack(
+                            startRoute = initialStopID?.let { "detail/$it" } ?: Screen.Main.route,
+                            nearestStopID = nearestStopID,
+                            onStopSelected = onStopSelected,
+                        )
+                    }
+                }
+            }
+        }
+
+        @Composable
+        private fun FindNearestStop(onResolved: (String?) -> Unit) {
+            val context = androidx.compose.ui.platform.LocalContext.current
+            var canUseLocation by remember { mutableStateOf<Boolean?>(null) }
+            val permissionLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestMultiplePermissions(),
+            ) { result ->
+                canUseLocation = result[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                    result[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+            }
+
+            LaunchedEffect(Unit) {
+                val isGranted = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                ) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                ) == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    canUseLocation = true
+                } else {
+                    permissionLauncher.launch(
+                        arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                        ),
                     )
                 }
+            }
+
+            LaunchedEffect(canUseLocation) {
+                when (canUseLocation) {
+                    true -> {
+                        val location = WatchLocationProvider(context).currentLocation()
+                        onResolved(
+                            location?.let {
+                                NearestStopResolver.resolve(it.latitude, it.longitude, it.accuracy)
+                            },
+                        )
+                    }
+                    false -> onResolved(null)
+                    null -> Unit
+                }
+            }
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                CircularProgressIndicator()
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.finding_nearest_stop),
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
             }
         }
 
@@ -140,7 +232,12 @@ class MainActivity : ComponentActivity() {
         }
 
         @Composable
-        fun DepartureListScreen(stopID: String, viewModel: MainViewModel = MainViewModel(GraphQLModule.getInstance(), stopID)) {
+        fun DepartureListScreen(
+            stopID: String,
+            isNearest: Boolean = false,
+            onShowOtherStops: () -> Unit = {},
+        ) {
+            val viewModel = remember(stopID) { MainViewModel(GraphQLModule.getInstance(), stopID) }
             // Define the lifecycle events to start and stop the ViewModel
             LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { viewModel.start() }
             LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) { viewModel.stop() }
@@ -150,6 +247,7 @@ class MainActivity : ComponentActivity() {
             val thirdItem = viewModel.thirdItem.observeAsState()
             val fourthItem = viewModel.fourthItem.observeAsState()
             val result = viewModel.result.observeAsState()
+            val isLoading = viewModel.isLoading.observeAsState(true)
             val scrollState = rememberScalingLazyListState()
             // Display the result
             Scaffold (
@@ -162,11 +260,13 @@ class MainActivity : ComponentActivity() {
                             .padding(horizontal = 8.dp),
                         state = scrollState,
                     ) {
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
-                        item { ShuttleButton(stringResource(R.string.stop_station), firstItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time) }
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
+                        item { DepartureHeader(stopID, isNearest) }
+                        item { ShuttleButton(stringResource(R.string.stop_station), firstItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time, isLoading.value) }
+                        item { OtherStopsButton(onShowOtherStops) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
                     }
                 } else if (stopID == "shuttlecock"){
                     ScalingLazyColumn (
@@ -175,12 +275,14 @@ class MainActivity : ComponentActivity() {
                             .padding(horizontal = 8.dp),
                         state = scrollState,
                     ) {
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
-                        item { ShuttleButton(stringResource(R.string.stop_station), firstItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_dormitory), fourthItem.value?.time) }
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
+                        item { DepartureHeader(stopID, isNearest) }
+                        item { ShuttleButton(stringResource(R.string.stop_station), firstItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_dormitory), fourthItem.value?.time, isLoading.value) }
+                        item { OtherStopsButton(onShowOtherStops) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
                     }
                 } else if (stopID == "station"){
                     ScalingLazyColumn (
@@ -189,26 +291,44 @@ class MainActivity : ComponentActivity() {
                             .padding(horizontal = 8.dp),
                         state = scrollState,
                     ) {
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
+                        item { DepartureHeader(stopID, isNearest) }
                         item { ShuttleButton(
                             if (firstItem.value?.route?.name?.endsWith("S") == true) {
                                 stringResource(R.string.stop_shuttlecock)
                             } else {
                                 stringResource(R.string.stop_dormitory)
                             },
-                            firstItem.value?.time
+                            firstItem.value?.time,
+                            isLoading.value,
                         )}
-                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time) }
-                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time) }
-                        item { Spacer(modifier = Modifier.height(40.dp)) }
+                        item { ShuttleButton(stringResource(R.string.stop_terminal), secondItem.value?.time, isLoading.value) }
+                        item { ShuttleButton(stringResource(R.string.stop_jungang), thirdItem.value?.time, isLoading.value) }
+                        item { OtherStopsButton(onShowOtherStops) }
+                        item { Spacer(modifier = Modifier.height(20.dp)) }
                     }
                 } else if (stopID == "terminal"){
                     if (result.value == null || result.value!!.isEmpty()) {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
+                        ScalingLazyColumn(
+                            modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
+                            state = scrollState,
                         ) {
-                            Text(stringResource(R.string.no_scheduled_shuttle), textAlign = TextAlign.Center, color = Color(0xFF0E4A84))
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
+                            item { DepartureHeader(stopID, isNearest) }
+                            item {
+                                if (isLoading.value) {
+                                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                } else {
+                                    Text(
+                                        stringResource(R.string.no_scheduled_shuttle),
+                                        textAlign = TextAlign.Center,
+                                        color = Color.White,
+                                        modifier = Modifier.padding(vertical = 16.dp),
+                                    )
+                                }
+                            }
+                            item { OtherStopsButton(onShowOtherStops) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
                         }
                     } else {
                         ScalingLazyColumn (
@@ -217,7 +337,8 @@ class MainActivity : ComponentActivity() {
                                 .padding(horizontal = 8.dp),
                             state = scrollState,
                         ) {
-                            item { Spacer(modifier = Modifier.height(40.dp)) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
+                            item { DepartureHeader(stopID, isNearest) }
                             result.value?.subList(0, minOf(result.value!!.size, 3))?.forEach { item ->
                                 item { ShuttleButton(
                                     if (item.route.name.endsWith("S")) {
@@ -228,16 +349,32 @@ class MainActivity : ComponentActivity() {
                                     item.time
                                 )}
                             }
-                            item { Spacer(modifier = Modifier.height(40.dp)) }
+                            item { OtherStopsButton(onShowOtherStops) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
                         }
                     }
                 } else if (stopID == "jungang"){
                     if (result.value == null || result.value!!.isEmpty()) {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
+                        ScalingLazyColumn(
+                            modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
+                            state = scrollState,
                         ) {
-                            Text(stringResource(R.string.no_scheduled_shuttle), textAlign = TextAlign.Center, color = Color(0xFF0E4A84))
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
+                            item { DepartureHeader(stopID, isNearest) }
+                            item {
+                                if (isLoading.value) {
+                                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                } else {
+                                    Text(
+                                        stringResource(R.string.no_scheduled_shuttle),
+                                        textAlign = TextAlign.Center,
+                                        color = Color.White,
+                                        modifier = Modifier.padding(vertical = 16.dp),
+                                    )
+                                }
+                            }
+                            item { OtherStopsButton(onShowOtherStops) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
                         }
                     } else {
                         ScalingLazyColumn (
@@ -246,11 +383,13 @@ class MainActivity : ComponentActivity() {
                                 .padding(horizontal = 8.dp),
                             state = scrollState,
                         ) {
-                            item { Spacer(modifier = Modifier.height(40.dp)) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
+                            item { DepartureHeader(stopID, isNearest) }
                             result.value?.subList(0, minOf(result.value!!.size, 3))?.forEach { item ->
                                 item { ShuttleButton(stringResource(R.string.stop_dormitory), item.time) }
                             }
-                            item { Spacer(modifier = Modifier.height(40.dp)) }
+                            item { OtherStopsButton(onShowOtherStops) }
+                            item { Spacer(modifier = Modifier.height(20.dp)) }
                         }
                     }
                 }
@@ -263,28 +402,86 @@ class MainActivity : ComponentActivity() {
         }
 
         @Composable
+        private fun DepartureHeader(stopID: String, isNearest: Boolean) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (isNearest) {
+                    Text(
+                        text = stringResource(R.string.nearest_stop),
+                        color = Color(0xFFB8C7D9),
+                        maxLines = 1,
+                    )
+                }
+                Text(
+                    text = stopName(stopID),
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        @Composable
+        private fun OtherStopsButton(onClick: () -> Unit) {
+            Button(
+                onClick = onClick,
+                colors = ButtonDefaults.buttonColors(
+                    contentColor = Color.White,
+                    backgroundColor = Color(0xFF303033),
+                ),
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.other_stops),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        @Composable
+        private fun stopName(stopID: String): String = stringResource(
+            stops.firstOrNull { it.id == stopID }?.labelRes ?: R.string.shuttle,
+        )
+
+        @Composable
         private fun ShuttleButton(
             destination: String,
             time: LocalTime?,
+            isLoading: Boolean = false,
             modifier: Modifier = Modifier
         ) {
-            Button(
-                onClick = { },
-                colors = ButtonDefaults.buttonColors(
-                    contentColor = Color.White,
-                    backgroundColor = hanyangBlue,
-                ),
+            Box(
                 modifier = modifier
                     .fillMaxWidth()
                     .height(50.dp)
+                    .clip(RoundedCornerShape(25.dp))
+                    .background(hanyangBlue),
+                contentAlignment = Alignment.Center,
             ) {
                 Row(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(destination)
-                    Spacer(modifier = Modifier.weight(1f))
-                    Text(if (time == null) stringResource(R.string.shuttle_service_ended) else shuttleTime(time))
+                    Text(
+                        text = destination,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Spacer(modifier = Modifier.padding(horizontal = 4.dp))
+                    if (isLoading) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    } else {
+                        Text(
+                            text = if (time == null) stringResource(R.string.shuttle_service_ended) else shuttleTime(time),
+                            color = Color.White,
+                            maxLines = 1,
+                        )
+                    }
                 }
             }
         }

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainActivity.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainActivity.kt
@@ -32,20 +32,39 @@ import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.analytics.WatchAnalyticsTracker
 import app.kobuggi.hyuabot.presentation.NavigationUtils.Companion.NavigationStack
 import app.kobuggi.hyuabot.presentation.theme.HYUabotTheme
 import app.kobuggi.hyuabot.service.GraphQLModule
 import java.time.LocalTime
 
 class MainActivity : ComponentActivity() {
+    private lateinit var watchAnalyticsTracker: WatchAnalyticsTracker
+    private var appOpenEntryPoint = WatchAnalyticsTracker.EntryPoint.APP
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         setTheme(android.R.style.Theme_DeviceDefault)
         val stopID = intent.getStringExtra("stopID")
-        setContent {
-            NavHostScreen(stopID)
+        watchAnalyticsTracker = WatchAnalyticsTracker(applicationContext)
+        if (stopID != null) {
+            appOpenEntryPoint = WatchAnalyticsTracker.EntryPoint.TILE
+            if (savedInstanceState == null) {
+                watchAnalyticsTracker.trackStopSelected(normalizeStopId(stopID), WatchAnalyticsTracker.EntryPoint.TILE)
+            }
         }
+        setContent {
+            NavHostScreen(stopID) { selectedStopID ->
+                watchAnalyticsTracker.trackStopSelected(selectedStopID, WatchAnalyticsTracker.EntryPoint.APP)
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        watchAnalyticsTracker.trackAppOpen(appOpenEntryPoint)
+        appOpenEntryPoint = WatchAnalyticsTracker.EntryPoint.APP
     }
 
     companion object {
@@ -59,7 +78,10 @@ class MainActivity : ComponentActivity() {
         )
 
         @Composable
-        fun NavHostScreen(stopID: String?) {
+        fun NavHostScreen(
+            stopID: String?,
+            onStopSelected: (String) -> Unit = {},
+        ) {
             HYUabotTheme {
                 Box(
                     modifier = Modifier
@@ -67,13 +89,19 @@ class MainActivity : ComponentActivity() {
                         .background(Color(0xFF000000)),
                     contentAlignment = Alignment.Center
                 ) {
-                    NavigationStack(if (stopID != null) "detail/${normalizeStopId(stopID)}" else Screen.Main.route)
+                    NavigationStack(
+                        startRoute = if (stopID != null) "detail/${normalizeStopId(stopID)}" else Screen.Main.route,
+                        onStopSelected = onStopSelected,
+                    )
                 }
             }
         }
 
         @Composable
-        fun MainScreen(navController: NavHostController) {
+        fun MainScreen(
+            navController: NavHostController,
+            onStopSelected: (String) -> Unit = {},
+        ) {
             val scrollState = rememberScalingLazyListState()
             Scaffold (
                 positionIndicator = { PositionIndicator(scalingLazyListState = scrollState) }
@@ -88,7 +116,10 @@ class MainActivity : ComponentActivity() {
                     stops.forEach { stop ->
                         item {
                             Button(
-                                onClick = { navController.navigate("detail/${stop.id}") },
+                                onClick = {
+                                    onStopSelected(stop.id)
+                                    navController.navigate("detail/${stop.id}")
+                                },
                                 colors = ButtonDefaults.buttonColors(
                                     contentColor = Color.White,
                                     disabledContentColor = Color.White,

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainViewModel.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/MainViewModel.kt
@@ -25,6 +25,7 @@ class MainViewModel(private val apolloClient: ApolloClient, private val stopID: 
     private val _thirdItem = MutableLiveData<ShuttleRealtimePageQuery.Entry?>(null)
     private val _fourthItem = MutableLiveData<ShuttleRealtimePageQuery.Entry?>(null)
     private val _result = MutableLiveData<List<ShuttleRealtimePageQuery.Entry>>(emptyList())
+    private val _isLoading = MutableLiveData(true)
     private val _disposable = CompositeDisposable()
 
     val firstItem: LiveData<ShuttleRealtimePageQuery.Entry?> get() = _firstItem
@@ -32,24 +33,26 @@ class MainViewModel(private val apolloClient: ApolloClient, private val stopID: 
     val thirdItem: LiveData<ShuttleRealtimePageQuery.Entry?> get() = _thirdItem
     val fourthItem: LiveData<ShuttleRealtimePageQuery.Entry?> get() = _fourthItem
     val result: LiveData<List<ShuttleRealtimePageQuery.Entry>> get() = _result
+    val isLoading: LiveData<Boolean> get() = _isLoading
 
     private fun fetchData() {
         val now = LocalDateTime.now()
         viewModelScope.launch {
-            val response = apolloClient.query(ShuttleRealtimePageQuery(
-                stops = getStop().map {
-                    ShuttleStopInput(
-                        name = it,
-                        limit = ShuttleLimitInput(
-                            destination = Optional.present(1),
+            try {
+                val response = apolloClient.query(ShuttleRealtimePageQuery(
+                    stops = getStop().map {
+                        ShuttleStopInput(
+                            name = it,
+                            limit = ShuttleLimitInput(
+                                destination = Optional.present(1),
+                            )
                         )
-                    )
-                },
-                after = Optional.present(now.toLocalTime())
-            )).fetchPolicy(FetchPolicy.NetworkOnly).execute()
-            response.data?.shuttle?.stops.let { stops ->
-                if (stops == null) return@let
-                when (stopID) {
+                    },
+                    after = Optional.present(now.toLocalTime())
+                )).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+                response.data?.shuttle?.stops.let { stops ->
+                    if (stops == null) return@let
+                    when (stopID) {
                     "dormitory" -> {
                         val stop = stops.first { it.name == "dormitory_o" }
                         stop.timetable.destination.let { timetableByDestination ->
@@ -102,7 +105,12 @@ class MainViewModel(private val apolloClient: ApolloClient, private val stopID: 
                             _result.value = timetableByDestination.first { it.destination == "CAMPUS" }.entries
                         }
                     }
+                    }
                 }
+            } catch (error: Exception) {
+                error.printStackTrace()
+            } finally {
+                _isLoading.value = false
             }
         }
     }

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/NavigationUtils.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/NavigationUtils.kt
@@ -10,11 +10,14 @@ import androidx.navigation.navArgument
 class NavigationUtils {
     companion object {
         @Composable
-        fun NavigationStack(startRoute: String = Screen.Main.route) {
+        fun NavigationStack(
+            startRoute: String = Screen.Main.route,
+            onStopSelected: (String) -> Unit = {},
+        ) {
             val navController = rememberNavController()
             NavHost(navController = navController, startDestination = startRoute) {
                 composable(Screen.Main.route) {
-                    MainActivity.MainScreen(navController)
+                    MainActivity.MainScreen(navController, onStopSelected)
                 }
                 composable(
                     route = Screen.Detail.route + "/{stopID}",

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/NavigationUtils.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/NavigationUtils.kt
@@ -12,6 +12,7 @@ class NavigationUtils {
         @Composable
         fun NavigationStack(
             startRoute: String = Screen.Main.route,
+            nearestStopID: String? = null,
             onStopSelected: (String) -> Unit = {},
         ) {
             val navController = rememberNavController()
@@ -30,7 +31,18 @@ class NavigationUtils {
                 ) {
                     val stopID = it.arguments?.getString("stopID")
                     if (stopID != null) {
-                        MainActivity.DepartureListScreen(stopID)
+                        MainActivity.DepartureListScreen(
+                            stopID = stopID,
+                            isNearest = stopID == nearestStopID,
+                            onShowOtherStops = {
+                                navController.navigate(Screen.Main.route) {
+                                    popUpTo(navController.graph.startDestinationId) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                            },
+                        )
                     }
                 }
             }

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/NearestStopResolver.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/NearestStopResolver.kt
@@ -1,0 +1,53 @@
+package app.kobuggi.hyuabot.presentation
+
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+object NearestStopResolver {
+    const val MAX_LOCATION_ACCURACY_METERS = 500f
+    const val MAX_STOP_DISTANCE_METERS = 3_000.0
+
+    private const val EARTH_RADIUS_METERS = 6_371_000.0
+
+    private val stops = listOf(
+        StopCoordinate("dormitory", 37.29339607529377, 126.83630604103446),
+        StopCoordinate("shuttlecock", 37.29875417910844, 126.83784054072336),
+        StopCoordinate("station", 37.309700971618255, 126.85207173389148),
+        StopCoordinate("terminal", 37.319338173415936, 126.8455263115596),
+        StopCoordinate("jungang", 37.31487247528457, 126.83963540399434),
+    )
+
+    fun resolve(latitude: Double, longitude: Double, accuracyMeters: Float): String? {
+        if (accuracyMeters < 0 || accuracyMeters > MAX_LOCATION_ACCURACY_METERS) return null
+
+        val nearest = stops.minByOrNull {
+            distanceMeters(latitude, longitude, it.latitude, it.longitude)
+        } ?: return null
+        val distance = distanceMeters(latitude, longitude, nearest.latitude, nearest.longitude)
+        return nearest.id.takeIf { distance <= MAX_STOP_DISTANCE_METERS }
+    }
+
+    private fun distanceMeters(
+        startLatitude: Double,
+        startLongitude: Double,
+        endLatitude: Double,
+        endLongitude: Double,
+    ): Double {
+        val latitudeDelta = Math.toRadians(endLatitude - startLatitude)
+        val longitudeDelta = Math.toRadians(endLongitude - startLongitude)
+        val startLatitudeRadians = Math.toRadians(startLatitude)
+        val endLatitudeRadians = Math.toRadians(endLatitude)
+        val haversine = sin(latitudeDelta / 2).pow(2) +
+            cos(startLatitudeRadians) * cos(endLatitudeRadians) * sin(longitudeDelta / 2).pow(2)
+        return 2 * EARTH_RADIUS_METERS * asin(sqrt(haversine))
+    }
+
+    private data class StopCoordinate(
+        val id: String,
+        val latitude: Double,
+        val longitude: Double,
+    )
+}

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/WatchLocationProvider.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/WatchLocationProvider.kt
@@ -1,0 +1,48 @@
+package app.kobuggi.hyuabot.presentation
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.CancellationSignal
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+class WatchLocationProvider(context: Context) {
+    private val appContext = context.applicationContext
+    private val locationManager = appContext.getSystemService(LocationManager::class.java)
+
+    @SuppressLint("MissingPermission")
+    suspend fun currentLocation(): Location? = withTimeoutOrNull(LOCATION_TIMEOUT_MILLIS) {
+        suspendCancellableCoroutine { continuation ->
+            val provider = preferredProvider()
+            if (provider == null) {
+                continuation.resume(null)
+                return@suspendCancellableCoroutine
+            }
+
+            val cancellationSignal = CancellationSignal()
+            continuation.invokeOnCancellation { cancellationSignal.cancel() }
+            locationManager.getCurrentLocation(
+                provider,
+                cancellationSignal,
+                appContext.mainExecutor,
+            ) { location ->
+                if (continuation.isActive) continuation.resume(location)
+            }
+        }
+    }
+
+    private fun preferredProvider(): String? = listOf(
+        LocationManager.GPS_PROVIDER,
+        LocationManager.FUSED_PROVIDER,
+        LocationManager.NETWORK_PROVIDER,
+    ).firstOrNull { provider ->
+        locationManager.allProviders.contains(provider) && locationManager.isProviderEnabled(provider)
+    }
+
+    private companion object {
+        const val LOCATION_TIMEOUT_MILLIS = 8_000L
+    }
+}

--- a/watch/src/main/java/app/kobuggi/hyuabot/presentation/WatchStopPreferences.kt
+++ b/watch/src/main/java/app/kobuggi/hyuabot/presentation/WatchStopPreferences.kt
@@ -1,0 +1,18 @@
+package app.kobuggi.hyuabot.presentation
+
+import android.content.Context
+
+class WatchStopPreferences(context: Context) {
+    private val preferences = context.applicationContext.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+
+    var recentStopId: String?
+        get() = preferences.getString(KEY_RECENT_STOP_ID, null)
+        set(value) {
+            preferences.edit().putString(KEY_RECENT_STOP_ID, value).apply()
+        }
+
+    private companion object {
+        const val FILE_NAME = "watch_stop_preferences"
+        const val KEY_RECENT_STOP_ID = "recent_stop_id"
+    }
+}

--- a/watch/src/main/res/values-en/strings.xml
+++ b/watch/src/main/res/values-en/strings.xml
@@ -2,10 +2,13 @@
     <string name="app_name">HYUabot</string>
     <string name="shuttle">Shuttle</string>
     <string name="stop_dormitory">Dormitory</string>
-    <string name="stop_shuttlecock">Shuttlecoke</string>
+    <string name="stop_shuttlecock">Shuttlecock</string>
     <string name="stop_station">Station</string>
     <string name="stop_terminal">Terminal</string>
     <string name="stop_jungang">Jungang Stn.</string>
     <string name="no_scheduled_shuttle">No scheduled\nshuttle.</string>
     <string name="shuttle_service_ended">Ended</string>
+    <string name="finding_nearest_stop">Finding the nearest stop</string>
+    <string name="nearest_stop">Nearest stop</string>
+    <string name="other_stops">Other stops</string>
 </resources>

--- a/watch/src/main/res/values-ja/strings.xml
+++ b/watch/src/main/res/values-ja/strings.xml
@@ -8,4 +8,7 @@
     <string name="stop_jungang">中央駅</string>
     <string name="no_scheduled_shuttle">予定されている\nシャトルがありません。</string>
     <string name="shuttle_service_ended">運行終了</string>
+    <string name="finding_nearest_stop">最寄りの停留所を検索中</string>
+    <string name="nearest_stop">最寄りの停留所</string>
+    <string name="other_stops">他の停留所を見る</string>
 </resources>

--- a/watch/src/main/res/values-zh/strings.xml
+++ b/watch/src/main/res/values-zh/strings.xml
@@ -8,4 +8,7 @@
     <string name="stop_jungang">中央站</string>
     <string name="no_scheduled_shuttle">暂无预定\n校车。</string>
     <string name="shuttle_service_ended">运行结束</string>
+    <string name="finding_nearest_stop">正在查找最近的车站</string>
+    <string name="nearest_stop">最近的车站</string>
+    <string name="other_stops">查看其他车站</string>
 </resources>

--- a/watch/src/main/res/values/strings.xml
+++ b/watch/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="stop_jungang">중앙역</string>
     <string name="no_scheduled_shuttle">도착 예정인\n셔틀이 없습니다.</string>
     <string name="shuttle_service_ended">운행 종료</string>
+    <string name="finding_nearest_stop">가까운 정류장을 찾고 있습니다</string>
+    <string name="nearest_stop">가장 가까운 정류장</string>
+    <string name="other_stops">다른 정류장 보기</string>
 </resources>

--- a/watch/src/test/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsEventTest.kt
+++ b/watch/src/test/java/app/kobuggi/hyuabot/analytics/WatchAnalyticsEventTest.kt
@@ -1,0 +1,43 @@
+package app.kobuggi.hyuabot.analytics
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class WatchAnalyticsEventTest {
+    private val gson = Gson()
+
+    @Test
+    fun appOpenUsesSharedEventContract() {
+        val json = gson.toJsonTree(
+            WatchAnalyticsEvent.appOpen(
+                installationId = "123e4567-e89b-12d3-a456-426614174000",
+                appVersion = "5.0.0",
+                entryPoint = "app",
+            ),
+        ).asJsonObject
+
+        assertEquals("watch_app_open", json["event"].asString)
+        assertEquals("wear_os", json["platform"].asString)
+        assertEquals("app", json["entryPoint"].asString)
+        assertFalse(json.has("stopId"))
+    }
+
+    @Test
+    fun stopSelectedIncludesStopAndEntryPoint() {
+        val json = gson.toJsonTree(
+            WatchAnalyticsEvent.stopSelected(
+                installationId = "123e4567-e89b-12d3-a456-426614174000",
+                appVersion = "5.0.0",
+                entryPoint = "tile",
+                stopId = "station",
+            ),
+        ).asJsonObject
+
+        assertEquals("watch_stop_selected", json["event"].asString)
+        assertEquals("wear_os", json["platform"].asString)
+        assertEquals("tile", json["entryPoint"].asString)
+        assertEquals("station", json["stopId"].asString)
+    }
+}

--- a/watch/src/test/java/app/kobuggi/hyuabot/presentation/NearestStopResolverTest.kt
+++ b/watch/src/test/java/app/kobuggi/hyuabot/presentation/NearestStopResolverTest.kt
@@ -1,0 +1,27 @@
+package app.kobuggi.hyuabot.presentation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NearestStopResolverTest {
+    @Test
+    fun exactShuttlecockLocationResolvesToShuttlecock() {
+        assertEquals(
+            "shuttlecock",
+            NearestStopResolver.resolve(37.29875417910844, 126.83784054072336, 10f),
+        )
+    }
+
+    @Test
+    fun inaccurateLocationDoesNotSelectAStop() {
+        assertNull(
+            NearestStopResolver.resolve(37.29875417910844, 126.83784054072336, 600f),
+        )
+    }
+
+    @Test
+    fun locationOutsideCampusDoesNotSelectAStop() {
+        assertNull(NearestStopResolver.resolve(37.5665, 126.9780, 10f))
+    }
+}


### PR DESCRIPTION
## Changes

### 캠퍼스 도구
- 지도, 열람실, 학사일정, 연락처를 한곳에서 여는 캠퍼스 도구 허브 추가
- 한국어, 영어, 일본어, 중국어 문구와 라이트·다크 모드 색상 지원
- 캠퍼스 도구 이동 경로와 접근성 식별자 보강

### 셔틀 UI·안정성
- 다크 모드에서 막차·탑승 위치 배지와 환승 연결 정보의 대비 개선
- 셔틀콕 출발 및 DY 노선 조건에 맞게 탑승 위치 배지 표시 정리
- 홈 목적지 버튼 갱신 중 잘못된 child drawing order로 발생할 수 있는 크래시 방어

### Analytics
- Android와 iOS에서 공통으로 사용할 화면·선택 이벤트 스키마 정리
- 화면 전환 이벤트를 Activity lifecycle에 맞춰 안정적으로 전송
- 앱 시작 시 분석 동의 설정을 불러오기 전 발생한 이벤트 처리 보강
- 이벤트 스키마 버전, 요소, 유형, 이동 목적지 매개변수와 테스트 추가

### Release
- 앱 버전을 5.1.9로 업데이트

## Checks

- `maestro check-syntax .maestro/main-navigation.yaml`
- `maestro check-syntax .maestro/menu-destinations.yaml`
- `./gradlew :app:bundleProductionRelease`
- GitHub Actions: Kotlin style, unit tests, connected Android tests, Maestro E2E smoke tests, and release bundle build
