### PR TITLE
fix: Target Android 15 on Wear OS

### DIFF
--- a/watch/build.gradle.kts
+++ b/watch/build.gradle.kts
@@ -28,12 +28,21 @@ android {
     namespace = "app.kobuggi.hyuabot"
     compileSdk = 37
 
+    signingConfigs {
+        create("config") {
+            storeFile = file(props["SIGNING_KEY_FILE"]?.toString() ?: "keystore.jks")
+            storePassword = props["SIGNED_STORE_PASSWORD"]?.toString() ?: "storePassword"
+            keyAlias = props["SIGNED_KEY_ALIAS"]?.toString() ?: "keyAlias"
+            keyPassword = props["SIGNED_KEY_PASSWORD"]?.toString() ?: "keyPassword"
+        }
+    }
+
     defaultConfig {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 33
-        targetSdk = 34
-        versionCode = 500100000
-        versionName = "5.0.0"
+        targetSdk = 35
+        versionCode = 519100000
+        versionName = "5.1.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     }
@@ -45,7 +54,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("config")
         }
     }
 


### PR DESCRIPTION
## Changes

### Wear OS compatibility

- Update the Wear OS target SDK from Android 14 (API 34) to Android 15 (API 35)
- Keep the existing compile SDK and minimum SDK configuration

### Release and signing

- Update the Wear OS app version from 5.0.0 to 5.1.9
- Sign Wear OS release bundles with the production signing configuration instead of the debug key
- Keep the Wear OS release certificate aligned with the Android app release certificate

## Checks

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :watch:bundleProductionRelease`
- [x] Verified the Wear OS and Android app production bundles use the same signing certificate SHA-256 fingerprint
