### PR TITLE
fix: Align cafeteria default meal tab with home schedule

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/cafeteria/CafeteriaFragment.kt
@@ -23,6 +23,7 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -111,7 +112,14 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
             "breakfast" -> 0
             "lunch" -> 1
             "dinner" -> 2
-            else -> defaultMealTab(viewModel.date.value ?: LocalDateTime.now())
+            else -> {
+                val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                // 20시 이후에는 홈 화면과 동일하게 내일 조식으로 진입한다.
+                if (now.hour >= 20) {
+                    viewModel.date.value = now.plusDays(1)
+                }
+                defaultMealTab(now)
+            }
         }
         binding.viewPager.setCurrentItem(initialTab, false)
         showCoachmarkOnce(userPreferencesRepository, Coachmarks.CAFETERIA) {
@@ -147,10 +155,11 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
         else -> "lunch" to (viewModel.lunch.value ?: emptyList())
     }
 
-    private fun defaultMealTab(dateTime: LocalDateTime): Int = when (dateTime.hour) {
-        in 0..10 -> 0
-        in 11..16 -> 1
-        else -> 2
+    // 홈 화면(HomeFragment.automaticMealPeriod)과 동일한 시각 경계로 조식/중식/석식을 선택한다.
+    private fun defaultMealTab(dateTime: LocalDateTime): Int = when {
+        dateTime.hour < 10 || dateTime.hour >= 20 -> 0 // 조식
+        dateTime.hour < 15 -> 1 // 중식
+        else -> 2 // 석식
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Changes

### Cafeteria screen

- Align the cafeteria default meal tab with the home screen schedule when entering directly (bottom navigation / deep link without a `tab` argument)
- Previously `defaultMealTab` used different hour boundaries (`0..10` breakfast, `11..16` lunch) than the home screen's `automaticMealPeriod`, so 10:00–10:59 defaulted to breakfast and 20:00+ never rolled over to the next day
- Match the home boundaries: before 10:00 breakfast, before 15:00 lunch, before 20:00 dinner, 20:00 and later next-day breakfast
- After 20:00 the direct-entry date now advances to the next day so it shows tomorrow's breakfast, consistent with the home card

## Checks

- Verified the hour boundaries and next-day rollover match `HomeFragment.automaticMealPeriod`
- Build/lint not run locally; relying on CI (`ktlintCheck`, build) for verification
