### PR TITLE
feat: Replace KakaoTalk inquiry link with in-app chat

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/service/InquiryService.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/InquiryService.kt
@@ -1,0 +1,171 @@
+package app.kobuggi.hyuabot.service
+
+import android.content.Context
+import app.kobuggi.hyuabot.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class InquiryThread(
+    val id: String,
+    val status: String,
+    val subject: String?,
+    val entryScreen: String?,
+    val entryScreenName: String?,
+    val lastMessageAt: String?,
+    val createdAt: String?,
+)
+
+data class InquiryMessage(
+    val id: Long,
+    val senderType: String,
+    val body: String,
+    val readAt: String?,
+    val createdAt: String?,
+)
+
+@Singleton
+class InquiryService @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val client = OkHttpClient.Builder()
+        .callTimeout(10, TimeUnit.SECONDS)
+        .build()
+    private val installationId = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE).let { preferences ->
+        preferences.getString(SESSION_ID_KEY, null) ?: UUID.randomUUID().toString().lowercase().also {
+            preferences.edit().putString(SESSION_ID_KEY, it).apply()
+        }
+    }
+
+    private fun Request.Builder.withCommonHeaders(): Request.Builder = this
+        .header("X-Installation-Id", installationId)
+        .header("X-App-Platform", "android")
+        .header("X-App-Version", BuildConfig.VERSION_NAME)
+        .header("Content-Type", "application/json")
+
+    private fun parseThread(json: JSONObject): InquiryThread = InquiryThread(
+        id = json.getString("id"),
+        status = json.optString("status"),
+        subject = json.optStringOrNull("subject"),
+        entryScreen = json.optStringOrNull("entryScreen"),
+        entryScreenName = json.optStringOrNull("entryScreenName"),
+        lastMessageAt = json.optStringOrNull("lastMessageAt"),
+        createdAt = json.optStringOrNull("createdAt"),
+    )
+
+    private fun parseMessage(json: JSONObject): InquiryMessage = InquiryMessage(
+        id = json.getLong("id"),
+        senderType = json.optString("senderType"),
+        body = json.optString("body"),
+        readAt = json.optStringOrNull("readAt"),
+        createdAt = json.optStringOrNull("createdAt"),
+    )
+
+    suspend fun openThread(
+        subject: String?,
+        entryScreen: String?,
+        entryScreenName: String?,
+    ): InquiryThread? = withContext(Dispatchers.IO) {
+        runCatching {
+            val payload = JSONObject()
+                .put("subject", subject ?: JSONObject.NULL)
+                .put("entryScreen", entryScreen ?: JSONObject.NULL)
+                .put("entryScreenName", entryScreenName ?: JSONObject.NULL)
+                .toString()
+                .toRequestBody(JSON_MEDIA_TYPE)
+            val request = Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/inquiry/threads")
+                .withCommonHeaders()
+                .post(payload)
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val json = response.body.string().let(::JSONObject)
+                parseThread(json.optJSONObject("result") ?: json)
+            }
+        }.getOrNull()
+    }
+
+    suspend fun activeThread(): InquiryThread? = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/inquiry/threads/me")
+                .withCommonHeaders()
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (response.code == 204 || !response.isSuccessful) return@use null
+                val json = response.body.string().let(::JSONObject)
+                parseThread(json.optJSONObject("result") ?: json)
+            }
+        }.getOrNull()
+    }
+
+    suspend fun messages(threadId: String): List<InquiryMessage> = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/inquiry/threads/$threadId/messages")
+                .withCommonHeaders()
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use emptyList()
+                val json = response.body.string().let(::JSONObject)
+                val array = json.optJSONArray("result") ?: JSONArray()
+                (0 until array.length()).map { parseMessage(array.getJSONObject(it)) }
+            }
+        }.getOrElse { emptyList() }
+    }
+
+    suspend fun send(threadId: String, body: String): InquiryMessage? = withContext(Dispatchers.IO) {
+        runCatching {
+            val payload = JSONObject()
+                .put("body", body)
+                .toString()
+                .toRequestBody(JSON_MEDIA_TYPE)
+            val request = Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/inquiry/threads/$threadId/messages")
+                .withCommonHeaders()
+                .post(payload)
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val json = response.body.string().let(::JSONObject)
+                parseMessage(json.optJSONObject("result") ?: json)
+            }
+        }.getOrNull()
+    }
+
+    suspend fun markRead(threadId: String) {
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val payload = "{}".toRequestBody(JSON_MEDIA_TYPE)
+                val request = Request.Builder()
+                    .url("${BuildConfig.API_URL}/api/v1/inquiry/threads/$threadId/read")
+                    .withCommonHeaders()
+                    .post(payload)
+                    .build()
+                client.newCall(request).execute().use { }
+            }
+        }
+    }
+
+    private fun JSONObject.optStringOrNull(key: String): String? =
+        if (isNull(key) || !has(key)) null else optString(key)
+
+    private companion object {
+        const val PREFERENCES_NAME = "shuttle_presence"
+        const val SESSION_ID_KEY = "anonymous_installation_id"
+        val JSON_MEDIA_TYPE = "application/json".toMediaType()
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
@@ -1,0 +1,128 @@
+package app.kobuggi.hyuabot.ui.inquiry
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.databinding.FragmentInquiryChatBinding
+import app.kobuggi.hyuabot.service.InquiryMessage
+import app.kobuggi.hyuabot.service.InquiryService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class InquiryChatFragment @Inject constructor() : Fragment() {
+    private val binding by lazy { FragmentInquiryChatBinding.inflate(layoutInflater) }
+    private val messageAdapter = InquiryMessageAdapter(emptyList())
+
+    @Inject
+    lateinit var inquiryService: InquiryService
+
+    private var threadId: String? = null
+    private var lastMessages: List<InquiryMessage> = emptyList()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding.inquiryMessageList.apply {
+            adapter = messageAdapter
+            layoutManager = LinearLayoutManager(requireContext()).apply { stackFromEnd = true }
+        }
+        binding.inquirySendButton.setOnClickListener { sendMessage() }
+        binding.inquiryInput.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEND) {
+                sendMessage()
+                true
+            } else {
+                false
+            }
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val thread = inquiryService.activeThread()
+                ?: inquiryService.openThread(
+                    subject = null,
+                    entryScreen = "menu",
+                    entryScreenName = getString(R.string.menu_chat),
+                )
+            if (thread == null) {
+                showLoadFailed()
+                return@launch
+            }
+            threadId = thread.id
+            refreshMessages(markRead = true)
+            pollMessages()
+        }
+    }
+
+    private suspend fun pollMessages() {
+        val currentThreadId = threadId ?: return
+        while (viewLifecycleOwner.lifecycleScope.isActive) {
+            delay(POLL_INTERVAL_MS)
+            val previousAdminCount = lastMessages.count { it.senderType == "ADMIN" }
+            val updated = inquiryService.messages(currentThreadId)
+            applyMessages(updated)
+            val newAdminCount = updated.count { it.senderType == "ADMIN" }
+            if (newAdminCount > previousAdminCount) {
+                inquiryService.markRead(currentThreadId)
+            }
+        }
+    }
+
+    private suspend fun refreshMessages(markRead: Boolean) {
+        val currentThreadId = threadId ?: return
+        val updated = inquiryService.messages(currentThreadId)
+        applyMessages(updated)
+        if (markRead) {
+            inquiryService.markRead(currentThreadId)
+        }
+    }
+
+    private fun applyMessages(messages: List<InquiryMessage>) {
+        lastMessages = messages
+        messageAdapter.updateData(messages)
+        binding.inquiryEmptyView.visibility = if (messages.isEmpty()) View.VISIBLE else View.GONE
+        if (messages.isNotEmpty()) {
+            binding.inquiryMessageList.scrollToPosition(messages.size - 1)
+        }
+    }
+
+    private fun sendMessage() {
+        val currentThreadId = threadId ?: return
+        val text = binding.inquiryInput.text?.toString()?.trim().orEmpty()
+        if (text.isEmpty()) return
+        binding.inquiryInput.text?.clear()
+        viewLifecycleOwner.lifecycleScope.launch {
+            val sent = inquiryService.send(currentThreadId, text)
+            if (sent == null) {
+                showLoadFailed()
+            } else {
+                refreshMessages(markRead = false)
+            }
+        }
+    }
+
+    private fun showLoadFailed() {
+        if (!isAdded) return
+        Toast.makeText(requireContext(), R.string.inquiry_load_failed, Toast.LENGTH_SHORT).show()
+    }
+
+    private companion object {
+        const val POLL_INTERVAL_MS = 4000L
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryMessageAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryMessageAdapter.kt
@@ -1,0 +1,99 @@
+package app.kobuggi.hyuabot.ui.inquiry
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import app.kobuggi.hyuabot.databinding.ItemInquiryMessageAdminBinding
+import app.kobuggi.hyuabot.databinding.ItemInquiryMessageSystemBinding
+import app.kobuggi.hyuabot.databinding.ItemInquiryMessageUserBinding
+import app.kobuggi.hyuabot.service.InquiryMessage
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+class InquiryMessageAdapter(
+    private var messages: List<InquiryMessage>,
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    inner class UserViewHolder(private val binding: ItemInquiryMessageUserBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(message: InquiryMessage) {
+            binding.inquiryMessageBody.text = message.body
+            bindTime(binding.inquiryMessageTime, message.createdAt)
+        }
+    }
+
+    inner class AdminViewHolder(private val binding: ItemInquiryMessageAdminBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(message: InquiryMessage) {
+            binding.inquiryMessageBody.text = message.body
+            bindTime(binding.inquiryMessageTime, message.createdAt)
+            binding.inquiryMessageRead.visibility =
+                if (message.readAt.isNullOrBlank()) android.view.View.GONE else android.view.View.VISIBLE
+        }
+    }
+
+    inner class SystemViewHolder(private val binding: ItemInquiryMessageSystemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(message: InquiryMessage) {
+            binding.inquiryMessageBody.text = message.body
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int = when (messages[position].senderType) {
+        "USER" -> TYPE_USER
+        "ADMIN" -> TYPE_ADMIN
+        else -> TYPE_SYSTEM
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_USER -> UserViewHolder(ItemInquiryMessageUserBinding.inflate(inflater, parent, false))
+            TYPE_ADMIN -> AdminViewHolder(ItemInquiryMessageAdminBinding.inflate(inflater, parent, false))
+            else -> SystemViewHolder(ItemInquiryMessageSystemBinding.inflate(inflater, parent, false))
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val message = messages[position]
+        when (holder) {
+            is UserViewHolder -> holder.bind(message)
+            is AdminViewHolder -> holder.bind(message)
+            is SystemViewHolder -> holder.bind(message)
+        }
+    }
+
+    override fun getItemCount(): Int = messages.size
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateData(newMessages: List<InquiryMessage>) {
+        messages = newMessages
+        notifyDataSetChanged()
+    }
+
+    private fun bindTime(view: android.widget.TextView, raw: String?) {
+        val formatted = formatTime(raw)
+        if (formatted == null) {
+            view.visibility = android.view.View.GONE
+        } else {
+            view.visibility = android.view.View.VISIBLE
+            view.text = formatted
+        }
+    }
+
+    private fun formatTime(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        val cleaned = raw.substringBefore('[')
+        return runCatching {
+            OffsetDateTime.parse(cleaned).format(TIME_FORMATTER)
+        }.getOrNull()
+    }
+
+    private companion object {
+        const val TYPE_USER = 0
+        const val TYPE_ADMIN = 1
+        const val TYPE_SYSTEM = 2
+        val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/menu/MenuFragment.kt
@@ -152,8 +152,7 @@ class MenuFragment @Inject constructor() : Fragment() {
                 }
             }
             R.string.menu_chat -> {
-                val url = "https://open.kakao.com/o/sW2kAinb"
-                MenuFragmentDirections.actionMenuFragmentToNoticeWebViewFragment(url).also {
+                MenuFragmentDirections.actionMenuFragmentToInquiryChatFragment().also {
                     findNavController().safeNavigate(it)
                 }
             }

--- a/app/src/main/res/drawable/bg_inquiry_bubble_admin.xml
+++ b/app/src/main/res/drawable/bg_inquiry_bubble_admin.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/inquiry_bubble_admin" />
+    <corners
+        android:topLeftRadius="16dp"
+        android:topRightRadius="16dp"
+        android:bottomLeftRadius="4dp"
+        android:bottomRightRadius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_inquiry_bubble_user.xml
+++ b/app/src/main/res/drawable/bg_inquiry_bubble_user.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/inquiry_bubble_user" />
+    <corners
+        android:topLeftRadius="16dp"
+        android:topRightRadius="16dp"
+        android:bottomLeftRadius="16dp"
+        android:bottomRightRadius="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_inquiry_chat.xml
+++ b/app/src/main/res/layout/fragment_inquiry_chat.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/inquiry_message_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="12dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:stackFromEnd="true" />
+
+        <TextView
+            android:id="@+id/inquiry_empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:paddingHorizontal="32dp"
+            android:gravity="center"
+            android:text="@string/inquiry_empty"
+            android:textColor="@color/secondary_text"
+            android:textSize="15sp"
+            android:visibility="gone" />
+    </FrameLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/app_separator" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp"
+        android:paddingVertical="8dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/inquiry_input_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/inquiry_input_hint"
+            app:boxCornerRadiusBottomEnd="20dp"
+            app:boxCornerRadiusBottomStart="20dp"
+            app:boxCornerRadiusTopEnd="20dp"
+            app:boxCornerRadiusTopStart="20dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/inquiry_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionSend"
+                android:inputType="textMultiLine|textCapSentences"
+                android:maxLines="4"
+                android:textColor="@color/primary_text"
+                android:textSize="15sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/inquiry_send_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginStart="8dp"
+            android:layout_marginBottom="4dp"
+            android:text="@string/inquiry_send" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_inquiry_message_admin.xml
+++ b/app/src/main/res/layout/item_inquiry_message_admin.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="start"
+    android:orientation="vertical"
+    android:paddingVertical="4dp">
+
+    <TextView
+        android:id="@+id/inquiry_message_body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="48dp"
+        android:background="@drawable/bg_inquiry_bubble_admin"
+        android:paddingHorizontal="14dp"
+        android:paddingVertical="10dp"
+        android:textColor="@color/primary_text"
+        android:textSize="15sp" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/inquiry_message_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/tertiary_text"
+            android:textSize="11sp" />
+
+        <TextView
+            android:id="@+id/inquiry_message_read"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="6dp"
+            android:text="@string/inquiry_read"
+            android:textColor="@color/tertiary_text"
+            android:textSize="11sp"
+            android:visibility="gone" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_inquiry_message_system.xml
+++ b/app/src/main/res/layout/item_inquiry_message_system.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingVertical="6dp">
+
+    <TextView
+        android:id="@+id/inquiry_message_body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:gravity="center"
+        android:textColor="@color/secondary_text"
+        android:textSize="12sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_inquiry_message_user.xml
+++ b/app/src/main/res/layout/item_inquiry_message_user.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="end"
+    android:orientation="vertical"
+    android:paddingVertical="4dp">
+
+    <TextView
+        android:id="@+id/inquiry_message_body"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="48dp"
+        android:background="@drawable/bg_inquiry_bubble_user"
+        android:paddingHorizontal="14dp"
+        android:paddingVertical="10dp"
+        android:textColor="@color/inquiry_bubble_user_text"
+        android:textSize="15sp" />
+
+    <TextView
+        android:id="@+id/inquiry_message_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textColor="@color/tertiary_text"
+        android:textSize="11sp" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -231,6 +231,14 @@
         <deepLink app:uri="https://hyuabot.app/calendar" />
     </fragment>
     <fragment
+        android:id="@+id/inquiryChatFragment"
+        android:name="app.kobuggi.hyuabot.ui.inquiry.InquiryChatFragment"
+        android:label="@string/inquiry_title"
+        tools:layout="@layout/fragment_inquiry_chat">
+        <deepLink app:uri="hyuabot://inquiry" />
+        <deepLink app:uri="https://hyuabot.app/inquiry" />
+    </fragment>
+    <fragment
         android:id="@+id/menuFragment"
         android:name="app.kobuggi.hyuabot.ui.menu.MenuFragment"
         android:label="@string/tabbar_campus"
@@ -255,6 +263,9 @@
         <action
             android:id="@+id/action_menuFragment_to_noticeWebViewFragment"
             app:destination="@id/noticeWebViewFragment" />
+        <action
+            android:id="@+id/action_menuFragment_to_inquiryChatFragment"
+            app:destination="@id/inquiryChatFragment" />
     </fragment>
     <dialog
         android:id="@+id/shuttleStopDialogFragment"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -468,6 +468,12 @@
     <string name="menu_settings">Settings</string>
     <string name="menu_chat">Inquiries</string>
     <string name="menu_donate">Donate</string>
+    <string name="inquiry_title">Inquiries</string>
+    <string name="inquiry_input_hint">Type a message</string>
+    <string name="inquiry_send">Send</string>
+    <string name="inquiry_empty">No messages yet. Feel free to leave your question.</string>
+    <string name="inquiry_read">Read</string>
+    <string name="inquiry_load_failed">Failed to load the conversation.</string>
     <string name="menu_review">Rate this App</string>
     <string name="menu_section_school_life">School life</string>
     <string name="menu_section_support">Support and settings</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -445,6 +445,12 @@
     <string name="menu_settings">設定</string>
     <string name="menu_chat">お問い合わせ</string>
     <string name="menu_donate">寄付する</string>
+    <string name="inquiry_title">お問い合わせ</string>
+    <string name="inquiry_input_hint">メッセージを入力してください</string>
+    <string name="inquiry_send">送信</string>
+    <string name="inquiry_empty">まだ会話がありません。ご質問をお気軽にどうぞ。</string>
+    <string name="inquiry_read">既読</string>
+    <string name="inquiry_load_failed">会話を読み込めませんでした。</string>
     <string name="menu_review">アプリ評価</string>
     <string name="menu_section_school_life">学校生活</string>
     <string name="menu_section_support">サポート・設定</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -54,4 +54,7 @@
     <color name="widget_accent">#FFFFFF</color>
     <color name="widget_accent_on">#000000</color>
     <color name="widget_divider">#99545458</color>
+    <color name="inquiry_bubble_user">#0E4A84</color>
+    <color name="inquiry_bubble_user_text">#FFFFFF</color>
+    <color name="inquiry_bubble_admin">#2C2C2E</color>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -445,6 +445,12 @@
     <string name="menu_settings">设置</string>
     <string name="menu_chat">联系我们</string>
     <string name="menu_donate">捐赠</string>
+    <string name="inquiry_title">联系我们</string>
+    <string name="inquiry_input_hint">请输入消息</string>
+    <string name="inquiry_send">发送</string>
+    <string name="inquiry_empty">还没有对话。欢迎留下您的问题。</string>
+    <string name="inquiry_read">已读</string>
+    <string name="inquiry_load_failed">无法加载对话。</string>
     <string name="menu_review">评价应用</string>
     <string name="menu_section_school_life">校园生活</string>
     <string name="menu_section_support">支持与设置</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -79,4 +79,7 @@
     <color name="widget_accent">#0E4A84</color>
     <color name="widget_accent_on">#FFFFFF</color>
     <color name="widget_divider">#493C3C43</color>
+    <color name="inquiry_bubble_user">#0E4A84</color>
+    <color name="inquiry_bubble_user_text">#FFFFFF</color>
+    <color name="inquiry_bubble_admin">#F2F2F7</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -524,6 +524,12 @@
     <string name="menu_settings">설정</string>
     <string name="menu_chat">문의하기</string>
     <string name="menu_donate">기부하기</string>
+    <string name="inquiry_title">문의하기</string>
+    <string name="inquiry_input_hint">메시지를 입력하세요</string>
+    <string name="inquiry_send">전송</string>
+    <string name="inquiry_empty">아직 대화가 없습니다. 궁금한 점을 남겨주세요.</string>
+    <string name="inquiry_read">읽음</string>
+    <string name="inquiry_load_failed">대화를 불러오지 못했습니다.</string>
     <string name="menu_review">앱 평가하기</string>
     <string name="menu_section_school_life">학교생활</string>
     <string name="menu_section_support">지원 및 설정</string>


### PR DESCRIPTION
## Changes

### 문의하기

- 문의하기 진입점을 카카오톡 오픈채팅 웹뷰에서 **인앱 문의 채팅 화면**으로 교체 (`MenuFragment`의 `menu_chat` → `InquiryChatFragment`). 기부하기(카카오페이)는 유지.
- `InquiryChatFragment`: 사용자/관리자/시스템 메시지(RecyclerView, 대문자 senderType 분기), 하단 입력(Material `TextInputLayout` + 전송/IME actionSend), 4초 폴링, 새 관리자 답변 도착 시 읽음 처리, 빈 상태/실패 안내.
- `InquiryService`(OkHttp): 스레드 열기/조회, 메시지 조회/전송, 읽음 처리. 익명 식별자는 기존 SharedPreferences(`shuttle_presence`/`anonymous_installation_id`)를 재사용해 `X-Installation-Id` 헤더로 전송.
- 진입 시 활성 스레드가 있으면 이어가고, 없으면 생성(진입 화면 전달).

### 리소스/현지화

- 말풍선 색상 3종을 `values/colors.xml`·`values-night/colors.xml`(다크모드) 양쪽에 추가, 말풍선 배경 drawable.
- `inquiry_title` / `inquiry_input_hint` / `inquiry_send` / `inquiry_empty` / `inquiry_read` / `inquiry_load_failed` 를 ko/en/ja/zh 4개 언어로 추가.
- `nav_graph`에 `inquiryChatFragment` 목적지 + `menuFragment` 액션 추가(SafeArgs).

## Checks

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew :app:assembleDevDebug` (SafeArgs·Hilt 컴파일 확인)
- [x] `./gradlew testDevDebugUnitTest` (기존 테스트 유지)
