### PR TITLE
fix: Refine weather attribution link

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -2,16 +2,24 @@ package app.kobuggi.hyuabot.ui.home
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.ColorStateList
-import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.TextPaint
 import android.text.TextUtils
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.RelativeSizeSpan
 import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.Gravity
@@ -530,6 +538,7 @@ class HomeFragment : Fragment() {
         if (weather == null) {
             binding.homeHeroTitle.setText(R.string.home_hero_title)
             binding.homeHeroSubtitle.setText(R.string.home_hero_subtitle)
+            binding.homeHeroSubtitle.movementMethod = null
             binding.homeWeatherIcon.visibility = View.GONE
             return
         }
@@ -617,15 +626,53 @@ class HomeFragment : Fragment() {
             )
             else -> getString(R.string.home_hero_subtitle)
         }
-        binding.homeHeroSubtitle.text = buildList {
+        val subtitleParts = buildList {
             add(subtitle)
             if (weather.precipitationConfidence == "LOW") {
                 add(getString(R.string.home_weather_confidence_low))
             }
-            if (weather.attribution != null) {
-                add(getString(R.string.home_weather_attribution))
-            }
-        }.joinToString(" · ")
+        }
+        binding.homeHeroSubtitle.apply {
+            text = weatherSubtitleWithAttribution(
+                subtitle = subtitleParts.joinToString(" · "),
+                includesAttribution = weather.attribution != null,
+            )
+            movementMethod = if (weather.attribution != null) LinkMovementMethod.getInstance() else null
+            highlightColor = android.graphics.Color.TRANSPARENT
+        }
+    }
+
+    private fun weatherSubtitleWithAttribution(
+        subtitle: String,
+        includesAttribution: Boolean,
+    ): CharSequence {
+        if (!includesAttribution) return subtitle
+        return SpannableStringBuilder(subtitle).apply {
+            append("  ")
+            val attributionStart = length
+            append(getString(R.string.home_weather_attribution))
+            setSpan(
+                object : ClickableSpan() {
+                    override fun onClick(widget: View) {
+                        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://open-meteo.com/")))
+                    }
+
+                    override fun updateDrawState(drawState: TextPaint) {
+                        drawState.color = binding.homeHeroSubtitle.currentTextColor
+                        drawState.isUnderlineText = false
+                    }
+                },
+                attributionStart,
+                length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+            setSpan(
+                RelativeSizeSpan(0.85f),
+                attributionStart,
+                length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
     }
 
     private fun renderMovement(data: HomePageQuery.Data?) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -33,7 +33,7 @@
     <string name="home_weather_range_subtitle">%1$.0f°C–%2$.0f°C today</string>
     <string name="home_weather_precipitation_amount_subtitle">Now %1$.0f°C · %2$.1f mm in the last hour</string>
     <string name="home_weather_confidence_low">Forecast may change</string>
-    <string name="home_weather_attribution">Forecast by Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">Move now</string>
     <string name="home_movement_detail">Shuttle details</string>
     <string name="home_movement_timetable">Full timetable</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -32,7 +32,7 @@
     <string name="home_weather_range_subtitle">今日 %1$.0f°C〜%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">現在 %1$.0f°C・直近1時間 %2$.1f mm</string>
     <string name="home_weather_confidence_low">予報が変わる可能性があります</string>
-    <string name="home_weather_attribution">予報：Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">今すぐ移動</string>
     <string name="home_movement_detail">シャトル詳細</string>
     <string name="home_movement_timetable">全時刻表</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -32,7 +32,7 @@
     <string name="home_weather_range_subtitle">今日 %1$.0f°C～%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">当前 %1$.0f°C · 近1小时 %2$.1f毫米</string>
     <string name="home_weather_confidence_low">预报可能会变化</string>
-    <string name="home_weather_attribution">预报由 Open-Meteo 提供</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">现在出发</string>
     <string name="home_movement_detail">校车详情</string>
     <string name="home_movement_timetable">完整时刻表</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="home_weather_range_subtitle">오늘 %1$.0f°C~%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">현재 %1$.0f°C · 최근 1시간 %2$.1fmm</string>
     <string name="home_weather_confidence_low">예보가 달라질 수 있어요</string>
-    <string name="home_weather_attribution">예보 Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">지금 이동</string>
     <string name="home_movement_detail">셔틀 상세</string>
     <string name="home_movement_timetable">전체 시간표</string>


### PR DESCRIPTION
## Changes

### 홈 날씨

- 날씨 부제목에서 `예보` 접두어 제거
- 데이터 출처를 작고 보조색인 `Open-Meteo ↗` 링크로 표시
- 출처가 제공될 때만 링크를 노출하고 Open-Meteo 공식 페이지로 연결

### 다국어

- 한국어, 영어, 일본어, 중국어 출처 표기 통일

## Checks

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDevDebugUnitTest`
- [x] `./gradlew :app:assembleProductionDebug`
- [x] Android 에뮬레이터 라이트·다크 모드 레이아웃 확인
- [x] Open-Meteo 링크 동작 확인
