### PR TITLE
feat: Add shuttle transfer connections and initial stop rules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 519000000
-        versionName = "5.1.9"
+        versionCode = 520000000
+        versionName = "5.2.0"
         signingConfig = signingConfigs.getByName("config")
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""
     }

--- a/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
@@ -44,6 +44,15 @@ query HomePageQuery(
         ],
         after: $after
     }) {
+        initialStopRules {
+            seq
+            stopName
+            priority
+            polygon {
+                latitude
+                longitude
+            }
+        }
         stops {
             name
             timetable {

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
@@ -22,6 +22,15 @@ query ShuttleRealtimePageQuery(
         ],
         after: $after
     }) {
+        initialStopRules {
+            seq
+            stopName
+            priority
+            polygon {
+                latitude
+                longitude
+            }
+        }
         stops {
             latitude
             longitude

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
@@ -1,4 +1,9 @@
-query ShuttleRealtimePageQuery($language: String!, $after: LocalTime, $weekday: String!) {
+query ShuttleRealtimePageQuery(
+    $language: String!
+    $after: LocalTime
+    $weekday: String!
+    $logDates: [Date!]
+) {
     notices(input: {language: $language, category: "셔틀,날씨"}) {
         notices {
             title
@@ -53,8 +58,11 @@ query ShuttleRealtimePageQuery($language: String!, $after: LocalTime, $weekday: 
         }
     }
     subway(input: { keys: [
-        { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 2 },
-        { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 2 },
+        { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
+        { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
+        { stationID: "K450", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
+        { stationID: "K258", direction: ["down"], weekdays: [$weekday], limit: 12 },
+        { stationID: "S26", direction: ["up"], weekdays: [$weekday] },
     ]}) {
         stationID
         arrival {
@@ -67,14 +75,21 @@ query ShuttleRealtimePageQuery($language: String!, $after: LocalTime, $weekday: 
                 terminal { stationID name }
             }
         }
+        timetable {
+            weekday
+            direction
+            time
+            terminal { stationID name }
+        }
     }
     transferBus: bus(input: [
-        { route: 216000075, stop: 216000759, limit: 2 },
-        { route: 216000075, stop: 216000117, limit: 2 },
+        { route: 216000075, stop: 216000759, limit: 12, dates: $logDates },
+        { route: 216000075, stop: 216000117, limit: 12, dates: $logDates },
     ]) {
         route { seq name }
         stop { seq }
         arrival { minutes stops isRealtime }
+        log { date time }
     }
     busAlternative: bus(input: [
         { route: 216000068, stop: 216000383, limit: 1 },

--- a/app/src/main/graphql/schema.graphqls
+++ b/app/src/main/graphql/schema.graphqls
@@ -744,7 +744,35 @@ type Shuttle {
 
   serviceNotices(end: Date!, start: Date!): [ShuttleServiceNotice!]!
 
+  initialStopRules: [ShuttleInitialStopRule!]!
+
   stops: [ShuttleStop!]!
+}
+
+type ShuttleInitialStopRule {
+  seq: Int!
+
+  name: String!
+
+  periodType: String!
+
+  weekday: Boolean!
+
+  startTime: LocalTime
+
+  endTime: LocalTime
+
+  stopName: String!
+
+  priority: Int!
+
+  polygon: [ShuttleGeoPoint!]!
+}
+
+type ShuttleGeoPoint {
+  latitude: Float!
+
+  longitude: Float!
 }
 
 type ShuttleServiceNotice {

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
@@ -365,6 +365,28 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             }
     }
 
+    override suspend fun setShuttleAlternativeDisplayMode(mode: String) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[SHUTTLE_ALTERNATIVE_DISPLAY_MODE_KEY] = mode
+            }
+        }
+    }
+
+    override suspend fun getShuttleAlternativeDisplayMode(): Flow<String> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[SHUTTLE_ALTERNATIVE_DISPLAY_MODE_KEY] ?: "automatic"
+            }
+    }
+
     override suspend fun setAnalyticsConsent(enabled: Boolean) {
         Result.runCatching {
             userDataStorePreferences.edit { preferences ->
@@ -472,6 +494,7 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
         private val HOME_SHOW_BUS50_TRANSFER_KEY = booleanPreferencesKey("home_show_bus50_transfer")
         private val HOME_SHOW_SUBWAY_TRANSFER_KEY = booleanPreferencesKey("home_show_subway_transfer")
         private val HOME_SUBWAY_TRANSFER_DESTINATION_KEY = stringPreferencesKey("home_subway_transfer_destination")
+        private val SHUTTLE_ALTERNATIVE_DISPLAY_MODE_KEY = stringPreferencesKey("shuttle_alternative_display_mode")
         private val ANALYTICS_CONSENT_KEY = booleanPreferencesKey("analytics_consent")
         private val LAUNCH_COUNT_KEY = intPreferencesKey("launch_count")
         private val REVIEW_REQUESTED_AT_KEY = longPreferencesKey("review_requested_at")

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
@@ -25,6 +25,8 @@ interface UserPreferencesRepositoryImpl {
     suspend fun getShowHomeSubwayTransfer(): Flow<Boolean>
     suspend fun setHomeSubwayTransferDestination(destination: String)
     suspend fun getHomeSubwayTransferDestination(): Flow<String>
+    suspend fun setShuttleAlternativeDisplayMode(mode: String)
+    suspend fun getShuttleAlternativeDisplayMode(): Flow<String>
     suspend fun setAnalyticsConsent(enabled: Boolean)
     suspend fun incrementLaunchCount(): Int
     suspend fun resetLaunchCount()

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -54,6 +54,8 @@ import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
 import app.kobuggi.hyuabot.util.localizedSubwayStationName
 import app.kobuggi.hyuabot.util.setSkeletonLoading
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopResolver
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopRuleCandidate
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -87,6 +89,7 @@ class HomeFragment : Fragment() {
     private var noticePosition = 0
     private var noticeManuallyScrolled = false
     private var locationCancellationTokenSource: CancellationTokenSource? = null
+    private var pendingDepartureLocation: Location? = null
     private val refreshHandler = Handler(Looper.getMainLooper())
     private val noticeScrollHandler = Handler(Looper.getMainLooper())
     private val noticeAutoScrollRunnable = Runnable {
@@ -107,7 +110,7 @@ class HomeFragment : Fragment() {
             shouldRestoreAutomaticDepartureOnForeground = false
             isDepartureManuallySelected = false
             hasResolvedInitialDepartureLocation = false
-            moveToNearestDeparture()
+            refreshHome()
         }
     }
     private val autoRefreshRunnable = object : Runnable {
@@ -208,6 +211,11 @@ class HomeFragment : Fragment() {
             renderNotices(it)
             render(it)
         }
+        viewModel.initialStopRules.observe(viewLifecycleOwner) { rules ->
+            if (rules != null) {
+                pendingDepartureLocation?.let { selectInitialDeparture(it, rules) }
+            }
+        }
         viewModel.showBus50Transfer.observe(viewLifecycleOwner) { render(viewModel.data.value) }
         viewModel.showSubwayTransfer.observe(viewLifecycleOwner) { render(viewModel.data.value) }
         viewModel.subwayTransferDestination.observe(viewLifecycleOwner) { render(viewModel.data.value) }
@@ -232,7 +240,6 @@ class HomeFragment : Fragment() {
                 Toast.makeText(requireContext(), getString(R.string.shuttle_no_realtime_data), Toast.LENGTH_SHORT).show()
             }
         }
-        moveToNearestDeparture()
         refreshHome()
         return binding.root
     }
@@ -256,6 +263,7 @@ class HomeFragment : Fragment() {
         stopNoticeAutoScroll()
         locationCancellationTokenSource?.cancel()
         locationCancellationTokenSource = null
+        pendingDepartureLocation = null
         binding.noticeViewPager.adapter = null
         super.onDestroyView()
     }
@@ -341,6 +349,7 @@ class HomeFragment : Fragment() {
     private fun selectDepartureManually(departure: HomeDeparture) {
         locationCancellationTokenSource?.cancel()
         locationCancellationTokenSource = null
+        pendingDepartureLocation = null
         isDepartureManuallySelected = true
         shouldRestoreAutomaticDepartureOnForeground = false
         hasResolvedInitialDepartureLocation = true
@@ -423,7 +432,7 @@ class HomeFragment : Fragment() {
         client.lastLocation
             .addOnSuccessListener { location ->
                 if (!isAdded || view == null) return@addOnSuccessListener
-                if (location != null && isFresh(location)) selectNearestDeparture(location)
+                if (location != null && isFresh(location)) selectInitialDeparture(location)
             }
             .addOnFailureListener {
                 if (!isAdded || view == null) return@addOnFailureListener
@@ -455,7 +464,7 @@ class HomeFragment : Fragment() {
                 }
                 if (!isAdded || view == null) return@addOnSuccessListener
                 if (location != null) {
-                    selectNearestDeparture(location)
+                    selectInitialDeparture(location)
                 } else {
                     selectLastKnownLocation(client)
                 }
@@ -470,21 +479,46 @@ class HomeFragment : Fragment() {
             }
     }
 
-    private fun selectNearestDeparture(location: Location) {
+    private fun selectInitialDeparture(
+        location: Location,
+        resolvedRules: List<ShuttleInitialStopRuleCandidate>? = null,
+    ) {
         if (!isAdded || view == null) return
         if (lockDepartureSelection || isDepartureManuallySelected) return
+        pendingDepartureLocation = location
+        val rules = resolvedRules ?: viewModel.initialStopRules.value ?: return
+        pendingDepartureLocation = null
+        val configuredStopName =
+            ShuttleInitialStopResolver.resolve(
+                latitude = location.latitude,
+                longitude = location.longitude,
+                rules = rules,
+            )
+        val configuredDeparture = configuredStopName?.let(HomeDeparture::fromShuttleStopName)
         val nearestDeparture = HomeDeparture.entries.minByOrNull { it.distanceTo(location) } ?: return
+        val initialDeparture = configuredDeparture ?: nearestDeparture
+        val initialDestination =
+            when (configuredStopName) {
+                "shuttlecock_i" -> HomeDestination.DORMITORY
+                "shuttlecock_o" -> selectedDestination.takeUnless { it == HomeDestination.DORMITORY } ?: HomeDestination.STATION
+                else -> selectedDestination.takeIf { it in initialDeparture.destinations } ?: initialDeparture.destinations.first()
+            }
         val shouldApplyHysteresis = hasResolvedInitialDepartureLocation
         hasResolvedInitialDepartureLocation = true
         val currentDistance = selectedDeparture.distanceTo(location)
-        val nearestDistance = nearestDeparture.distanceTo(location)
-        if (nearestDeparture == selectedDeparture) return
-        if (shouldApplyHysteresis && nearestDistance + DEPARTURE_SWITCH_HYSTERESIS_METERS >= currentDistance) return
-
-        selectedDeparture = nearestDeparture
-        if (selectedDestination !in selectedDeparture.destinations) {
-            selectedDestination = selectedDeparture.destinations.first()
+        val initialDistance = initialDeparture.distanceTo(location)
+        if (initialDeparture == selectedDeparture && initialDestination == selectedDestination) return
+        if (
+            initialDeparture != selectedDeparture &&
+            configuredDeparture == null &&
+            shouldApplyHysteresis &&
+            initialDistance + DEPARTURE_SWITCH_HYSTERESIS_METERS >= currentDistance
+        ) {
+            return
         }
+
+        selectedDeparture = initialDeparture
+        selectedDestination = initialDestination
         setupDestinationButtons()
         render(viewModel.data.value)
     }
@@ -501,6 +535,7 @@ class HomeFragment : Fragment() {
 
     private fun refreshHome() {
         binding.dateText.text = formattedToday()
+        viewModel.invalidateInitialStopRules()
         moveToNearestDeparture()
         viewModel.fetchData()
     }
@@ -1800,6 +1835,16 @@ private enum class HomeDeparture(
 
     companion object {
         fun fromDebugValue(value: String?): HomeDeparture? = entries.firstOrNull { it.debugValue == value }
+
+        fun fromShuttleStopName(value: String): HomeDeparture? =
+            when (value) {
+                "dormitory_o" -> DORMITORY
+                "shuttlecock_o", "shuttlecock_i" -> SHUTTLECOCK
+                "station" -> STATION
+                "terminal" -> TERMINAL
+                "jungang_stn" -> JUNGANG
+                else -> null
+            }
     }
 }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -2,16 +2,24 @@ package app.kobuggi.hyuabot.ui.home
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.ColorStateList
-import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.location.Location
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.TextPaint
 import android.text.TextUtils
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.RelativeSizeSpan
 import android.util.Log
 import android.view.ContextThemeWrapper
 import android.view.Gravity
@@ -530,6 +538,7 @@ class HomeFragment : Fragment() {
         if (weather == null) {
             binding.homeHeroTitle.setText(R.string.home_hero_title)
             binding.homeHeroSubtitle.setText(R.string.home_hero_subtitle)
+            binding.homeHeroSubtitle.movementMethod = null
             binding.homeWeatherIcon.visibility = View.GONE
             return
         }
@@ -617,15 +626,53 @@ class HomeFragment : Fragment() {
             )
             else -> getString(R.string.home_hero_subtitle)
         }
-        binding.homeHeroSubtitle.text = buildList {
+        val subtitleParts = buildList {
             add(subtitle)
             if (weather.precipitationConfidence == "LOW") {
                 add(getString(R.string.home_weather_confidence_low))
             }
-            if (weather.attribution != null) {
-                add(getString(R.string.home_weather_attribution))
-            }
-        }.joinToString(" · ")
+        }
+        binding.homeHeroSubtitle.apply {
+            text = weatherSubtitleWithAttribution(
+                subtitle = subtitleParts.joinToString(" · "),
+                includesAttribution = weather.attribution != null,
+            )
+            movementMethod = if (weather.attribution != null) LinkMovementMethod.getInstance() else null
+            highlightColor = android.graphics.Color.TRANSPARENT
+        }
+    }
+
+    private fun weatherSubtitleWithAttribution(
+        subtitle: String,
+        includesAttribution: Boolean,
+    ): CharSequence {
+        if (!includesAttribution) return subtitle
+        return SpannableStringBuilder(subtitle).apply {
+            append(" · ")
+            val attributionStart = length
+            append(getString(R.string.home_weather_attribution))
+            setSpan(
+                object : ClickableSpan() {
+                    override fun onClick(widget: View) {
+                        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://open-meteo.com/")))
+                    }
+
+                    override fun updateDrawState(drawState: TextPaint) {
+                        drawState.color = binding.homeHeroSubtitle.currentTextColor
+                        drawState.isUnderlineText = false
+                    }
+                },
+                attributionStart,
+                length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+            setSpan(
+                RelativeSizeSpan(0.85f),
+                attributionStart,
+                length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+            )
+        }
     }
 
     private fun renderMovement(data: HomePageQuery.Data?) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -10,6 +10,8 @@ import app.kobuggi.hyuabot.HomePageQuery
 import app.kobuggi.hyuabot.service.ShuttlePresenceService
 import app.kobuggi.hyuabot.service.alarm.ShuttleServiceNoticeScheduler
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleGeoCoordinate
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopRuleCandidate
 import app.kobuggi.hyuabot.type.BusRouteStopInput
 import app.kobuggi.hyuabot.util.QueryError
 import com.apollographql.apollo.ApolloClient
@@ -39,6 +41,7 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
     private val _isLoading = MutableLiveData(false)
     private val _data = MutableLiveData<HomePageQuery.Data?>()
+    private val _initialStopRules = MutableLiveData<List<ShuttleInitialStopRuleCandidate>?>(null)
     private val _queryError = MutableLiveData<QueryError?>(null)
     private val _showBus50Transfer = MutableLiveData(true)
     private val _showSubwayTransfer = MutableLiveData(true)
@@ -55,6 +58,7 @@ class HomeViewModel @Inject constructor(
 
     val isLoading: LiveData<Boolean> get() = _isLoading
     val data: LiveData<HomePageQuery.Data?> get() = _data
+    val initialStopRules: LiveData<List<ShuttleInitialStopRuleCandidate>?> get() = _initialStopRules
     val queryError: LiveData<QueryError?> get() = _queryError
     val showBus50Transfer: LiveData<Boolean> get() = _showBus50Transfer
     val showSubwayTransfer: LiveData<Boolean> get() = _showSubwayTransfer
@@ -106,20 +110,41 @@ class HomeViewModel @Inject constructor(
                 ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
                 if (response.data == null || response.exception != null) {
+                    _initialStopRules.value = emptyList()
                     _queryError.value = QueryError.SERVER_ERROR
                 } else {
+                    _initialStopRules.value =
+                        response.data?.shuttle?.initialStopRules.orEmpty().map { rule ->
+                            ShuttleInitialStopRuleCandidate(
+                                sequence = rule.seq,
+                                stopName = rule.stopName,
+                                priority = rule.priority,
+                                polygon =
+                                    rule.polygon.map { point ->
+                                        ShuttleGeoCoordinate(
+                                            latitude = point.latitude,
+                                            longitude = point.longitude,
+                                        )
+                                    },
+                            )
+                        }
                     _data.value = response.data
                     _bus50TerminalLogTimes.value = fetchBus50TerminalLogTimes(now.toLocalDate())
                     shuttleServiceNoticeScheduler.sync()
                     _queryError.value = null
                 }
             } catch (_: Exception) {
+                _initialStopRules.value = emptyList()
                 _queryError.value = QueryError.SERVER_ERROR
             } finally {
                 _isLoading.value = false
                 isFetching = false
             }
         }
+    }
+
+    fun invalidateInitialStopRules() {
+        _initialStopRules.value = null
     }
 
     fun setShowBus50Transfer(show: Boolean) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/initialstop/ShuttleInitialStopResolver.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/initialstop/ShuttleInitialStopResolver.kt
@@ -1,0 +1,71 @@
+package app.kobuggi.hyuabot.ui.shuttle.initialstop
+
+data class ShuttleGeoCoordinate(
+    val latitude: Double,
+    val longitude: Double,
+)
+
+data class ShuttleInitialStopRuleCandidate(
+    val sequence: Int,
+    val stopName: String,
+    val priority: Int,
+    val polygon: List<ShuttleGeoCoordinate>,
+)
+
+object ShuttleInitialStopResolver {
+    fun resolve(
+        latitude: Double,
+        longitude: Double,
+        rules: List<ShuttleInitialStopRuleCandidate>,
+    ): String? {
+        if (!latitude.isFinite() || !longitude.isFinite()) return null
+        val location = ShuttleGeoCoordinate(latitude, longitude)
+        return rules
+            .sortedWith(compareByDescending<ShuttleInitialStopRuleCandidate> { it.priority }.thenBy { it.sequence })
+            .firstOrNull { contains(location, it.polygon) }
+            ?.stopName
+    }
+
+    internal fun contains(
+        location: ShuttleGeoCoordinate,
+        polygon: List<ShuttleGeoCoordinate>,
+    ): Boolean {
+        if (polygon.size < 3 || polygon.any { !it.latitude.isFinite() || !it.longitude.isFinite() }) {
+            return false
+        }
+
+        var inside = false
+        var previous = polygon.last()
+        polygon.forEach { current ->
+            if (isOnSegment(location, previous, current)) return true
+            val crossesLatitude = (current.latitude > location.latitude) != (previous.latitude > location.latitude)
+            if (crossesLatitude) {
+                val intersectionLongitude =
+                    (previous.longitude - current.longitude) *
+                        (location.latitude - current.latitude) /
+                        (previous.latitude - current.latitude) +
+                        current.longitude
+                if (location.longitude < intersectionLongitude) inside = !inside
+            }
+            previous = current
+        }
+        return inside
+    }
+
+    private fun isOnSegment(
+        point: ShuttleGeoCoordinate,
+        start: ShuttleGeoCoordinate,
+        end: ShuttleGeoCoordinate,
+    ): Boolean {
+        val cross =
+            (point.latitude - start.latitude) * (end.longitude - start.longitude) -
+                (point.longitude - start.longitude) * (end.latitude - start.latitude)
+        if (kotlin.math.abs(cross) > COORDINATE_EPSILON) return false
+        return point.latitude >= minOf(start.latitude, end.latitude) - COORDINATE_EPSILON &&
+            point.latitude <= maxOf(start.latitude, end.latitude) + COORDINATE_EPSILON &&
+            point.longitude >= minOf(start.longitude, end.longitude) - COORDINATE_EPSILON &&
+            point.longitude <= maxOf(start.longitude, end.longitude) + COORDINATE_EPSILON
+    }
+
+    private const val COORDINATE_EPSILON = 1e-10
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleAlternativeDisplayMode.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleAlternativeDisplayMode.kt
@@ -1,0 +1,19 @@
+package app.kobuggi.hyuabot.ui.shuttle.realtime
+
+import androidx.annotation.StringRes
+import app.kobuggi.hyuabot.R
+
+enum class ShuttleAlternativeDisplayMode(
+    val value: String,
+    @param:StringRes val titleRes: Int,
+) {
+    AUTOMATIC("automatic", R.string.shuttle_quick_settings_alternative_mode_automatic),
+    ALWAYS("always", R.string.shuttle_quick_settings_alternative_mode_always),
+    HIDDEN("hidden", R.string.shuttle_quick_settings_alternative_mode_hidden),
+    ;
+
+    companion object {
+        fun from(value: String?): ShuttleAlternativeDisplayMode =
+            entries.firstOrNull { it.value == value } ?: AUTOMATIC
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleQuickSettingsDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleQuickSettingsDialog.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
 import app.kobuggi.hyuabot.databinding.DialogShuttleQuickSettingsBinding
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -28,29 +30,37 @@ class ShuttleQuickSettingsDialog : BottomSheetDialogFragment() {
         val showByDestination = requireArguments().getBoolean(ARG_SHOW_BY_DESTINATION)
         val showDepartureTime = requireArguments().getBoolean(ARG_SHOW_DEPARTURE_TIME)
         val showPresenceStatus = requireArguments().getBoolean(ARG_SHOW_PRESENCE_STATUS, true)
-        binding.showByDestinationGroup.check(
-            if (showByDestination) binding.showByDestinationButton.id else binding.showByTimeButton.id,
+        val showBusTransfer = requireArguments().getBoolean(ARG_SHOW_BUS_TRANSFER, true)
+        val showSubwayTransfer = requireArguments().getBoolean(ARG_SHOW_SUBWAY_TRANSFER, true)
+        var subwayDestination = HomeSubwayTransferDestination.from(
+            requireArguments().getString(ARG_SUBWAY_DESTINATION),
         )
-        binding.showDepartureTimeGroup.check(
-            if (showDepartureTime) binding.showDepartureTimeButton.id else binding.showRemainingTimeButton.id,
+        var alternativeMode = ShuttleAlternativeDisplayMode.from(
+            requireArguments().getString(ARG_ALTERNATIVE_MODE),
         )
+        binding.showByDestinationSwitch.isChecked = showByDestination
+        binding.showDepartureTimeSwitch.isChecked = showDepartureTime
         binding.showPresenceStatusSwitch.isChecked = showPresenceStatus
+        binding.showBusTransferSwitch.isChecked = showBusTransfer
+        binding.showSubwayTransferSwitch.isChecked = showSubwayTransfer
+        binding.subwayDestinationButton.isEnabled = showSubwayTransfer
+        binding.subwayDestinationButton.alpha = if (showSubwayTransfer) 1f else DISABLED_ALPHA
+        binding.subwayDestinationButton.setText(subwayDestination.titleRes)
+        binding.alternativeModeButton.setText(alternativeMode.titleRes)
 
-        binding.showByDestinationGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
-            if (!isChecked) return@addOnButtonCheckedListener
+        binding.showByDestinationSwitch.setOnCheckedChangeListener { _, isChecked ->
             parentFragmentManager.setFragmentResult(
                 REQUEST_KEY,
                 Bundle().apply {
-                    putBoolean(KEY_SHOW_BY_DESTINATION, checkedId == binding.showByDestinationButton.id)
+                    putBoolean(KEY_SHOW_BY_DESTINATION, isChecked)
                 },
             )
         }
-        binding.showDepartureTimeGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
-            if (!isChecked) return@addOnButtonCheckedListener
+        binding.showDepartureTimeSwitch.setOnCheckedChangeListener { _, isChecked ->
             parentFragmentManager.setFragmentResult(
                 REQUEST_KEY,
                 Bundle().apply {
-                    putBoolean(KEY_SHOW_DEPARTURE_TIME, checkedId == binding.showDepartureTimeButton.id)
+                    putBoolean(KEY_SHOW_DEPARTURE_TIME, isChecked)
                 },
             )
         }
@@ -61,6 +71,62 @@ class ShuttleQuickSettingsDialog : BottomSheetDialogFragment() {
                     putBoolean(KEY_SHOW_PRESENCE_STATUS, isChecked)
                 },
             )
+        }
+        binding.showBusTransferSwitch.setOnCheckedChangeListener { _, isChecked ->
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply {
+                    putBoolean(KEY_SHOW_BUS_TRANSFER, isChecked)
+                },
+            )
+        }
+        binding.showSubwayTransferSwitch.setOnCheckedChangeListener { _, isChecked ->
+            binding.subwayDestinationButton.isEnabled = isChecked
+            binding.subwayDestinationButton.alpha = if (isChecked) 1f else DISABLED_ALPHA
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply {
+                    putBoolean(KEY_SHOW_SUBWAY_TRANSFER, isChecked)
+                },
+            )
+        }
+        binding.subwayDestinationButton.setOnClickListener { anchor ->
+            PopupMenu(requireContext(), anchor).apply {
+                HomeSubwayTransferDestination.entries.forEachIndexed { index, destination ->
+                    menu.add(0, index, index, destination.titleRes)
+                }
+                setOnMenuItemClickListener { item ->
+                    subwayDestination = HomeSubwayTransferDestination.entries[item.itemId]
+                    binding.subwayDestinationButton.setText(subwayDestination.titleRes)
+                    parentFragmentManager.setFragmentResult(
+                        REQUEST_KEY,
+                        Bundle().apply {
+                            putString(KEY_SUBWAY_DESTINATION, subwayDestination.value)
+                        },
+                    )
+                    true
+                }
+                show()
+            }
+        }
+        binding.alternativeModeButton.setOnClickListener { anchor ->
+            PopupMenu(requireContext(), anchor).apply {
+                ShuttleAlternativeDisplayMode.entries.forEachIndexed { index, mode ->
+                    menu.add(0, index, index, mode.titleRes)
+                }
+                setOnMenuItemClickListener { item ->
+                    alternativeMode = ShuttleAlternativeDisplayMode.entries[item.itemId]
+                    binding.alternativeModeButton.setText(alternativeMode.titleRes)
+                    parentFragmentManager.setFragmentResult(
+                        REQUEST_KEY,
+                        Bundle().apply {
+                            putString(KEY_ALTERNATIVE_MODE, alternativeMode.value)
+                        },
+                    )
+                    true
+                }
+                show()
+            }
         }
         binding.openHomeButton.setOnClickListener {
             parentFragmentManager.setFragmentResult(
@@ -89,21 +155,38 @@ class ShuttleQuickSettingsDialog : BottomSheetDialogFragment() {
         const val KEY_SHOW_BY_DESTINATION = "show_by_destination"
         const val KEY_SHOW_DEPARTURE_TIME = "show_departure_time"
         const val KEY_SHOW_PRESENCE_STATUS = "show_presence_status"
+        const val KEY_SHOW_BUS_TRANSFER = "show_bus_transfer"
+        const val KEY_SHOW_SUBWAY_TRANSFER = "show_subway_transfer"
+        const val KEY_SUBWAY_DESTINATION = "subway_destination"
+        const val KEY_ALTERNATIVE_MODE = "alternative_mode"
         const val KEY_OPEN_HOME = "open_home"
         private const val ARG_SHOW_BY_DESTINATION = "arg_show_by_destination"
         private const val ARG_SHOW_DEPARTURE_TIME = "arg_show_departure_time"
         private const val ARG_SHOW_PRESENCE_STATUS = "arg_show_presence_status"
+        private const val ARG_SHOW_BUS_TRANSFER = "arg_show_bus_transfer"
+        private const val ARG_SHOW_SUBWAY_TRANSFER = "arg_show_subway_transfer"
+        private const val ARG_SUBWAY_DESTINATION = "arg_subway_destination"
+        private const val ARG_ALTERNATIVE_MODE = "arg_alternative_mode"
+        private const val DISABLED_ALPHA = 0.38f
 
         fun newInstance(
             showByDestination: Boolean,
             showDepartureTime: Boolean,
             showPresenceStatus: Boolean,
+            showBusTransfer: Boolean,
+            showSubwayTransfer: Boolean,
+            subwayDestination: HomeSubwayTransferDestination,
+            alternativeMode: ShuttleAlternativeDisplayMode,
         ): ShuttleQuickSettingsDialog {
             return ShuttleQuickSettingsDialog().apply {
                 arguments = Bundle().apply {
                     putBoolean(ARG_SHOW_BY_DESTINATION, showByDestination)
                     putBoolean(ARG_SHOW_DEPARTURE_TIME, showDepartureTime)
                     putBoolean(ARG_SHOW_PRESENCE_STATUS, showPresenceStatus)
+                    putBoolean(ARG_SHOW_BUS_TRANSFER, showBusTransfer)
+                    putBoolean(ARG_SHOW_SUBWAY_TRANSFER, showSubwayTransfer)
+                    putString(ARG_SUBWAY_DESTINATION, subwayDestination.value)
+                    putString(ARG_ALTERNATIVE_MODE, alternativeMode.value)
                 }
             }
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeByDestinationListAdapter.kt
@@ -11,11 +11,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.databinding.ItemShuttleRealtimeBinding
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import app.kobuggi.hyuabot.ui.shuttle.via.ShuttleViaSheetDialog
+import app.kobuggi.hyuabot.util.TransitRow
+import app.kobuggi.hyuabot.util.buildShuttleConnectionRows
 import java.time.LocalTime
 
 class ShuttleRealtimeByDestinationListAdapter(
@@ -29,11 +33,53 @@ class ShuttleRealtimeByDestinationListAdapter(
     private val onAlarmClick: ((ShuttleRealtimePageQuery.Entry) -> Unit)? = null,
 ) : RecyclerView.Adapter<ShuttleRealtimeByDestinationListAdapter.ViewHolder>() {
     private var lastRunSeqs: Set<Int> = emptySet()
+    private var expandedSeq: Int? = null
+    private var transferData: ShuttleRealtimePageQuery.Data? = null
+    private var showBusTransfer = true
+    private var showSubwayTransfer = true
+    private var subwayTransferDestination = HomeSubwayTransferDestination.SEOUL
+
+    init {
+        shuttleRealtimeViewModel.transfer.observe(lifecycleOwner) {
+            transferData = it
+            notifyDataSetChanged()
+        }
+        shuttleRealtimeViewModel.showBusTransfer.observe(lifecycleOwner) {
+            showBusTransfer = it
+            notifyDataSetChanged()
+        }
+        shuttleRealtimeViewModel.showSubwayTransfer.observe(lifecycleOwner) {
+            showSubwayTransfer = it
+            notifyDataSetChanged()
+        }
+        shuttleRealtimeViewModel.subwayTransferDestination.observe(lifecycleOwner) {
+            subwayTransferDestination = it
+            notifyDataSetChanged()
+        }
+    }
 
     inner class ViewHolder(private val binding: ItemShuttleRealtimeBinding) : RecyclerView.ViewHolder(binding.root) {
         val darkMode = context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK == android.content.res.Configuration.UI_MODE_NIGHT_YES
         @SuppressLint("ClickableViewAccessibility")
         fun bind(item: ShuttleRealtimePageQuery.Entry) {
+            val transferRows = transferRows(item)
+            val isExpanded = expandedSeq == item.seq && transferRows.isNotEmpty()
+            binding.shuttleContent.setBackgroundColor(
+                ContextCompat.getColor(
+                    context,
+                    if (isExpanded) R.color.app_selection_background else R.color.background,
+                ),
+            )
+            binding.transferSelectionAccent.visibility = if (isExpanded) View.VISIBLE else View.GONE
+            binding.transferExpansionContainer.visibility = if (isExpanded) View.VISIBLE else View.GONE
+            if (isExpanded) {
+                binding.transferSelectionAccent.setBackgroundColor(
+                    ContextCompat.getColor(context, R.color.hanyang_blue),
+                )
+                ShuttleTransferBinder.bindCompact(binding.transferExpansionContainer, transferRows)
+            } else {
+                binding.transferExpansionContainer.removeAllViews()
+            }
             val isLastRun = item.seq in lastRunSeqs
             binding.lastRunBadge.visibility = if (isLastRun) View.VISIBLE else View.GONE
             binding.warningView.visibility = if (
@@ -194,8 +240,12 @@ class ShuttleRealtimeByDestinationListAdapter(
 
             binding.shuttleItem.setOnClickListener {
                 AnalyticsManager.logSelect(AnalyticsItem.SHUTTLE_SELECT_VIA_ROW, type = AnalyticsContentType.LIST_ITEM)
-                val viaSheet = ShuttleViaSheetDialog(stopsOfTimetableByDestination = item.stops)
-                viaSheet.show(childFragmentManager, "ShuttleViaSheetDialog")
+                if (transferRows.isEmpty()) {
+                    val viaSheet = ShuttleViaSheetDialog(stopsOfTimetableByDestination = item.stops)
+                    viaSheet.show(childFragmentManager, "ShuttleViaSheetDialog")
+                } else {
+                    toggleExpansion(item.seq)
+                }
             }
 
             if (onAlarmClick != null) {
@@ -207,6 +257,18 @@ class ShuttleRealtimeByDestinationListAdapter(
                 binding.shuttleAlarmButton.visibility = ViewGroup.INVISIBLE
             }
         }
+
+        private fun transferRows(item: ShuttleRealtimePageQuery.Entry): List<TransitRow> =
+            buildShuttleConnectionRows(
+                context = context,
+                stopName = stopName(),
+                destination = destinationName(),
+                shuttle = item,
+                data = transferData,
+                showBusTransfer = showBusTransfer,
+                showSubwayTransfer = showSubwayTransfer,
+                subwayDestination = subwayTransferDestination,
+            )
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -225,6 +287,9 @@ class ShuttleRealtimeByDestinationListAdapter(
         lastRunSeqs: Set<Int> = emptySet(),
     ) {
         this.lastRunSeqs = lastRunSeqs
+        if (expandedSeq != null && newData.none { it.seq == expandedSeq }) {
+            expandedSeq = null
+        }
         if (shuttleList.size > newData.size) {
             shuttleList = newData
             notifyItemRangeChanged(0, shuttleList.size)
@@ -239,4 +304,34 @@ class ShuttleRealtimeByDestinationListAdapter(
         }
     }
 
+    private fun toggleExpansion(seq: Int) {
+        val previousSeq = expandedSeq
+        expandedSeq = if (previousSeq == seq) null else seq
+        previousSeq?.let { previous ->
+            shuttleList.indexOfFirst { it.seq == previous }
+                .takeIf { it >= 0 }
+                ?.let(::notifyItemChanged)
+        }
+        if (expandedSeq != null) {
+            shuttleList.indexOfFirst { it.seq == expandedSeq }
+                .takeIf { it >= 0 }
+                ?.let(::notifyItemChanged)
+        }
+    }
+
+    private fun stopName(): String = when (stopID) {
+        R.string.shuttle_tab_dormitory_out -> "dormitory_o"
+        R.string.shuttle_tab_shuttlecock_out -> "shuttlecock_o"
+        R.string.shuttle_tab_station -> "station"
+        R.string.shuttle_tab_terminal -> "terminal"
+        R.string.shuttle_tab_jungang_station -> "jungang_stn"
+        else -> "shuttlecock_i"
+    }
+
+    private fun destinationName(): String = when (headerID) {
+        R.string.shuttle_header_bound_for_station -> "STATION"
+        R.string.shuttle_header_bound_for_terminal -> "TERMINAL"
+        R.string.shuttle_header_bound_for_jungang_station -> "JUNGANG"
+        else -> "CAMPUS"
+    }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -31,6 +31,7 @@ import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkShape
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkEligibility
 import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopResolver
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -207,7 +208,7 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
             }
             if (stops.isNotEmpty()) {
                 hasRequestedInitialStopLocation = true
-                moveToNearestStop(fusedLocationProviderClient, stops)
+                moveToInitialStop(fusedLocationProviderClient, stops)
             }
         }
         viewModel.queryError.observe(viewLifecycleOwner) {
@@ -295,7 +296,7 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
     }
 
     @SuppressLint("MissingPermission")
-    private fun moveToNearestStop(
+    private fun moveToInitialStop(
         client: FusedLocationProviderClient,
         stops: List<ShuttleRealtimePageQuery.Stop>,
     ) {
@@ -309,7 +310,7 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
     ) {
         client.lastLocation
             .addOnSuccessListener { location ->
-                if (location != null && isFresh(location)) selectNearestStop(stops, location)
+                if (location != null && isFresh(location)) selectInitialStop(stops, location)
             }
             .addOnFailureListener {
                 Log.e("ShuttleRealtimeFragment", "Failed to get last known location", it)
@@ -330,7 +331,7 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
         client.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, tokenSource.token)
             .addOnSuccessListener { location ->
                 if (location != null) {
-                    selectNearestStop(stops, location)
+                    selectInitialStop(stops, location)
                 } else {
                     selectLastKnownLocation(client, stops)
                 }
@@ -341,17 +342,29 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
             }
     }
 
-    private fun selectNearestStop(stops: List<ShuttleRealtimePageQuery.Stop>, location: Location) {
+    private fun selectInitialStop(stops: List<ShuttleRealtimePageQuery.Stop>, location: Location) {
         if (!isAdded || view == null || honorDeepLinkStop || hasManualStopSelection) {
             return
         }
+        val configuredStopName =
+            ShuttleInitialStopResolver.resolve(
+                latitude = location.latitude,
+                longitude = location.longitude,
+                rules = viewModel.initialStopRules.value.orEmpty(),
+            )
+        val configuredStop = configuredStopName?.let { name -> stops.firstOrNull { it.name == name } }
         val gpsCandidates = stops.filterNot { it.name == "shuttlecock_i" }.ifEmpty { stops }
         val nearestStop = gpsCandidates.map { stopItem ->
             Pair(stopItem, calculateDistance(stopItem, location))
         }.minByOrNull { it.second }?.first
-        Log.d("ShuttleRealtimeFragment", "Nearest stop: ${nearestStop?.name}, distance: ${nearestStop?.let { calculateDistance(it, location) }}")
+        val initialStop = configuredStop ?: nearestStop
+        Log.d(
+            "ShuttleRealtimeFragment",
+            "Initial stop: ${initialStop?.name}, configured: ${configuredStop != null}, " +
+                "distance: ${initialStop?.let { calculateDistance(it, location) }}",
+        )
         isApplyingInitialLocationSelection = true
-        binding.viewPager.setCurrentItem(stopNameToTabIndex(nearestStop?.name) ?: 0, false)
+        binding.viewPager.setCurrentItem(stopNameToTabIndex(initialStop?.name) ?: 0, false)
         isApplyingInitialLocationSelection = false
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -30,6 +30,7 @@ import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkController
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkShape
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.ensureCoachmarkEligibility
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -126,6 +127,18 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
             }
             if (result.containsKey(ShuttleQuickSettingsDialog.KEY_SHOW_PRESENCE_STATUS)) {
                 viewModel.setShowPresenceStatus(result.getBoolean(ShuttleQuickSettingsDialog.KEY_SHOW_PRESENCE_STATUS))
+            }
+            if (result.containsKey(ShuttleQuickSettingsDialog.KEY_SHOW_BUS_TRANSFER)) {
+                viewModel.setShowBusTransfer(result.getBoolean(ShuttleQuickSettingsDialog.KEY_SHOW_BUS_TRANSFER))
+            }
+            if (result.containsKey(ShuttleQuickSettingsDialog.KEY_SHOW_SUBWAY_TRANSFER)) {
+                viewModel.setShowSubwayTransfer(result.getBoolean(ShuttleQuickSettingsDialog.KEY_SHOW_SUBWAY_TRANSFER))
+            }
+            result.getString(ShuttleQuickSettingsDialog.KEY_SUBWAY_DESTINATION)?.let {
+                viewModel.setSubwayTransferDestination(HomeSubwayTransferDestination.from(it))
+            }
+            result.getString(ShuttleQuickSettingsDialog.KEY_ALTERNATIVE_MODE)?.let {
+                viewModel.setAlternativeDisplayMode(ShuttleAlternativeDisplayMode.from(it))
             }
             if (result.getBoolean(ShuttleQuickSettingsDialog.KEY_OPEN_HOME, false)) {
                 findNavController().navigate(R.id.homeFragment)
@@ -274,6 +287,10 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
             showByDestination = viewModel.showByDestination.value ?: false,
             showDepartureTime = viewModel.showDepartureTime.value ?: false,
             showPresenceStatus = viewModel.showPresenceStatus.value ?: true,
+            showBusTransfer = viewModel.showBusTransfer.value ?: true,
+            showSubwayTransfer = viewModel.showSubwayTransfer.value ?: true,
+            subwayDestination = viewModel.subwayTransferDestination.value ?: HomeSubwayTransferDestination.SEOUL,
+            alternativeMode = viewModel.alternativeDisplayMode.value ?: ShuttleAlternativeDisplayMode.AUTOMATIC,
         ).show(childFragmentManager, SHUTTLE_QUICK_SETTINGS_TAG)
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -10,8 +10,10 @@ import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.service.ShuttlePresenceService
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import app.kobuggi.hyuabot.util.QueryError
 import app.kobuggi.hyuabot.util.currentShuttleWeekday
+import app.kobuggi.hyuabot.util.shuttleBusLogReferenceDates
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Optional
 import com.apollographql.cache.normalized.FetchPolicy
@@ -57,6 +59,10 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private val _busAlternativeJungang62 = MutableLiveData<BusAlternativeData?>(null)
     private val _forceShowBusAlternative = MutableLiveData<Boolean>(false)
     private val _showPresenceStatus = MutableLiveData(true)
+    private val _showBusTransfer = MutableLiveData(true)
+    private val _showSubwayTransfer = MutableLiveData(true)
+    private val _subwayTransferDestination = MutableLiveData(HomeSubwayTransferDestination.SEOUL)
+    private val _alternativeDisplayMode = MutableLiveData(ShuttleAlternativeDisplayMode.AUTOMATIC)
     private val _presenceViewerCount = MutableLiveData<Int?>(null)
     private var presenceJob: Job? = null
     private var selectedPresenceStop = PRESENCE_STOP_IDS.first()
@@ -82,7 +88,34 @@ class ShuttleRealtimeViewModel @Inject constructor(
     val busAlternativeJungang62 get() = _busAlternativeJungang62
     val forceShowBusAlternative get() = _forceShowBusAlternative
     val showPresenceStatus get() = _showPresenceStatus
+    val showBusTransfer get() = _showBusTransfer
+    val showSubwayTransfer get() = _showSubwayTransfer
+    val subwayTransferDestination get() = _subwayTransferDestination
+    val alternativeDisplayMode get() = _alternativeDisplayMode
     val presenceViewerCount get() = _presenceViewerCount
+
+    init {
+        viewModelScope.launch {
+            userPreferencesRepository.getShowHomeBus50Transfer().collect {
+                _showBusTransfer.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getShowHomeSubwayTransfer().collect {
+                _showSubwayTransfer.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getHomeSubwayTransferDestination().collect {
+                _subwayTransferDestination.value = HomeSubwayTransferDestination.from(it)
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getShuttleAlternativeDisplayMode().collect {
+                _alternativeDisplayMode.value = ShuttleAlternativeDisplayMode.from(it)
+            }
+        }
+    }
 
     fun setForceShowBusAlternative(show: Boolean) {
         _forceShowBusAlternative.value = show
@@ -101,7 +134,8 @@ class ShuttleRealtimeViewModel @Inject constructor(
             val response = apolloClient.query(ShuttleRealtimePageQuery(
                 language,
                 Optional.present(LocalTime.now()),
-                currentShuttleWeekday()
+                currentShuttleWeekday(),
+                Optional.present(shuttleBusLogReferenceDates()),
             )).fetchPolicy(FetchPolicy.NetworkOnly).execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
@@ -224,6 +258,49 @@ class ShuttleRealtimeViewModel @Inject constructor(
         viewModelScope.launch { userPreferencesRepository.setShowShuttlePresence(show) }
     }
 
+    fun setShowBusTransfer(show: Boolean) {
+        _showBusTransfer.value = show
+        viewModelScope.launch { userPreferencesRepository.setShowHomeBus50Transfer(show) }
+    }
+
+    fun setShowSubwayTransfer(show: Boolean) {
+        _showSubwayTransfer.value = show
+        viewModelScope.launch { userPreferencesRepository.setShowHomeSubwayTransfer(show) }
+    }
+
+    fun setSubwayTransferDestination(destination: HomeSubwayTransferDestination) {
+        _subwayTransferDestination.value = destination
+        viewModelScope.launch {
+            userPreferencesRepository.setHomeSubwayTransferDestination(destination.value)
+        }
+    }
+
+    fun setAlternativeDisplayMode(mode: ShuttleAlternativeDisplayMode) {
+        _alternativeDisplayMode.value = mode
+        viewModelScope.launch { userPreferencesRepository.setShuttleAlternativeDisplayMode(mode.value) }
+    }
+
+    fun shouldShowBusAlternative(
+        data: BusAlternativeData?,
+        nextShuttleTime: LocalTime?,
+        forceShow: Boolean = false,
+    ): Boolean {
+        return when (_alternativeDisplayMode.value ?: ShuttleAlternativeDisplayMode.AUTOMATIC) {
+            ShuttleAlternativeDisplayMode.HIDDEN -> false
+            ShuttleAlternativeDisplayMode.ALWAYS -> data?.minutes != null || forceShow
+            ShuttleAlternativeDisplayMode.AUTOMATIC -> {
+                forceShow ||
+                    data?.minutes != null &&
+                    (nextShuttleTime == null || minutesUntil(nextShuttleTime) >= ALTERNATIVE_THRESHOLD_MINUTES)
+            }
+        }
+    }
+
+    private fun minutesUntil(time: LocalTime): Long {
+        val difference = java.time.Duration.between(LocalTime.now(), time).toMinutes()
+        return if (difference >= 0) difference else difference + MINUTES_PER_DAY
+    }
+
     fun setPresenceStop(position: Int) {
         val stopId = PRESENCE_STOP_IDS.getOrNull(position) ?: return
         if (selectedPresenceStop == stopId) return
@@ -266,6 +343,8 @@ class ShuttleRealtimeViewModel @Inject constructor(
     }
 
     private companion object {
+        const val ALTERNATIVE_THRESHOLD_MINUTES = 20
+        const val MINUTES_PER_DAY = 24 * 60L
         val PRESENCE_STOP_IDS = listOf(
             "dormitory_o",
             "shuttlecock_o",

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -11,6 +11,8 @@ import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.service.ShuttlePresenceService
 import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleGeoCoordinate
+import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopRuleCandidate
 import app.kobuggi.hyuabot.util.QueryError
 import app.kobuggi.hyuabot.util.currentShuttleWeekday
 import app.kobuggi.hyuabot.util.shuttleBusLogReferenceDates
@@ -44,6 +46,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private val _showByDestination = MutableLiveData(false)
     private val _showRemainingTime = MutableLiveData(true)
     private val _result = MutableLiveData<List<ShuttleRealtimePageQuery.Stop>>()
+    private val _initialStopRules = MutableLiveData<List<ShuttleInitialStopRuleCandidate>>(emptyList())
     private val _notices = MutableLiveData<List<ShuttleRealtimePageQuery.Notice1>>()
     private val _transfer = MutableLiveData<ShuttleRealtimePageQuery.Data?>(null)
     private val _disposable = CompositeDisposable()
@@ -71,6 +74,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private var isStarted = false
 
     val result get() = _result
+    val initialStopRules get() = _initialStopRules
     val notices get() = _notices
     val transfer get() = _transfer
     val isLoading get() = _isLoading
@@ -140,6 +144,21 @@ class ShuttleRealtimeViewModel @Inject constructor(
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.shuttle?.stops != null) {
+                _initialStopRules.value =
+                    response.data?.shuttle?.initialStopRules.orEmpty().map { rule ->
+                        ShuttleInitialStopRuleCandidate(
+                            sequence = rule.seq,
+                            stopName = rule.stopName,
+                            priority = rule.priority,
+                            polygon =
+                                rule.polygon.map { point ->
+                                    ShuttleGeoCoordinate(
+                                        latitude = point.latitude,
+                                        longitude = point.longitude,
+                                    )
+                                },
+                        )
+                    }
                 _result.value = response.data?.shuttle?.stops
                 _transfer.value = response.data
                 updateBusAlternatives(response.data?.busAlternative.orEmpty())

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabDormitoryFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabDormitoryFragment.kt
@@ -28,6 +28,9 @@ import app.kobuggi.hyuabot.widget.ShuttleWidgetSupport
 class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentShuttleRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: ShuttleRealtimeViewModel by viewModels({ requireParentFragment() })
+    private var nextStationShuttleTime: LocalTime? = null
+    private var nextTerminalShuttleTime: LocalTime? = null
+    private var nextJungangShuttleTime: LocalTime? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -317,6 +320,9 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             val shuttleForStation = shuttle.timetable.destination.firstOrNull { it.destination == "STATION" }?.entries?.filter { it.time > now } ?: emptyList()
             val shuttleForTerminal = shuttle.timetable.destination.firstOrNull { it.destination == "TERMINAL" }?.entries?.filter { it.time > now } ?: emptyList()
             val shuttleForJungangStation = shuttle.timetable.destination.firstOrNull { it.destination == "JUNGANG" }?.entries?.filter { it.time > now } ?: emptyList()
+            nextStationShuttleTime = shuttleForStation.firstOrNull()?.time
+            nextTerminalShuttleTime = shuttleForTerminal.firstOrNull()?.time
+            nextJungangShuttleTime = shuttleForJungangStation.firstOrNull()?.time
             // Hide the layout by showing the destination conf
             binding.shuttleDestinationScroll.visibility = if (source.showByDestination) View.VISIBLE else View.GONE
             binding.shuttleTimeScroll.visibility = if (source.showByDestination) View.GONE else View.VISIBLE
@@ -363,6 +369,13 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
         parentViewModel.busAlternativeDormitory80.observe(viewLifecycleOwner) { data ->
             updateBusAlternative80(data)
         }
+        parentViewModel.alternativeDisplayMode.observe(viewLifecycleOwner) {
+            updateBusAlternativeStation(
+                parentViewModel.busAlternativeDormitory.value,
+                parentViewModel.forceShowBusAlternative.value ?: false,
+            )
+            updateBusAlternative80(parentViewModel.busAlternativeDormitory80.value)
+        }
         binding.apply {
             headerBoundForDormitory.visibility = View.GONE
             realtimeViewBoundForDormitory.visibility = View.GONE
@@ -370,15 +383,16 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
             entireTimetableBoundForDormitory.visibility = View.GONE
             entireTimetableDormitory.visibility = View.GONE
         }
-        parentViewModel.transfer.observe(viewLifecycleOwner) { data ->
-            ShuttleTransferBinder.bind(binding.transferSection, binding.transferContainer, "dormitory_o", data)
-        }
         bindShuttleHelpButtons(binding.helpButton, binding.helpButton2)
         return binding.root.also { disableViewStateSaving(it) }
     }
 
     private fun updateBusAlternativeStation(data: BusAlternativeData?, forceShow: Boolean = false) {
-        val shouldShow = data?.minutes != null || forceShow
+        val shouldShow = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextStationShuttleTime,
+            forceShow,
+        )
         binding.busAlternativeStation.visibility = if (shouldShow) View.VISIBLE else View.GONE
         if (shouldShow) {
             binding.busAlternativeStationTime.text = if (data?.minutes != null)
@@ -418,10 +432,17 @@ class ShuttleTabDormitoryFragment @Inject constructor() : Fragment() {
 
     private fun updateBusAlternative80(data: BusAlternativeData?) {
         val color = requireContext().getColor(R.color.blue_bus)
-        val shouldShow = data?.minutes != null
-        binding.busAlternativeTerminal.visibility = if (shouldShow) View.VISIBLE else View.GONE
-        binding.busAlternativeJungangStation.visibility = if (shouldShow) View.VISIBLE else View.GONE
-        if (shouldShow) {
+        val showForTerminal = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextTerminalShuttleTime,
+        )
+        val showForJungang = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextJungangShuttleTime,
+        )
+        binding.busAlternativeTerminal.visibility = if (showForTerminal) View.VISIBLE else View.GONE
+        binding.busAlternativeJungangStation.visibility = if (showForJungang) View.VISIBLE else View.GONE
+        if ((showForTerminal || showForJungang) && data != null) {
             binding.busAccentBarTerminal.setBackgroundColor(color)
             binding.busAlternativeTerminalRoute.setTextColor(color)
             binding.busAlternativeTerminalRoute.text = getString(data.routeDisplayName)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabJungangStationFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabJungangStationFragment.kt
@@ -27,6 +27,7 @@ import app.kobuggi.hyuabot.widget.ShuttleWidgetSupport
 class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentShuttleRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: ShuttleRealtimeViewModel by viewModels({ requireParentFragment() })
+    private var nextCampusShuttleTime: LocalTime? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -144,6 +145,7 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
             val shuttle = source.result.firstOrNull { it.name == "jungang_stn" } ?: return@observe
             val shuttleByOrder = shuttle.timetable.order.filter { it.time > now }
             val shuttleForCampus = shuttle.timetable.destination.firstOrNull { it.destination == "CAMPUS" }?.entries?.filter { it.time > now } ?: emptyList()
+            nextCampusShuttleTime = shuttleForCampus.firstOrNull()?.time
             // Hide the layout by showing the destination conf
             binding.shuttleDestinationScroll.visibility = if (source.showByDestination) View.VISIBLE else View.GONE
             binding.shuttleTimeScroll.visibility = if (source.showByDestination) View.GONE else View.VISIBLE
@@ -189,6 +191,12 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
         parentViewModel.busAlternativeJungang62.observe(viewLifecycleOwner) { busMinutes ->
             updateBusAlternativeDormitory(parentViewModel.busAlternativeJungang80.value, busMinutes)
         }
+        parentViewModel.alternativeDisplayMode.observe(viewLifecycleOwner) {
+            updateBusAlternativeDormitory(
+                parentViewModel.busAlternativeJungang80.value,
+                parentViewModel.busAlternativeJungang62.value,
+            )
+        }
         bindShuttleHelpButtons(binding.helpButton, binding.helpButton2)
         return binding.root.also { disableViewStateSaving(it) }
     }
@@ -220,9 +228,9 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
         val blueColor = requireContext().getColor(R.color.blue_bus)
         val greenColor = requireContext().getColor(R.color.green_bus)
 
-        val shouldShow80 = data80?.minutes != null
+        val shouldShow80 = parentViewModel.shouldShowBusAlternative(data80, nextCampusShuttleTime)
         binding.busAlternativeDormitory.visibility = if (shouldShow80) View.VISIBLE else View.GONE
-        if (shouldShow80) {
+        if (shouldShow80 && data80 != null) {
             binding.busAccentBarDormitory.setBackgroundColor(blueColor)
             binding.busAlternativeDormitoryRoute.setTextColor(blueColor)
             binding.busAlternativeDormitoryRoute.text = getString(data80.routeDisplayName)
@@ -239,9 +247,9 @@ class ShuttleTabJungangStationFragment @Inject constructor() : Fragment() {
             binding.busAlternativeDormitoryInfo.alpha = 0.38f
         }
 
-        val shouldShow62 = data62?.minutes != null
+        val shouldShow62 = parentViewModel.shouldShowBusAlternative(data62, nextCampusShuttleTime)
         binding.busAlternativeDormitory2.visibility = if (shouldShow62) View.VISIBLE else View.GONE
-        if (shouldShow62) {
+        if (shouldShow62 && data62 != null) {
             binding.busAccentBarDormitory2.setBackgroundColor(greenColor)
             binding.busAlternativeDormitory2Route.setTextColor(greenColor)
             binding.busAlternativeDormitory2Route.text = getString(data62.routeDisplayName)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockOutFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabShuttlecockOutFragment.kt
@@ -27,6 +27,9 @@ import app.kobuggi.hyuabot.widget.ShuttleWidgetSupport
 class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentShuttleRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: ShuttleRealtimeViewModel by viewModels({ requireParentFragment() })
+    private var nextStationShuttleTime: LocalTime? = null
+    private var nextTerminalShuttleTime: LocalTime? = null
+    private var nextJungangShuttleTime: LocalTime? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -316,6 +319,9 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             val shuttleForStation = shuttle.timetable.destination.firstOrNull { it.destination == "STATION" }?.entries?.filter { it.time > now } ?: emptyList()
             val shuttleForTerminal = shuttle.timetable.destination.firstOrNull { it.destination == "TERMINAL" }?.entries?.filter { it.time > now } ?: emptyList()
             val shuttleForJungangStation = shuttle.timetable.destination.firstOrNull { it.destination == "JUNGANG" }?.entries?.filter { it.time > now } ?: emptyList()
+            nextStationShuttleTime = shuttleForStation.firstOrNull()?.time
+            nextTerminalShuttleTime = shuttleForTerminal.firstOrNull()?.time
+            nextJungangShuttleTime = shuttleForJungangStation.firstOrNull()?.time
             // Hide the layout by showing the destination conf
             binding.shuttleDestinationScroll.visibility = if (source.showByDestination) View.VISIBLE else View.GONE
             binding.shuttleTimeScroll.visibility = if (source.showByDestination) View.GONE else View.VISIBLE
@@ -362,6 +368,13 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
         parentViewModel.busAlternativeShuttlecock62.observe(viewLifecycleOwner) { busMinutes ->
             updateBusAlternative62(busMinutes)
         }
+        parentViewModel.alternativeDisplayMode.observe(viewLifecycleOwner) {
+            updateBusAlternativeStation(
+                parentViewModel.busAlternativeShuttlecock.value,
+                parentViewModel.forceShowBusAlternative.value ?: false,
+            )
+            updateBusAlternative62(parentViewModel.busAlternativeShuttlecock62.value)
+        }
 
         binding.apply {
             headerBoundForDormitory.visibility = View.GONE
@@ -369,9 +382,6 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
             noRealtimeDataBoundForDormitory.visibility = View.GONE
             entireTimetableBoundForDormitory.visibility = View.GONE
             entireTimetableDormitory.visibility = View.GONE
-        }
-        parentViewModel.transfer.observe(viewLifecycleOwner) { data ->
-            ShuttleTransferBinder.bind(binding.transferSection, binding.transferContainer, "shuttlecock_o", data)
         }
         bindShuttleHelpButtons(binding.helpButton, binding.helpButton2)
         return binding.root.also { disableViewStateSaving(it) }
@@ -401,7 +411,11 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
     }
 
     private fun updateBusAlternativeStation(data: BusAlternativeData?, forceShow: Boolean = false) {
-        val shouldShow = data?.minutes != null || forceShow
+        val shouldShow = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextStationShuttleTime,
+            forceShow,
+        )
         binding.busAlternativeStation.visibility = if (shouldShow) View.VISIBLE else View.GONE
         if (shouldShow) {
             binding.busAlternativeStationTime.text = if (data?.minutes != null)
@@ -418,10 +432,17 @@ class ShuttleTabShuttlecockOutFragment @Inject constructor() : Fragment() {
 
     private fun updateBusAlternative62(data: BusAlternativeData?) {
         val color = requireContext().getColor(R.color.green_bus)
-        val shouldShow = data?.minutes != null
-        binding.busAlternativeTerminal.visibility = if (shouldShow) View.VISIBLE else View.GONE
-        binding.busAlternativeJungangStation.visibility = if (shouldShow) View.VISIBLE else View.GONE
-        if (shouldShow) {
+        val showForTerminal = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextTerminalShuttleTime,
+        )
+        val showForJungang = parentViewModel.shouldShowBusAlternative(
+            data,
+            nextJungangShuttleTime,
+        )
+        binding.busAlternativeTerminal.visibility = if (showForTerminal) View.VISIBLE else View.GONE
+        binding.busAlternativeJungangStation.visibility = if (showForJungang) View.VISIBLE else View.GONE
+        if ((showForTerminal || showForJungang) && data != null) {
             val timeText = getString(R.string.shuttle_bus_alternative_time, data.minutes)
             val routeText = getString(data.routeDisplayName)
             binding.busAccentBarTerminal.setBackgroundColor(color)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabStationFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabStationFragment.kt
@@ -27,6 +27,7 @@ import app.kobuggi.hyuabot.widget.ShuttleWidgetSupport
 class ShuttleTabStationFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentShuttleRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: ShuttleRealtimeViewModel by viewModels({ requireParentFragment() })
+    private var nextCampusShuttleTime: LocalTime? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -380,6 +381,7 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
             val shuttle = source.result.firstOrNull { it.name == "station" } ?: return@observe
             val shuttleByOrder = shuttle.timetable.order.filter { it.time > now }
             val shuttleForCampus = shuttle.timetable.destination.firstOrNull { it.destination == "CAMPUS" }?.entries?.filter { it.time > now } ?: emptyList()
+            nextCampusShuttleTime = shuttleForCampus.firstOrNull()?.time
             val shuttleForTerminal = shuttle.timetable.destination.firstOrNull { it.destination == "TERMINAL" }?.entries?.filter { it.time > now } ?: emptyList()
             val shuttleForJungangStation = shuttle.timetable.destination.firstOrNull { it.destination == "JUNGANG" }?.entries?.filter { it.time > now } ?: emptyList()
             // Hide the layout by showing the destination conf
@@ -425,6 +427,9 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
         parentViewModel.busAlternativeStation.observe(viewLifecycleOwner) { busMinutes ->
             updateBusAlternativeDormitory(busMinutes)
         }
+        parentViewModel.alternativeDisplayMode.observe(viewLifecycleOwner) {
+            updateBusAlternativeDormitory(parentViewModel.busAlternativeStation.value)
+        }
 
         binding.apply {
             headerBoundForStation.visibility = View.GONE
@@ -461,9 +466,9 @@ class ShuttleTabStationFragment @Inject constructor() : Fragment() {
     }
 
     private fun updateBusAlternativeDormitory(data: BusAlternativeData?) {
-        val shouldShow = data?.minutes != null
+        val shouldShow = parentViewModel.shouldShowBusAlternative(data, nextCampusShuttleTime)
         binding.busAlternativeDormitory.visibility = if (shouldShow) View.VISIBLE else View.GONE
-        if (shouldShow) {
+        if (shouldShow && data != null) {
             binding.busAlternativeDormitoryTime.text = getString(R.string.shuttle_bus_alternative_time, data.minutes)
             bindBusAlternativeInfo(
                 binding.busAlternativeDormitoryInfo,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabTerminalFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTabTerminalFragment.kt
@@ -27,6 +27,7 @@ import app.kobuggi.hyuabot.widget.ShuttleWidgetSupport
 class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentShuttleRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: ShuttleRealtimeViewModel by viewModels({ requireParentFragment() })
+    private var nextCampusShuttleTime: LocalTime? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -155,6 +156,7 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
             val shuttle = source.result.firstOrNull { it.name == "terminal" } ?: return@observe
             val shuttleByOrder = shuttle.timetable.order.filter { it.time > now }
             val shuttleForCampus = shuttle.timetable.destination.firstOrNull { it.destination == "CAMPUS" }?.entries?.filter { it.time > now } ?: emptyList()
+            nextCampusShuttleTime = shuttleForCampus.firstOrNull()?.time
             // Hide the layout by showing the destination conf
             binding.shuttleDestinationScroll.visibility = if (source.showByDestination) View.VISIBLE else View.GONE
             binding.shuttleTimeScroll.visibility = if (source.showByDestination) View.GONE else View.VISIBLE
@@ -200,8 +202,11 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
         parentViewModel.busAlternativeTerminal62.observe(viewLifecycleOwner) { busMinutes ->
             updateBusAlternativeDormitory(parentViewModel.busAlternativeTerminal80.value, busMinutes)
         }
-        parentViewModel.transfer.observe(viewLifecycleOwner) { data ->
-            ShuttleTransferBinder.bind(binding.transferSection, binding.transferContainer, "terminal", data)
+        parentViewModel.alternativeDisplayMode.observe(viewLifecycleOwner) {
+            updateBusAlternativeDormitory(
+                parentViewModel.busAlternativeTerminal80.value,
+                parentViewModel.busAlternativeTerminal62.value,
+            )
         }
         bindShuttleHelpButtons(binding.helpButton, binding.helpButton2)
         return binding.root.also { disableViewStateSaving(it) }
@@ -234,9 +239,9 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
         val blueColor = requireContext().getColor(R.color.blue_bus)
         val greenColor = requireContext().getColor(R.color.green_bus)
 
-        val shouldShow80 = data80?.minutes != null
+        val shouldShow80 = parentViewModel.shouldShowBusAlternative(data80, nextCampusShuttleTime)
         binding.busAlternativeDormitory.visibility = if (shouldShow80) View.VISIBLE else View.GONE
-        if (shouldShow80) {
+        if (shouldShow80 && data80 != null) {
             binding.busAccentBarDormitory.setBackgroundColor(blueColor)
             binding.busAlternativeDormitoryRoute.setTextColor(blueColor)
             binding.busAlternativeDormitoryRoute.text = getString(data80.routeDisplayName)
@@ -253,9 +258,9 @@ class ShuttleTabTerminalFragment @Inject constructor() : Fragment() {
             binding.busAlternativeDormitoryInfo.alpha = 0.38f
         }
 
-        val shouldShow62 = data62?.minutes != null
+        val shouldShow62 = parentViewModel.shouldShowBusAlternative(data62, nextCampusShuttleTime)
         binding.busAlternativeDormitory2.visibility = if (shouldShow62) View.VISIBLE else View.GONE
-        if (shouldShow62) {
+        if (shouldShow62 && data62 != null) {
             binding.busAccentBarDormitory2.setBackgroundColor(greenColor)
             binding.busAlternativeDormitory2Route.setTextColor(greenColor)
             binding.busAlternativeDormitory2Route.text = getString(data62.routeDisplayName)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTransferBinder.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleTransferBinder.kt
@@ -3,6 +3,8 @@ import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
 
 import android.content.res.ColorStateList
+import android.content.res.Configuration
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
@@ -12,7 +14,9 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
+import app.kobuggi.hyuabot.databinding.ItemShuttleConnectionRowBinding
 import app.kobuggi.hyuabot.service.safeNavigate
+import app.kobuggi.hyuabot.util.TransitRow
 import app.kobuggi.hyuabot.util.buildTransitRows
 
 fun Fragment.bindShuttleHelpButtons(vararg buttons: View) {
@@ -51,5 +55,58 @@ object ShuttleTransferBinder {
             container.addView(view)
         }
         section.visibility = View.VISIBLE
+    }
+
+    fun bindCompact(container: LinearLayout, rows: List<TransitRow>) {
+        container.removeAllViews()
+        val inflater = LayoutInflater.from(container.context)
+        val darkMode = container.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+            Configuration.UI_MODE_NIGHT_YES
+        rows.forEach { row ->
+            val binding = ItemShuttleConnectionRowBinding.inflate(inflater, container, false)
+            val tint = ContextCompat.getColor(container.context, row.colorRes)
+            binding.transferAccent.setBackgroundColor(tint)
+            binding.transferTitle.text = row.compactTitle
+            binding.transferTitle.setTextColor(tint)
+            binding.transferTrailing.text = row.compactTrailing
+            binding.transferConnector.visibility = if (row.connectorTitle == null) View.GONE else View.VISIBLE
+            if (row.connectorTitle != null) {
+                binding.transferConnectorText.text = if (row.connectorTravelMinutes != null) {
+                    container.context.getString(
+                        R.string.home_transfer_connector_travel_time,
+                        row.connectorTitle,
+                        row.connectorTravelMinutes,
+                    )
+                } else {
+                    row.connectorTitle
+                }
+                val connectorColor = if (darkMode) Color.WHITE else tint
+                binding.transferConnectorText.setTextColor(connectorColor)
+                binding.transferConnectorIcon.imageTintList = ColorStateList.valueOf(connectorColor)
+                binding.transferConnector.strokeColor = Color.argb(
+                    if (darkMode) 153 else 46,
+                    Color.red(tint),
+                    Color.green(tint),
+                    Color.blue(tint),
+                )
+                binding.transferConnector.alpha = 0f
+                binding.transferConnector.scaleX = 0.96f
+                binding.transferConnector.scaleY = 0.96f
+            }
+            container.addView(binding.root)
+        }
+        container.post {
+            for (index in 0 until container.childCount) {
+                val connector = container.getChildAt(index).findViewById<View>(R.id.transfer_connector)
+                if (connector.visibility == View.VISIBLE) {
+                    connector.animate()
+                        .alpha(1f)
+                        .scaleX(1f)
+                        .scaleY(1f)
+                        .setDuration(180)
+                        .start()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/util/ShuttleTransfer.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/ShuttleTransfer.kt
@@ -8,7 +8,11 @@ import androidx.appcompat.app.AppCompatDelegate
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.ShuttleTransferQuery
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import java.time.DayOfWeek
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -18,6 +22,10 @@ data class TransitRow(
     val detail: String,
     val vehicleType: TransitVehicleType,
     val timeline: List<TransitTimelineEntry> = emptyList(),
+    val compactTitle: String = name,
+    val compactTrailing: String = detail,
+    val connectorTitle: String? = null,
+    val connectorTravelMinutes: Int? = null,
 )
 
 enum class TransitVehicleType {
@@ -34,6 +42,8 @@ data class TransitTimelineEntry(
     val direction: Int,
 )
 
+private const val SUBWAY_TRANSFER_MINUTES = 5
+private const val CHOJI_TRANSFER_MINUTES = 8
 private const val BUS_STOP_KWANGMYEONG = 216000759
 private const val BUS_STOP_ANSAN = 216000117
 
@@ -45,6 +55,7 @@ private data class TransferData(
 private data class TransferSubwayStation(
     val stationID: String,
     val arrival: List<TransferSubwayArrival>,
+    val timetable: List<TransferSubwayTimetable>,
 )
 
 private data class TransferSubwayArrival(
@@ -61,14 +72,34 @@ private data class TransferSubwayEntry(
     val terminalName: String,
 )
 
+private data class TransferSubwayTimetable(
+    val direction: String,
+    val time: LocalTime,
+    val terminalID: String,
+    val terminalName: String,
+)
+
 private data class TransferBus(
     val stopSeq: Int,
     val arrival: List<TransferBusArrival>,
+    val log: List<LocalTime>,
 )
 
 private data class TransferBusArrival(
     val minutes: Int?,
     val stops: Int?,
+    val isRealtime: Boolean,
+)
+
+private data class SubwayCandidate(
+    val lineName: String,
+    @param:ColorRes val colorRes: Int,
+    val terminalID: String,
+    val terminalName: String,
+    val arrivalDate: ZonedDateTime,
+    val minutes: Int?,
+    val stops: Int?,
+    val direction: Int,
     val isRealtime: Boolean,
 )
 
@@ -79,11 +110,15 @@ fun localizedContext(context: Context): Context {
     return context.createConfigurationContext(config)
 }
 
-fun currentShuttleWeekday(): String = when (ZonedDateTime.now(ZoneId.of("Asia/Seoul")).dayOfWeek) {
-    DayOfWeek.SATURDAY -> "saturday"
-    DayOfWeek.SUNDAY -> "sunday"
-    else -> "weekday"
-}
+fun currentShuttleWeekday(): String =
+    if (ZonedDateTime.now(ZoneId.of("Asia/Seoul")).dayOfWeek in setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)) {
+        "weekends"
+    } else {
+        "weekdays"
+    }
+
+fun shuttleBusLogReferenceDates(today: LocalDate = LocalDate.now(ZoneId.of("Asia/Seoul"))): List<LocalDate> =
+    listOf(today.minusDays(7), today.minusDays(2), today.minusDays(1))
 
 fun buildTransitRows(
     context: Context,
@@ -169,6 +204,9 @@ private val SUBWAY_STATION_NAMES: Map<String, Int> = mapOf(
     "K444" to R.string.subway_station_K444,
     "K453" to R.string.subway_station_K453,
     "K456" to R.string.subway_station_K456,
+    "S07" to R.string.subway_station_S07,
+    "S11" to R.string.subway_station_S11,
+    "S16" to R.string.subway_station_S16,
 )
 
 fun localizedSubwayStationName(context: Context, stationID: String, fallback: String): String =
@@ -205,6 +243,422 @@ private fun busRow(
     return TransitRow(destination, R.color.green_bus, detail, TransitVehicleType.BUS, timeline)
 }
 
+fun buildShuttleConnectionRows(
+    context: Context,
+    stopName: String,
+    destination: String,
+    shuttle: ShuttleRealtimePageQuery.Entry,
+    data: ShuttleRealtimePageQuery.Data?,
+    showBusTransfer: Boolean,
+    showSubwayTransfer: Boolean,
+    subwayDestination: HomeSubwayTransferDestination,
+): List<TransitRow> {
+    if (data == null || stopName !in setOf("dormitory_o", "shuttlecock_o")) return emptyList()
+    val transferData = data.toTransferData()
+    return when (destination) {
+        "STATION" -> if (showSubwayTransfer) {
+            stationConnectionRows(context, shuttle, transferData, subwayDestination)
+        } else {
+            emptyList()
+        }
+        "TERMINAL" -> if (showBusTransfer) {
+            terminalBusConnectionRows(context, shuttle, transferData)
+        } else {
+            emptyList()
+        }
+        "JUNGANG" -> if (showSubwayTransfer) {
+            jungangConnectionRows(context, shuttle, transferData, subwayDestination)
+        } else {
+            emptyList()
+        }
+        else -> emptyList()
+    }
+}
+
+private fun stationConnectionRows(
+    context: Context,
+    shuttle: ShuttleRealtimePageQuery.Entry,
+    data: TransferData,
+    destination: HomeSubwayTransferDestination,
+): List<TransitRow> {
+    val transferStart = shuttleTransferDate(shuttle, "station")
+    val line4 = subwayCandidates(context, data, "K449", "up", R.string.subway_line4, R.color.subway_line4)
+    val suin = subwayCandidates(
+        context,
+        data,
+        "K251",
+        "up",
+        R.string.home_transfer_subway_suin_bundang_badge,
+        R.color.home_subway_yellow,
+    )
+    return when (destination) {
+        HomeSubwayTransferDestination.SEOUL ->
+            earliestCandidate(line4, transferStart, SUBWAY_TRANSFER_MINUTES)
+                ?.let { listOf(candidateRow(context, it, transferStart, SUBWAY_TRANSFER_MINUTES)) }
+                .orEmpty()
+        HomeSubwayTransferDestination.SUWON_YONGIN ->
+            earliestCandidate(suin, transferStart, SUBWAY_TRANSFER_MINUTES)
+                ?.let { listOf(candidateRow(context, it, transferStart, SUBWAY_TRANSFER_MINUTES)) }
+                .orEmpty()
+        HomeSubwayTransferDestination.OIDO -> {
+            val candidates = oidoFirstLegCandidates(context, data)
+            earliestCandidate(candidates, transferStart, SUBWAY_TRANSFER_MINUTES)
+                ?.let { listOf(candidateRow(context, it, transferStart, SUBWAY_TRANSFER_MINUTES)) }
+                .orEmpty()
+        }
+        HomeSubwayTransferDestination.SOSA -> sosaRows(context, data, transferStart)
+        HomeSubwayTransferDestination.INCHEON -> incheonRows(context, data, transferStart)
+    }.mapIndexed { index, row ->
+        if (index == 0) {
+            row.copy(
+                connectorTitle = context.getString(
+                    R.string.shuttle_connection_transfer_format,
+                    context.getString(R.string.home_transfer_subway_connector),
+                ),
+                connectorTravelMinutes = SUBWAY_TRANSFER_MINUTES,
+            )
+        } else {
+            row
+        }
+    }
+}
+
+private fun sosaRows(
+    context: Context,
+    data: TransferData,
+    transferStart: ZonedDateTime?,
+): List<TransitRow> {
+    val firstLegs = eligibleCandidates(
+        chojiFirstLegCandidates(context, data),
+        transferStart,
+        SUBWAY_TRANSFER_MINUTES,
+    )
+    val secondLegs = subwayTimetableCandidates(
+        context,
+        data,
+        "S26",
+        "up",
+        R.string.home_transfer_subway_seohae_badge,
+        R.color.subway_seohae,
+    ) { it <= "S16" && it.startsWith("S") }
+    val path = firstLegs.mapNotNull { first ->
+        val second = earliestCandidate(secondLegs, first.arrivalDate, CHOJI_TRANSFER_MINUTES)
+            ?: return@mapNotNull null
+        listOf(first, second)
+    }.minByOrNull { it.last().arrivalDate } ?: return emptyList()
+    return listOf(
+        candidateRow(context, path[0], transferStart, SUBWAY_TRANSFER_MINUTES),
+        candidateRow(
+            context,
+            path[1],
+            path[0].arrivalDate,
+            CHOJI_TRANSFER_MINUTES,
+            context.getString(R.string.home_transfer_subway_choji_connector),
+            CHOJI_TRANSFER_MINUTES,
+        ),
+    )
+}
+
+private fun incheonRows(
+    context: Context,
+    data: TransferData,
+    transferStart: ZonedDateTime?,
+): List<TransitRow> {
+    val direct = subwayCandidates(
+        context,
+        data,
+        "K251",
+        "down",
+        R.string.home_transfer_subway_suin_bundang_badge,
+        R.color.home_subway_yellow,
+    ) { it > "K258" && it.startsWith("K2") }
+        .let { eligibleCandidates(it, transferStart, SUBWAY_TRANSFER_MINUTES) }
+        .map(::listOf)
+    val firstLegs = eligibleCandidates(
+        oidoFirstLegCandidates(context, data),
+        transferStart,
+        SUBWAY_TRANSFER_MINUTES,
+    )
+    val secondLegs = subwayCandidates(
+        context,
+        data,
+        "K258",
+        "down",
+        R.string.home_transfer_subway_suin_bundang_badge,
+        R.color.home_subway_yellow,
+    ) { it > "K258" && it.startsWith("K2") }
+    val transfer = firstLegs.mapNotNull { first ->
+        val second = earliestCandidate(secondLegs, first.arrivalDate, SUBWAY_TRANSFER_MINUTES)
+            ?: return@mapNotNull null
+        listOf(first, second)
+    }
+    val path = (direct + transfer).minByOrNull { it.last().arrivalDate } ?: return emptyList()
+    return path.mapIndexed { index, candidate ->
+        candidateRow(
+            context = context,
+            candidate = candidate,
+            transferStart = if (index == 0) transferStart else path[index - 1].arrivalDate,
+            travelMinutes = if (index == 0) SUBWAY_TRANSFER_MINUTES else null,
+            connectorTitle = if (index == 0) null else context.getString(R.string.home_transfer_subway_oido_connector),
+            connectorTravelMinutes = null,
+        )
+    }
+}
+
+private fun chojiFirstLegCandidates(context: Context, data: TransferData): List<SubwayCandidate> =
+    subwayCandidates(
+        context,
+        data,
+        "K449",
+        "down",
+        R.string.subway_line4,
+        R.color.subway_line4,
+    ) { it >= "K452" && it.startsWith("K4") } + subwayCandidates(
+        context,
+        data,
+        "K251",
+        "down",
+        R.string.home_transfer_subway_suin_bundang_badge,
+        R.color.home_subway_yellow,
+    ) { it >= "K254" && it.startsWith("K2") }
+
+private fun oidoFirstLegCandidates(context: Context, data: TransferData): List<SubwayCandidate> =
+    subwayCandidates(
+        context,
+        data,
+        "K449",
+        "down",
+        R.string.subway_line4,
+        R.color.subway_line4,
+    ) { it == "K456" } + subwayCandidates(
+        context,
+        data,
+        "K251",
+        "down",
+        R.string.home_transfer_subway_suin_bundang_badge,
+        R.color.home_subway_yellow,
+    ) { it >= "K258" && it.startsWith("K2") }
+
+private fun jungangConnectionRows(
+    context: Context,
+    shuttle: ShuttleRealtimePageQuery.Entry,
+    data: TransferData,
+    destination: HomeSubwayTransferDestination,
+): List<TransitRow> {
+    val direction = when (destination) {
+        HomeSubwayTransferDestination.SEOUL -> "up"
+        HomeSubwayTransferDestination.OIDO,
+        HomeSubwayTransferDestination.SOSA -> "down"
+        else -> return emptyList()
+    }
+    val transferStart = shuttleTransferDate(shuttle, "jungang_stn")
+    val candidate = earliestCandidate(
+        subwayCandidates(context, data, "K450", direction, R.string.subway_line4, R.color.subway_line4),
+        transferStart,
+        0,
+    ) ?: return emptyList()
+    return listOf(
+        candidateRow(context, candidate, transferStart, null).copy(
+            connectorTitle = context.getString(
+                R.string.shuttle_connection_transfer_format,
+                context.getString(R.string.shuttle_tab_jungang_station),
+            ),
+        ),
+    )
+}
+
+private fun terminalBusConnectionRows(
+    context: Context,
+    shuttle: ShuttleRealtimePageQuery.Entry,
+    data: TransferData,
+): List<TransitRow> {
+    val transferStart = shuttleTransferDate(shuttle, "terminal")
+    val bus = data.bus.firstOrNull { it.stopSeq == BUS_STOP_KWANGMYEONG } ?: return emptyList()
+    val realtime = bus.arrival
+        .filter { it.isRealtime && it.minutes != null }
+        .map { arrival ->
+            val arrivalDate = nowInSeoul().plusMinutes(arrival.minutes!!.toLong())
+            arrival to arrivalDate
+        }
+        .filter { (_, date) -> transferStart == null || !date.isBefore(transferStart) }
+        .minByOrNull { (_, date) -> date }
+    val arrivalDate = realtime?.second ?: bus.log
+        .map(::upcomingDateTime)
+        .filter { transferStart == null || !it.isBefore(transferStart) }
+        .minOrNull()
+        ?: return emptyList()
+    val trailing = transferWaitingText(context, transferStart, arrivalDate, null)
+    val detail = if (realtime != null) {
+        realtime.first.stops?.let { context.getString(R.string.home_transfer_bus50_realtime_stops, it) }
+            ?: context.getString(R.string.home_transfer_realtime_minutes, realtime.first.minutes)
+    } else {
+        context.getString(R.string.home_transfer_bus50_log_arrival_record, arrivalDate.hour, arrivalDate.minute)
+    }
+    val badge = context.getString(R.string.home_transfer_bus50_badge)
+    return listOf(
+        TransitRow(
+            name = badge,
+            colorRes = R.color.green_bus,
+            detail = detail,
+            vehicleType = TransitVehicleType.BUS,
+            compactTitle = badge,
+            compactTrailing = trailing ?: detail,
+            connectorTitle = context.getString(
+                R.string.shuttle_connection_transfer_format,
+                context.getString(R.string.home_transfer_bus50_connector),
+            ),
+        ),
+    )
+}
+
+private fun candidateRow(
+    context: Context,
+    candidate: SubwayCandidate,
+    transferStart: ZonedDateTime?,
+    travelMinutes: Int?,
+    connectorTitle: String? = null,
+    connectorTravelMinutes: Int? = null,
+): TransitRow {
+    val destination = localizedSubwayStationName(context, candidate.terminalID, candidate.terminalName)
+    val detail = if (candidate.isRealtime) {
+        candidate.stops?.let { context.getString(R.string.home_transfer_subway_realtime_stops, it) }
+            ?: candidate.minutes?.let { context.getString(R.string.home_transfer_realtime_minutes, it) }
+            ?: ""
+    } else {
+        context.getString(
+            R.string.home_transfer_subway_timetable_arrival,
+            candidate.arrivalDate.hour,
+            candidate.arrivalDate.minute,
+        )
+    }
+    return TransitRow(
+        name = candidate.lineName,
+        colorRes = candidate.colorRes,
+        detail = detail,
+        vehicleType = TransitVehicleType.SUBWAY,
+        timeline = listOf(
+            TransitTimelineEntry(
+                destination = destination,
+                minutes = candidate.minutes,
+                stops = candidate.stops,
+                locationLabel = null,
+                isRealtime = candidate.isRealtime,
+                direction = candidate.direction,
+            ),
+        ),
+        compactTitle = context.getString(R.string.home_transfer_subway_title, destination),
+        compactTrailing = transferWaitingText(context, transferStart, candidate.arrivalDate, travelMinutes) ?: detail,
+        connectorTitle = connectorTitle,
+        connectorTravelMinutes = connectorTravelMinutes,
+    )
+}
+
+private fun subwayCandidates(
+    context: Context,
+    data: TransferData,
+    stationID: String,
+    direction: String,
+    @StringRes lineNameRes: Int,
+    @ColorRes colorRes: Int,
+    isEligible: (String) -> Boolean = { true },
+): List<SubwayCandidate> {
+    val group = data.subway.firstOrNull { it.stationID == stationID }
+        ?.arrival
+        ?.firstOrNull { it.direction == direction }
+        ?: return emptyList()
+    val now = nowInSeoul()
+    return group.entries.filter { isEligible(it.terminalID) }.map {
+        SubwayCandidate(
+            lineName = context.getString(lineNameRes),
+            colorRes = colorRes,
+            terminalID = it.terminalID,
+            terminalName = it.terminalName,
+            arrivalDate = now.plusMinutes(it.minutes.toLong()),
+            minutes = it.minutes,
+            stops = it.stops,
+            direction = subwayDirection(direction),
+            isRealtime = it.isRealtime,
+        )
+    }
+}
+
+private fun subwayTimetableCandidates(
+    context: Context,
+    data: TransferData,
+    stationID: String,
+    direction: String,
+    @StringRes lineNameRes: Int,
+    @ColorRes colorRes: Int,
+    isEligible: (String) -> Boolean,
+): List<SubwayCandidate> =
+    data.subway.firstOrNull { it.stationID == stationID }
+        ?.timetable
+        ?.filter { it.direction == direction && isEligible(it.terminalID) }
+        ?.map {
+            val date = upcomingDateTime(it.time)
+            SubwayCandidate(
+                lineName = context.getString(lineNameRes),
+                colorRes = colorRes,
+                terminalID = it.terminalID,
+                terminalName = it.terminalName,
+                arrivalDate = date,
+                minutes = Duration.between(nowInSeoul(), date).toMinutes().coerceAtLeast(0).toInt(),
+                stops = null,
+                direction = subwayDirection(direction),
+                isRealtime = false,
+            )
+        }
+        .orEmpty()
+
+private fun earliestCandidate(
+    candidates: List<SubwayCandidate>,
+    transferStart: ZonedDateTime?,
+    minimumTransferMinutes: Int,
+): SubwayCandidate? =
+    eligibleCandidates(candidates, transferStart, minimumTransferMinutes).minByOrNull { it.arrivalDate }
+
+private fun eligibleCandidates(
+    candidates: List<SubwayCandidate>,
+    transferStart: ZonedDateTime?,
+    minimumTransferMinutes: Int,
+): List<SubwayCandidate> {
+    if (transferStart == null) return candidates
+    return candidates.filter {
+        Duration.between(transferStart, it.arrivalDate).toMinutes() >= minimumTransferMinutes
+    }
+}
+
+private fun shuttleTransferDate(
+    shuttle: ShuttleRealtimePageQuery.Entry,
+    stopName: String,
+): ZonedDateTime? =
+    shuttle.stops.firstOrNull { it.stop == stopName }?.time?.let(::upcomingDateTime)
+
+private fun transferWaitingText(
+    context: Context,
+    transferStart: ZonedDateTime?,
+    arrivalDate: ZonedDateTime,
+    travelMinutes: Int?,
+): String? {
+    if (transferStart == null) return null
+    val buffer = Duration.between(transferStart, arrivalDate).toMinutes().coerceAtLeast(0).toInt()
+    val waiting = (buffer - (travelMinutes ?: 0)).coerceAtLeast(0)
+    return if (waiting == 0) {
+        context.getString(R.string.home_transfer_wait_immediate)
+    } else {
+        context.getString(R.string.home_transfer_wait_minutes, waiting)
+    }
+}
+
+private fun upcomingDateTime(time: LocalTime): ZonedDateTime {
+    val now = nowInSeoul()
+    var result = now.toLocalDate().atTime(time).atZone(now.zone)
+    if (result.isBefore(now)) result = result.plusDays(1)
+    return result
+}
+
+private fun nowInSeoul(): ZonedDateTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+
 private fun ShuttleTransferQuery.Data.toTransferData(): TransferData =
     TransferData(
         subway = subway.map { station ->
@@ -225,6 +679,7 @@ private fun ShuttleTransferQuery.Data.toTransferData(): TransferData =
                         },
                     )
                 },
+                timetable = emptyList(),
             )
         },
         bus = bus.map { item ->
@@ -233,6 +688,7 @@ private fun ShuttleTransferQuery.Data.toTransferData(): TransferData =
                 arrival = item.arrival.map { arrival ->
                     TransferBusArrival(arrival.minutes, arrival.stops, arrival.isRealtime)
                 },
+                log = emptyList(),
             )
         },
     )
@@ -257,6 +713,14 @@ private fun ShuttleRealtimePageQuery.Data.toTransferData(): TransferData =
                         },
                     )
                 },
+                timetable = station.timetable.map {
+                    TransferSubwayTimetable(
+                        direction = it.direction,
+                        time = it.time,
+                        terminalID = it.terminal.stationID,
+                        terminalName = it.terminal.name,
+                    )
+                },
             )
         },
         bus = transferBus.map { item ->
@@ -265,6 +729,7 @@ private fun ShuttleRealtimePageQuery.Data.toTransferData(): TransferData =
                 arrival = item.arrival.map { arrival ->
                     TransferBusArrival(arrival.minutes, arrival.stops, arrival.isRealtime)
                 },
+                log = item.log.map { it.time },
             )
         },
     )

--- a/app/src/main/res/layout/dialog_shuttle_quick_settings.xml
+++ b/app/src/main/res/layout/dialog_shuttle_quick_settings.xml
@@ -4,196 +4,308 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/background"
-    android:orientation="vertical"
-    android:paddingHorizontal="20dp"
-    android:paddingTop="22dp"
-    android:paddingBottom="24dp">
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/title_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="20dp"
+        android:paddingTop="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="12dp"
         android:text="@string/shuttle_quick_settings_title"
         android:textColor="@color/primary_text"
         android:textSize="20sp"
         android:textStyle="bold" />
 
-    <LinearLayout
-        android:id="@+id/show_by_destination_row"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="14dp"
-        android:background="@drawable/bg_home_row"
-        android:orientation="vertical"
-        android:paddingHorizontal="14dp"
-        android:paddingVertical="12dp">
+        android:fillViewport="true"
+        android:overScrollMode="never">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:paddingBottom="18dp">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/shuttle_display_order_title"
-                android:textColor="@color/primary_text"
-                android:textSize="16sp"
+                android:layout_marginBottom="6dp"
+                android:text="@string/shuttle_quick_settings_section_display"
+                android:textColor="@color/secondary_text"
+                android:textSize="13sp"
                 android:textStyle="bold" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_home_row"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/shuttle_quick_settings_order_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/show_by_destination_switch"
+                        style="@style/Widget.App.Switch.Shuttle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/shuttle_quick_settings_order_title" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/app_separator" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/shuttle_quick_settings_time_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/show_departure_time_switch"
+                        style="@style/Widget.App.Switch.Shuttle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/shuttle_quick_settings_time_title" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/app_separator" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/shuttle_quick_settings_presence_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/show_presence_status_switch"
+                        style="@style/Widget.App.Switch.Shuttle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/shuttle_quick_settings_presence_title" />
+                </LinearLayout>
+            </LinearLayout>
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="@string/shuttle_display_order_subtitle"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="6dp"
+                android:text="@string/shuttle_quick_settings_section_connections"
                 android:textColor="@color/secondary_text"
-                android:textSize="13sp" />
-        </LinearLayout>
-
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/show_by_destination_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            app:selectionRequired="true"
-            app:singleSelection="true">
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/show_by_time_button"
-                style="@style/Widget.App.SegmentedButton"
-                android:layout_width="0dp"
-                android:layout_height="36dp"
-                android:layout_weight="1"
-                android:maxLines="1"
-                android:text="@string/shuttle_display_time_order" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/show_by_destination_button"
-                style="@style/Widget.App.SegmentedButton"
-                android:layout_width="0dp"
-                android:layout_height="36dp"
-                android:layout_weight="1"
-                android:maxLines="1"
-                android:text="@string/shuttle_display_destination_order" />
-        </com.google.android.material.button.MaterialButtonToggleGroup>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/show_departure_time_row"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="14dp"
-        android:background="@drawable/bg_home_row"
-        android:orientation="vertical"
-        android:paddingHorizontal="14dp"
-        android:paddingVertical="12dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/shuttle_time_display_title"
-                android:textColor="@color/primary_text"
-                android:textSize="16sp"
+                android:textSize="13sp"
                 android:textStyle="bold" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/bg_home_row"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/home_quick_settings_bus50_transfer_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/show_bus_transfer_switch"
+                        style="@style/Widget.App.Switch.Shuttle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/home_quick_settings_bus50_transfer_title" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/app_separator" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/home_quick_settings_subway_transfer_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/show_subway_transfer_switch"
+                        style="@style/Widget.App.Switch.Shuttle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/home_quick_settings_subway_transfer_title" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/app_separator" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/shuttle_quick_settings_subway_destination_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/subway_destination_button"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:minWidth="0dp"
+                        android:textColor="@color/plain_button_text"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        app:icon="@drawable/ic_chevron_down"
+                        app:iconGravity="textEnd"
+                        app:iconPadding="6dp"
+                        app:iconSize="16dp"
+                        app:iconTint="@color/plain_button_text" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/app_separator" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="52dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="14dp"
+                    android:paddingEnd="10dp">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/shuttle_quick_settings_alternative_title"
+                        android:textColor="@color/primary_text"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/alternative_mode_button"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:minWidth="0dp"
+                        android:textColor="@color/plain_button_text"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        app:icon="@drawable/ic_chevron_down"
+                        app:iconGravity="textEnd"
+                        app:iconPadding="6dp"
+                        app:iconSize="16dp"
+                        app:iconTint="@color/plain_button_text" />
+                </LinearLayout>
+            </LinearLayout>
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="@string/shuttle_time_display_subtitle"
+                android:layout_marginTop="8dp"
+                android:text="@string/shuttle_quick_settings_alternative_subtitle"
                 android:textColor="@color/secondary_text"
-                android:textSize="13sp" />
-        </LinearLayout>
-
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/show_departure_time_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            app:selectionRequired="true"
-            app:singleSelection="true">
+                android:textSize="12sp" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/show_remaining_time_button"
-                style="@style/Widget.App.SegmentedButton"
-                android:layout_width="0dp"
-                android:layout_height="36dp"
-                android:layout_weight="1"
-                android:maxLines="1"
-                android:text="@string/shuttle_time_remaining" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/show_departure_time_button"
-                style="@style/Widget.App.SegmentedButton"
-                android:layout_width="0dp"
-                android:layout_height="36dp"
-                android:layout_weight="1"
-                android:maxLines="1"
-                android:text="@string/shuttle_time_departure" />
-        </com.google.android.material.button.MaterialButtonToggleGroup>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/show_presence_status_row"
-        android:layout_width="match_parent"
-        android:layout_height="76dp"
-        android:layout_marginTop="14dp"
-        android:background="@drawable/bg_home_row"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingHorizontal="14dp"
-        android:paddingVertical="12dp">
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
+                android:id="@+id/open_home_button"
+                style="@style/Widget.Material3.Button"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/shuttle_quick_settings_presence_title"
-                android:textColor="@color/primary_text"
-                android:textSize="16sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:text="@string/shuttle_quick_settings_presence_subtitle"
-                android:textColor="@color/secondary_text"
-                android:textSize="13sp" />
+                android:layout_height="48dp"
+                android:layout_marginTop="12dp"
+                android:gravity="center_vertical"
+                android:text="@string/home_experience_new"
+                android:textColor="@color/hanyang_blue"
+                android:textSize="17sp"
+                android:textStyle="bold"
+                app:backgroundTint="@color/home_action_button_background"
+                app:icon="@drawable/ic_home"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="@color/hanyang_blue" />
         </LinearLayout>
-
-        <com.google.android.material.materialswitch.MaterialSwitch
-            android:id="@+id/show_presence_status_switch"
-            style="@style/Widget.App.Switch.Shuttle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/shuttle_quick_settings_presence_title" />
-    </LinearLayout>
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/open_home_button"
-        style="@style/Widget.Material3.Button"
-        android:layout_width="match_parent"
-        android:layout_height="52dp"
-        android:layout_marginTop="14dp"
-        android:gravity="center_vertical"
-        android:text="@string/home_experience_new"
-        android:textColor="@color/hanyang_blue"
-        android:textSize="17sp"
-        android:textStyle="bold"
-        app:backgroundTint="@color/home_action_button_background"
-        app:icon="@drawable/ic_home"
-        app:iconGravity="textStart"
-        app:iconPadding="8dp"
-        app:iconTint="@color/hanyang_blue" />
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -70,6 +70,8 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="4dp"
+                            android:ellipsize="end"
+                            android:maxLines="1"
                             android:text="@string/home_hero_subtitle"
                             android:textColor="@color/secondary_text"
                             android:textSize="14sp" />

--- a/app/src/main/res/layout/item_shuttle_connection_row.xml
+++ b/app/src/main/res/layout/item_shuttle_connection_row.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="50dp"
+    android:clipChildren="false"
+    android:clipToPadding="false">
+
+    <View
+        android:id="@+id/transfer_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_gravity="top"
+        android:layout_marginHorizontal="20dp"
+        android:background="@color/app_separator" />
+
+    <View
+        android:id="@+id/transfer_accent"
+        android:layout_width="4dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@color/subway_line4" />
+
+    <TextView
+        android:id="@+id/transfer_title"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:layout_marginStart="20dp"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:textColor="@color/subway_line4"
+        android:textFontWeight="700"
+        android:textSize="18sp" />
+
+    <TextView
+        android:id="@+id/transfer_trailing"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:layout_marginEnd="20dp"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:textColor="@color/primary_text"
+        android:textSize="18sp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/transfer_connector"
+        android:layout_width="wrap_content"
+        android:layout_height="24dp"
+        android:layout_gravity="top|center_horizontal"
+        android:translationY="-12dp"
+        app:cardBackgroundColor="@color/background"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/app_separator"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingHorizontal="8dp">
+
+            <ImageView
+                android:id="@+id/transfer_connector_icon"
+                android:layout_width="12dp"
+                android:layout_height="12dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_home_link" />
+
+            <TextView
+                android:id="@+id/transfer_connector_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:maxLines="1"
+                android:textFontWeight="700"
+                android:textSize="11sp" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+</FrameLayout>

--- a/app/src/main/res/layout/item_shuttle_realtime.xml
+++ b/app/src/main/res/layout/item_shuttle_realtime.xml
@@ -1,19 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/shuttle_item"
     android:layout_width="match_parent"
-    android:layout_height="50dp">
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/shuttle_content"
-        android:layout_width="0dp"
-        android:layout_height="50dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_width="match_parent"
+        android:layout_height="50dp">
+
+        <View
+            android:id="@+id/transfer_selection_accent"
+            android:layout_width="4dp"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/shuttle_label_group"
@@ -113,4 +121,13 @@
             app:layout_constraintTop_toTopOf="parent"
             app:tint="@color/plain_button_text" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/transfer_expansion_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:orientation="vertical"
+        android:visibility="gone" />
+</LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -33,7 +33,7 @@
     <string name="home_weather_range_subtitle">%1$.0f°C–%2$.0f°C today</string>
     <string name="home_weather_precipitation_amount_subtitle">Now %1$.0f°C · %2$.1f mm in the last hour</string>
     <string name="home_weather_confidence_low">Forecast may change</string>
-    <string name="home_weather_attribution">Forecast by Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">Move now</string>
     <string name="home_movement_detail">Shuttle details</string>
     <string name="home_movement_timetable">Full timetable</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -145,6 +145,17 @@
     <string name="shuttle_quick_settings_departure_time_subtitle">Show shuttle times by departure time.</string>
     <string name="shuttle_quick_settings_presence_title">Show fellow viewers</string>
     <string name="shuttle_quick_settings_presence_subtitle">Show how many people are viewing the same stop information.</string>
+    <string name="shuttle_quick_settings_section_display">Shuttle display</string>
+    <string name="shuttle_quick_settings_section_connections">Transfers &amp; alternatives</string>
+    <string name="shuttle_quick_settings_order_title">By Destination / Time</string>
+    <string name="shuttle_quick_settings_time_title">Remaining / Departure Time</string>
+    <string name="shuttle_quick_settings_subway_destination_title">Subway destination</string>
+    <string name="shuttle_quick_settings_alternative_title">Show alternatives</string>
+    <string name="shuttle_quick_settings_alternative_subtitle">Auto shows alternatives when the next shuttle is at least 20 minutes away.</string>
+    <string name="shuttle_quick_settings_alternative_mode_automatic">Auto</string>
+    <string name="shuttle_quick_settings_alternative_mode_always">Always</string>
+    <string name="shuttle_quick_settings_alternative_mode_hidden">Hide</string>
+    <string name="shuttle_connection_transfer_format">Transfer at %1$s</string>
     <string name="shuttle_presence_viewer_count">Viewing together: %1$d</string>
     <string name="shuttle_display_order_title">Display order</string>
     <string name="shuttle_display_order_subtitle">Organize shuttle arrivals by time or destination.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -32,7 +32,7 @@
     <string name="home_weather_range_subtitle">今日 %1$.0f°C〜%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">現在 %1$.0f°C・直近1時間 %2$.1f mm</string>
     <string name="home_weather_confidence_low">予報が変わる可能性があります</string>
-    <string name="home_weather_attribution">予報：Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">今すぐ移動</string>
     <string name="home_movement_detail">シャトル詳細</string>
     <string name="home_movement_timetable">全時刻表</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -141,6 +141,17 @@
     <string name="shuttle_quick_settings_departure_time_subtitle">出発時刻でシャトル時刻を表示します。</string>
     <string name="shuttle_quick_settings_presence_title">一緒に見ている人を表示</string>
     <string name="shuttle_quick_settings_presence_subtitle">同じ停留所の情報を見ている人数を表示します。</string>
+    <string name="shuttle_quick_settings_section_display">シャトル表示</string>
+    <string name="shuttle_quick_settings_section_connections">乗り換え・代替手段</string>
+    <string name="shuttle_quick_settings_order_title">目的地/時間順</string>
+    <string name="shuttle_quick_settings_time_title">残り時間/出発時間</string>
+    <string name="shuttle_quick_settings_subway_destination_title">電車の行き先</string>
+    <string name="shuttle_quick_settings_alternative_title">代替手段を表示</string>
+    <string name="shuttle_quick_settings_alternative_subtitle">自動では次のシャトルまで20分以上の場合に表示します。</string>
+    <string name="shuttle_quick_settings_alternative_mode_automatic">自動</string>
+    <string name="shuttle_quick_settings_alternative_mode_always">常に</string>
+    <string name="shuttle_quick_settings_alternative_mode_hidden">非表示</string>
+    <string name="shuttle_connection_transfer_format">%1$sで乗り換え</string>
     <string name="shuttle_presence_viewer_count">%1$d人が一緒に閲覧中</string>
     <string name="shuttle_display_order_title">表示順</string>
     <string name="shuttle_display_order_subtitle">シャトル到着を時間順または行先別に整理します。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -32,7 +32,7 @@
     <string name="home_weather_range_subtitle">今日 %1$.0f°C～%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">当前 %1$.0f°C · 近1小时 %2$.1f毫米</string>
     <string name="home_weather_confidence_low">预报可能会变化</string>
-    <string name="home_weather_attribution">预报由 Open-Meteo 提供</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">现在出发</string>
     <string name="home_movement_detail">校车详情</string>
     <string name="home_movement_timetable">完整时刻表</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -141,6 +141,17 @@
     <string name="shuttle_quick_settings_departure_time_subtitle">按发车时间显示校车时刻。</string>
     <string name="shuttle_quick_settings_presence_title">显示同时查看的人</string>
     <string name="shuttle_quick_settings_presence_subtitle">显示正在查看同一站点信息的人数。</string>
+    <string name="shuttle_quick_settings_section_display">校车显示</string>
+    <string name="shuttle_quick_settings_section_connections">换乘与替代交通</string>
+    <string name="shuttle_quick_settings_order_title">按目的地/时间排序</string>
+    <string name="shuttle_quick_settings_time_title">剩余时间/出发时间</string>
+    <string name="shuttle_quick_settings_subway_destination_title">地铁目的地</string>
+    <string name="shuttle_quick_settings_alternative_title">显示替代交通</string>
+    <string name="shuttle_quick_settings_alternative_subtitle">自动模式会在距下一班校车至少20分钟时显示。</string>
+    <string name="shuttle_quick_settings_alternative_mode_automatic">自动</string>
+    <string name="shuttle_quick_settings_alternative_mode_always">始终</string>
+    <string name="shuttle_quick_settings_alternative_mode_hidden">隐藏</string>
+    <string name="shuttle_connection_transfer_format">在%1$s换乘</string>
     <string name="shuttle_presence_viewer_count">%1$d人同时查看</string>
     <string name="shuttle_display_order_title">显示顺序</string>
     <string name="shuttle_display_order_subtitle">按时间或目的地整理校车到达信息。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="home_weather_range_subtitle">오늘 %1$.0f°C~%2$.0f°C</string>
     <string name="home_weather_precipitation_amount_subtitle">현재 %1$.0f°C · 최근 1시간 %2$.1fmm</string>
     <string name="home_weather_confidence_low">예보가 달라질 수 있어요</string>
-    <string name="home_weather_attribution">예보 Open-Meteo</string>
+    <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">지금 이동</string>
     <string name="home_movement_detail">셔틀 상세</string>
     <string name="home_movement_timetable">전체 시간표</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,17 @@
     <string name="shuttle_quick_settings_departure_time_subtitle">셔틀 시간을 출발 시각 기준으로 보여줘요.</string>
     <string name="shuttle_quick_settings_presence_title">함께 보는 사람 표시</string>
     <string name="shuttle_quick_settings_presence_subtitle">현재 같은 정류장 정보를 보고 있는 사람 수를 표시해요.</string>
+    <string name="shuttle_quick_settings_section_display">셔틀 표시</string>
+    <string name="shuttle_quick_settings_section_connections">환승·대체 수단</string>
+    <string name="shuttle_quick_settings_order_title">목적지/시간 순서</string>
+    <string name="shuttle_quick_settings_time_title">남은 시간/출발 시간</string>
+    <string name="shuttle_quick_settings_subway_destination_title">전철 행선지</string>
+    <string name="shuttle_quick_settings_alternative_title">대체 수단 표시</string>
+    <string name="shuttle_quick_settings_alternative_subtitle">자동은 다음 셔틀까지 20분 이상일 때 표시해요.</string>
+    <string name="shuttle_quick_settings_alternative_mode_automatic">자동</string>
+    <string name="shuttle_quick_settings_alternative_mode_always">항상</string>
+    <string name="shuttle_quick_settings_alternative_mode_hidden">숨김</string>
+    <string name="shuttle_connection_transfer_format">%1$s 환승</string>
     <string name="shuttle_presence_viewer_count">%1$d명이 함께 보는 중</string>
     <string name="shuttle_display_order_title">표시 순서</string>
     <string name="shuttle_display_order_subtitle">셔틀 도착 정보를 시간순 또는 행선지별로 정리해요.</string>

--- a/app/src/test/java/app/kobuggi/hyuabot/ui/shuttle/initialstop/ShuttleInitialStopResolverTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/ui/shuttle/initialstop/ShuttleInitialStopResolverTest.kt
@@ -1,0 +1,98 @@
+package app.kobuggi.hyuabot.ui.shuttle.initialstop
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShuttleInitialStopResolverTest {
+    @Test
+    fun `returns highest-priority matching rule`() {
+        val rules =
+            listOf(
+                rule(sequence = 2, stopName = "station", priority = 10),
+                rule(sequence = 1, stopName = "dormitory_o", priority = 20),
+            )
+
+        assertEquals(
+            "dormitory_o",
+            ShuttleInitialStopResolver.resolve(latitude = 37.5, longitude = 126.5, rules = rules),
+        )
+    }
+
+    @Test
+    fun `uses sequence as tie breaker`() {
+        val rules =
+            listOf(
+                rule(sequence = 2, stopName = "station", priority = 10),
+                rule(sequence = 1, stopName = "terminal", priority = 10),
+            )
+
+        assertEquals(
+            "terminal",
+            ShuttleInitialStopResolver.resolve(latitude = 37.5, longitude = 126.5, rules = rules),
+        )
+    }
+
+    @Test
+    fun `treats polygon boundary as inside`() {
+        assertTrue(
+            ShuttleInitialStopResolver.contains(
+                ShuttleGeoCoordinate(latitude = 37.0, longitude = 126.5),
+                square(),
+            ),
+        )
+    }
+
+    @Test
+    fun `returns null outside every rule or for invalid input`() {
+        assertNull(
+            ShuttleInitialStopResolver.resolve(
+                latitude = 38.0,
+                longitude = 128.0,
+                rules = listOf(rule(sequence = 1, stopName = "station", priority = 10)),
+            ),
+        )
+        assertNull(
+            ShuttleInitialStopResolver.resolve(
+                latitude = Double.NaN,
+                longitude = 126.5,
+                rules = listOf(rule(sequence = 1, stopName = "station", priority = 10)),
+            ),
+        )
+        assertNull(
+            ShuttleInitialStopResolver.resolve(
+                latitude = 37.5,
+                longitude = 126.5,
+                rules =
+                    listOf(
+                        ShuttleInitialStopRuleCandidate(
+                            sequence = 1,
+                            stopName = "station",
+                            priority = 10,
+                            polygon = square().take(2),
+                        ),
+                    ),
+            ),
+        )
+    }
+
+    private fun rule(
+        sequence: Int,
+        stopName: String,
+        priority: Int,
+    ) = ShuttleInitialStopRuleCandidate(
+        sequence = sequence,
+        stopName = stopName,
+        priority = priority,
+        polygon = square(),
+    )
+
+    private fun square() =
+        listOf(
+            ShuttleGeoCoordinate(latitude = 37.0, longitude = 126.0),
+            ShuttleGeoCoordinate(latitude = 37.0, longitude = 127.0),
+            ShuttleGeoCoordinate(latitude = 38.0, longitude = 127.0),
+            ShuttleGeoCoordinate(latitude = 38.0, longitude = 126.0),
+        )
+}


### PR DESCRIPTION
## Changes

### 셔틀 환승 연결

- 실시간 셔틀 행에서 목적지별 환승 경로와 도착 정보를 펼쳐 확인하도록 개선
- 10-1번·50번 등 대체 버스 표시 모드와 빠른 설정 추가
- 환승 시간, 남은 정류장, 연결 구간을 홈과 셔틀 화면에 일관되게 표시

### 초기 정류장

- 학기·계절학기·방학, 평일·주말·휴일, 시간대에 따라 활성화된 초기 정류장 규칙 조회
- 현재 위치가 Geofence 다각형 내부일 때 우선순위와 순서에 따라 초기 정류장 선택
- 일치하는 규칙이 없으면 기존 가까운 정류장으로 fallback
- 사용자가 직접 선택한 정류장과 딥 링크 이동 우선순위 유지

### 날씨 출처·다국어

- 홈 날씨 출처 링크와 터치 영역 보완
- 환승 연결 UI의 한국어, 영어, 일본어, 중국어 문구 반영
- 확장된 셔틀 GraphQL 스키마와 쿼리 반영

### Release

- 앱 버전을 5.2.0으로 업데이트

## Checks

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:testDevDebugUnitTest`
- [x] `./gradlew :app:koverVerifyDevDebug`
