### PR TITLE
feat: Label cafeteria tabs as tomorrow's meals when auto-rolled

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/cafeteria/CafeteriaFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/cafeteria/CafeteriaFragment.kt
@@ -33,6 +33,7 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentCafeteriaBinding.inflate(layoutInflater) }
     private val viewModel: CafeteriaViewModel by viewModels()
     private val args: CafeteriaFragmentArgs by navArgs()
+    private var showingAutomaticTomorrow = false
 
     @Inject
     lateinit var userPreferencesRepository: UserPreferencesRepository
@@ -59,6 +60,7 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
             .build()
         datePicker.addOnPositiveButtonClickListener {
             AnalyticsManager.logSelect(AnalyticsItem.CAFETERIA_DATE_CHANGED, type = AnalyticsContentType.DATE_CONTROL)
+            clearAutomaticTomorrowIfNeeded()
             viewModel.date.value = LocalDateTime.ofEpochSecond(it / 1000, 0, ZoneOffset.ofHours(9))
         }
 
@@ -92,8 +94,8 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
                 datePicker.show(childFragmentManager, "CafeteriaDatePicker")
             }
         }
-        binding.prevButton.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.CAFETERIA_PREVIOUS_DATE, type = AnalyticsContentType.DATE_CONTROL); viewModel.date.value = viewModel.date.value?.minusDays(1) }
-        binding.nextButton.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.CAFETERIA_NEXT_DATE, type = AnalyticsContentType.DATE_CONTROL); viewModel.date.value = viewModel.date.value?.plusDays(1) }
+        binding.prevButton.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.CAFETERIA_PREVIOUS_DATE, type = AnalyticsContentType.DATE_CONTROL); clearAutomaticTomorrowIfNeeded(); viewModel.date.value = viewModel.date.value?.minusDays(1) }
+        binding.nextButton.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.CAFETERIA_NEXT_DATE, type = AnalyticsContentType.DATE_CONTROL); clearAutomaticTomorrowIfNeeded(); viewModel.date.value = viewModel.date.value?.plusDays(1) }
         binding.shareCafeteriaButton.setOnClickListener {
             val (mealType, menus) = currentMealMenus()
             if (menus.isEmpty()) return@setOnClickListener
@@ -117,11 +119,16 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
                 // 20시 이후에는 홈 화면과 동일하게 내일 조식으로 진입한다.
                 if (now.hour >= 20) {
                     viewModel.date.value = now.plusDays(1)
+                    showingAutomaticTomorrow = true
                 }
                 defaultMealTab(now)
             }
         }
         binding.viewPager.setCurrentItem(initialTab, false)
+        // 자동으로 내일 식단으로 넘어간 경우에만 탭 제목을 "내일 조식/중식/석식"으로 표시한다.
+        if (showingAutomaticTomorrow) {
+            updateMealTabTitles(tomorrow = true)
+        }
         showCoachmarkOnce(userPreferencesRepository, Coachmarks.CAFETERIA) {
             listOf(
                 CoachmarkStep(
@@ -160,6 +167,29 @@ class CafeteriaFragment @Inject constructor() : Fragment() {
         dateTime.hour < 10 || dateTime.hour >= 20 -> 0 // 조식
         dateTime.hour < 15 -> 1 // 중식
         else -> 2 // 석식
+    }
+
+    // 자동으로 내일 식단으로 넘어간 경우에만 탭 제목을 "내일 조식/중식/석식"으로 표시한다.
+    // 접두어 포맷(cafeteria_tab_tomorrow_format)은 언어별로 정의되며, 탭이 길어지는
+    // 영어는 접두어 없이("%1$s") 기본 제목을 그대로 사용한다.
+    private fun updateMealTabTitles(tomorrow: Boolean) {
+        val labels = listOf(
+            R.string.cafeteria_tab_breakfast,
+            R.string.cafeteria_tab_lunch,
+            R.string.cafeteria_tab_dinner
+        )
+        for (i in labels.indices) {
+            val base = getString(labels[i])
+            val text = if (tomorrow) getString(R.string.cafeteria_tab_tomorrow_format, base) else base
+            binding.tabLayout.getTabAt(i)?.text = text
+        }
+    }
+
+    // 사용자가 날짜를 직접 변경하면 자동 "내일" 표시를 해제하고 기본 탭 제목으로 되돌린다.
+    private fun clearAutomaticTomorrowIfNeeded() {
+        if (!showingAutomaticTomorrow) return
+        showingAutomaticTomorrow = false
+        updateMealTabTitles(tomorrow = false)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -385,6 +385,7 @@
     <string name="subway_timetable_title_suin_down">Suin Line (Incheon)</string>
     <string name="subway_timetable_time_format">%1$s:%2$s</string>
     <string name="cafeteria">Cafeteria</string>
+    <string name="cafeteria_tab_tomorrow_format">%1$s</string>
     <string name="cafeteria_tab_breakfast">Breakfast</string>
     <string name="cafeteria_tab_lunch">Lunch</string>
     <string name="cafeteria_tab_dinner">Dinner</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -362,6 +362,7 @@
     <string name="subway_timetable_title_suin_down">水仁線 (仁川)</string>
     <string name="subway_timetable_time_format">%1$s時%2$s分</string>
     <string name="cafeteria">学食</string>
+    <string name="cafeteria_tab_tomorrow_format">明日の%1$s</string>
     <string name="cafeteria_tab_breakfast">朝食</string>
     <string name="cafeteria_tab_lunch">昼食</string>
     <string name="cafeteria_tab_dinner">夕食</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -362,6 +362,7 @@
     <string name="subway_timetable_title_suin_down">水仁线 (仁川)</string>
     <string name="subway_timetable_time_format">%1$s时%2$s分</string>
     <string name="cafeteria">学生食堂</string>
+    <string name="cafeteria_tab_tomorrow_format">明天%1$s</string>
     <string name="cafeteria_tab_breakfast">早餐</string>
     <string name="cafeteria_tab_lunch">午餐</string>
     <string name="cafeteria_tab_dinner">晚餐</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -439,6 +439,7 @@
     <string name="subway_timetable_time_format">%1$s시 %2$s분</string>
     <!-- 학식 -->
     <string name="cafeteria">학식</string>
+    <string name="cafeteria_tab_tomorrow_format">내일 %1$s</string>
     <string name="cafeteria_tab_breakfast">조식</string>
     <string name="cafeteria_tab_lunch">중식</string>
     <string name="cafeteria_tab_dinner">석식</string>


### PR DESCRIPTION
## Changes

### Cafeteria screen

- When the screen automatically rolls over to tomorrow's meals (direct entry after 20:00), prefix the tab titles with the "tomorrow" label (e.g. "내일 조식 / 내일 중식 / 내일 석식")
- Reset to the plain titles (Breakfast / Lunch / Dinner) as soon as the user changes the date (previous / next / date picker)
- Handle the prefix with a dedicated string resource `cafeteria_tab_tomorrow_format`. Because the three tabs split the screen width, **English keeps the plain title ("%1$s", no prefix)** to avoid overflow; Korean ("내일 %1$s"), Japanese ("明日の%1$s") and Chinese ("明天%1$s") show the prefix
- The tomorrow state is computed only at first entry / external navigation and the tabs are refreshed only on state transitions

## Checks

- Verified the tomorrow/plain transition and the per-language prefix resources
- Build/lint not run locally; relying on CI (`ktlintCheck`, build, unit tests) for verification
