### PR TITLE
feat: Improve inquiry chat experience

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 520000000
-        versionName = "5.2.0"
+        versionCode = 521000000
+        versionName = "5.2.1"
         signingConfig = signingConfigs.getByName("config")
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/service/InquiryService.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/InquiryService.kt
@@ -8,7 +8,10 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -34,12 +37,19 @@ data class InquiryMessage(
     val createdAt: String?,
 )
 
+data class InquiryStreamEvent(
+    val threadId: String?,
+)
+
 @Singleton
 class InquiryService @Inject constructor(
     @ApplicationContext context: Context,
 ) {
     private val client = OkHttpClient.Builder()
         .callTimeout(10, TimeUnit.SECONDS)
+        .build()
+    private val streamClient = OkHttpClient.Builder()
+        .readTimeout(0, TimeUnit.MILLISECONDS)
         .build()
     private val installationId = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE).let { preferences ->
         preferences.getString(SESSION_ID_KEY, null) ?: UUID.randomUUID().toString().lowercase().also {
@@ -52,6 +62,46 @@ class InquiryService @Inject constructor(
         .header("X-App-Platform", "android")
         .header("X-App-Version", BuildConfig.VERSION_NAME)
         .header("Content-Type", "application/json")
+
+    suspend fun streamEvents(onEvent: (InquiryStreamEvent) -> Unit) = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url("${BuildConfig.API_URL}/api/v1/inquiry/stream")
+            .withCommonHeaders()
+            .get()
+            .build()
+        val call = streamClient.newCall(request)
+        coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
+        call.execute().use { response ->
+            if (!response.isSuccessful) return@withContext
+            var eventType: String? = null
+            var data: String? = null
+            val source = response.body.source()
+            while (!source.exhausted()) {
+                coroutineContext.ensureActive()
+                val line = source.readUtf8Line() ?: break
+                when {
+                    line.startsWith("event:") -> eventType = line.removePrefix("event:").trim()
+                    line.startsWith("data:") -> data = line.removePrefix("data:").trim()
+                    line.isEmpty() -> {
+                        if (eventType == "message") {
+                            data?.let { eventData ->
+                                val payload = JSONObject(eventData)
+                                val threadId =
+                                    if (payload.has("threadId") && !payload.isNull("threadId")) {
+                                        payload.getString("threadId")
+                                    } else {
+                                        null
+                                    }
+                                onEvent(InquiryStreamEvent(threadId))
+                            }
+                        }
+                        eventType = null
+                        data = null
+                    }
+                }
+            }
+        }
+    }
 
     private fun parseThread(json: JSONObject): InquiryThread = InquiryThread(
         id = json.getString("id"),

--- a/app/src/main/java/app/kobuggi/hyuabot/service/ShuttlePresenceService.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/ShuttlePresenceService.kt
@@ -50,6 +50,27 @@ class ShuttlePresenceService @Inject constructor(
         }.getOrNull()
     }
 
+    suspend fun viewerCounts(): Map<String, Int>? = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url("${BuildConfig.API_URL}/api/v1/presence/shuttle")
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val stops = JSONObject(response.body.string()).optJSONArray("stops") ?: return@use null
+                buildMap<String, Int> {
+                    for (index in 0 until stops.length()) {
+                        val stop = stops.getJSONObject(index)
+                        if (stop.optBoolean("visible", false) && !stop.isNull("viewerCount")) {
+                            put(stop.getString("stopId"), stop.getInt("viewerCount"))
+                        }
+                    }
+                }
+            }
+        }.getOrNull()
+    }
+
     private companion object {
         const val PREFERENCES_NAME = "shuttle_presence"
         const val SESSION_ID_KEY = "anonymous_installation_id"

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeFragment.kt
@@ -101,6 +101,11 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
                 findNavController().safeNavigate(it)
             }
         }
+        binding.inquiryButton.setOnClickListener {
+            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToInquiryChatFragment().also {
+                findNavController().safeNavigate(it)
+            }
+        }
         binding.noticeViewPager.adapter = noticeAdapter
         binding.noticeViewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageScrollStateChanged(state: Int) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -164,6 +164,11 @@ class HomeFragment : Fragment() {
         binding.legacyShuttleButton.setOnClickListener {
             openQuickSettings()
         }
+        binding.inquiryButton.setOnClickListener {
+            findNavController().navigate(
+                HomeFragmentDirections.actionHomeFragmentToInquiryChatFragment(),
+            )
+        }
         setupNotices()
         childFragmentManager.setFragmentResultListener(
             HomeQuickSettingsDialog.REQUEST_KEY,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -235,6 +235,17 @@ class HomeFragment : Fragment() {
                     R.string.shuttle_presence_viewer_count,
                     viewerCount,
                 )
+                val availableSeats = viewModel.presenceAvailableSeats.value
+                val isWarning = availableSeats != null && viewerCount > availableSeats / 2
+                val isFull = availableSeats != null && viewerCount > availableSeats
+                binding.homePresencePill.setCardBackgroundColor(ContextCompat.getColor(
+                    requireContext(),
+                    if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background,
+                ))
+                binding.homePresenceCount.setTextColor(ContextCompat.getColor(
+                    requireContext(),
+                    if (isWarning) android.R.color.white else R.color.hanyang_blue,
+                ))
             } else {
                 binding.homePresencePill.contentDescription = null
             }
@@ -553,7 +564,9 @@ class HomeFragment : Fragment() {
 
     private fun render(data: HomePageQuery.Data?) {
         renderWeather(data?.homeWeather)
-        viewModel.setPresenceStop(selectedDeparture.routeTo(selectedDestination).stop)
+        selectedDeparture.routeTo(selectedDestination).let { route ->
+            viewModel.setPresenceStop(route.stop, route.destination)
+        }
         binding.movementTitle.text = getString(selectedDeparture.titleRes)
         binding.movementTitle.contentDescription = getString(
             R.string.home_departure_selector_description,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -49,9 +49,11 @@ class HomeViewModel @Inject constructor(
     private val _bus50TerminalLogTimes = MutableLiveData<List<LocalTime>>(emptyList())
     private val _showPresenceStatus = MutableLiveData(true)
     private val _presenceViewerCount = MutableLiveData<Int?>(null)
+    private val _presenceAvailableSeats = MutableLiveData<Int?>(null)
     private var isFetching = false
     private var presenceJob: Job? = null
     private var selectedPresenceStop = "dormitory_o"
+    private var selectedPresenceDestination: String? = null
     private var presencePreviewCount: Int? = null
     private var presencePreferenceLoaded = false
     private var presenceUpdatesStarted = false
@@ -66,6 +68,7 @@ class HomeViewModel @Inject constructor(
     val bus50TerminalLogTimes: LiveData<List<LocalTime>> get() = _bus50TerminalLogTimes
     val showPresenceStatus: LiveData<Boolean> get() = _showPresenceStatus
     val presenceViewerCount: LiveData<Int?> get() = _presenceViewerCount
+    val presenceAvailableSeats: LiveData<Int?> get() = _presenceAvailableSeats
 
     init {
         viewModelScope.launch {
@@ -180,9 +183,10 @@ class HomeViewModel @Inject constructor(
         if (changed || presenceJob == null) restartPresenceUpdates()
     }
 
-    fun setPresenceStop(stopId: String) {
-        if (selectedPresenceStop == stopId) return
+    fun setPresenceStop(stopId: String, destination: String) {
+        if (selectedPresenceStop == stopId && selectedPresenceDestination == destination) return
         selectedPresenceStop = stopId
+        selectedPresenceDestination = destination
         restartPresenceUpdates()
     }
 
@@ -202,6 +206,7 @@ class HomeViewModel @Inject constructor(
         presenceJob?.cancel()
         presenceJob = null
         _presenceViewerCount.value = null
+        _presenceAvailableSeats.value = null
     }
 
     private fun restartPresenceUpdates() {
@@ -215,10 +220,24 @@ class HomeViewModel @Inject constructor(
                 return@launch
             }
             while (isActive) {
+                val viewerCounts = shuttlePresenceService.viewerCounts()
+                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts)
                 _presenceViewerCount.value = shuttlePresenceService.heartbeat(selectedPresenceStop)
                 delay(PRESENCE_REFRESH_INTERVAL_MILLIS)
             }
         }
+    }
+
+    private fun estimatedAvailableSeats(viewerCounts: Map<String, Int>?): Int? {
+        val stop = _data.value?.shuttle?.stops?.firstOrNull { it.name == selectedPresenceStop } ?: return null
+        val routeStops = stop.timetable.destination.firstOrNull { it.destination == selectedPresenceDestination }
+            ?.entries?.firstOrNull()?.stops?.map { it.stop } ?: return null
+        val stopIndex = routeStops.indexOf(selectedPresenceStop)
+        if (viewerCounts == null || stopIndex < 0) return null
+        val onboard = routeStops.take(stopIndex).fold(0) { count, stopId ->
+            (if (stopId == "station") 0 else count) + viewerCounts.getOrDefault(stopId, 0)
+        }
+        return (45 - onboard).coerceAtLeast(0)
     }
 
     private fun currentSubwayWeekday(now: ZonedDateTime): String {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentInquiryChatBinding
@@ -23,6 +24,7 @@ import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class InquiryChatFragment @Inject constructor() : Fragment() {
+    private val args: InquiryChatFragmentArgs by navArgs()
     private val binding by lazy { FragmentInquiryChatBinding.inflate(layoutInflater) }
     private val messageAdapter = InquiryMessageAdapter(emptyList())
 
@@ -60,12 +62,11 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycleScope.launch {
-            val thread = inquiryService.activeThread()
-                ?: inquiryService.openThread(
-                    subject = null,
-                    entryScreen = "menu",
-                    entryScreenName = getString(R.string.menu_chat),
-                )
+            val thread = inquiryService.openThread(
+                subject = null,
+                entryScreen = args.entryScreen,
+                entryScreenName = args.entryScreenName,
+            )
             if (thread == null) {
                 showLoadFailed()
                 return@launch

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryChatFragment.kt
@@ -8,6 +8,7 @@ import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentInquiryChatBinding
@@ -15,6 +16,7 @@ import app.kobuggi.hyuabot.service.InquiryMessage
 import app.kobuggi.hyuabot.service.InquiryService
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -29,6 +31,7 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
 
     private var threadId: String? = null
     private var lastMessages: List<InquiryMessage> = emptyList()
+    private var streamJob: Job? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -40,6 +43,9 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
             layoutManager = LinearLayoutManager(requireContext()).apply { stackFromEnd = true }
         }
         binding.inquirySendButton.setOnClickListener { sendMessage() }
+        binding.inquiryToolbar.setNavigationOnClickListener {
+            findNavController().navigateUp()
+        }
         binding.inquiryInput.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEND) {
                 sendMessage()
@@ -66,7 +72,26 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
             }
             threadId = thread.id
             refreshMessages(markRead = true)
+            startStream(thread.id)
             pollMessages()
+        }
+    }
+
+    private fun startStream(currentThreadId: String) {
+        streamJob?.cancel()
+        streamJob = viewLifecycleOwner.lifecycleScope.launch {
+            while (viewLifecycleOwner.lifecycleScope.isActive) {
+                try {
+                    inquiryService.streamEvents { event ->
+                        if (event.threadId == currentThreadId) {
+                            viewLifecycleOwner.lifecycleScope.launch { refreshMessages(markRead = true) }
+                        }
+                    }
+                } catch (_: Exception) {
+                    // The polling fallback keeps the conversation current while SSE reconnects.
+                }
+                delay(STREAM_RECONNECT_DELAY_MS)
+            }
         }
     }
 
@@ -97,8 +122,8 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
         lastMessages = messages
         messageAdapter.updateData(messages)
         binding.inquiryEmptyView.visibility = if (messages.isEmpty()) View.VISIBLE else View.GONE
-        if (messages.isNotEmpty()) {
-            binding.inquiryMessageList.scrollToPosition(messages.size - 1)
+        if (messageAdapter.itemCount > 0) {
+            binding.inquiryMessageList.scrollToPosition(messageAdapter.itemCount - 1)
         }
     }
 
@@ -123,6 +148,7 @@ class InquiryChatFragment @Inject constructor() : Fragment() {
     }
 
     private companion object {
-        const val POLL_INTERVAL_MS = 4000L
+        const val POLL_INTERVAL_MS = 30_000L
+        const val STREAM_RECONNECT_DELAY_MS = 1_000L
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryMessageAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/inquiry/InquiryMessageAdapter.kt
@@ -5,15 +5,23 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import app.kobuggi.hyuabot.databinding.ItemInquiryMessageAdminBinding
+import app.kobuggi.hyuabot.databinding.ItemInquiryMessageDateHeaderBinding
 import app.kobuggi.hyuabot.databinding.ItemInquiryMessageSystemBinding
 import app.kobuggi.hyuabot.databinding.ItemInquiryMessageUserBinding
 import app.kobuggi.hyuabot.service.InquiryMessage
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class InquiryMessageAdapter(
-    private var messages: List<InquiryMessage>,
+    messages: List<InquiryMessage>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private var items = buildItems(messages)
+
+    private sealed interface Item {
+        data class DateHeader(val label: String) : Item
+        data class Message(val value: InquiryMessage) : Item
+    }
 
     inner class UserViewHolder(private val binding: ItemInquiryMessageUserBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -40,10 +48,20 @@ class InquiryMessageAdapter(
         }
     }
 
-    override fun getItemViewType(position: Int): Int = when (messages[position].senderType) {
-        "USER" -> TYPE_USER
-        "ADMIN" -> TYPE_ADMIN
-        else -> TYPE_SYSTEM
+    private inner class DateHeaderViewHolder(private val binding: ItemInquiryMessageDateHeaderBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(header: Item.DateHeader) {
+            binding.inquiryDateHeader.text = header.label
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int = when (val item = items[position]) {
+        is Item.DateHeader -> TYPE_DATE_HEADER
+        is Item.Message -> when (item.value.senderType) {
+            "USER" -> TYPE_USER
+            "ADMIN" -> TYPE_ADMIN
+            else -> TYPE_SYSTEM
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -51,25 +69,43 @@ class InquiryMessageAdapter(
         return when (viewType) {
             TYPE_USER -> UserViewHolder(ItemInquiryMessageUserBinding.inflate(inflater, parent, false))
             TYPE_ADMIN -> AdminViewHolder(ItemInquiryMessageAdminBinding.inflate(inflater, parent, false))
-            else -> SystemViewHolder(ItemInquiryMessageSystemBinding.inflate(inflater, parent, false))
+            TYPE_SYSTEM -> SystemViewHolder(ItemInquiryMessageSystemBinding.inflate(inflater, parent, false))
+            else -> DateHeaderViewHolder(ItemInquiryMessageDateHeaderBinding.inflate(inflater, parent, false))
         }
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val message = messages[position]
-        when (holder) {
-            is UserViewHolder -> holder.bind(message)
-            is AdminViewHolder -> holder.bind(message)
-            is SystemViewHolder -> holder.bind(message)
+        when (val item = items[position]) {
+            is Item.DateHeader -> (holder as DateHeaderViewHolder).bind(item)
+            is Item.Message -> when (holder) {
+                is UserViewHolder -> holder.bind(item.value)
+                is AdminViewHolder -> holder.bind(item.value)
+                is SystemViewHolder -> holder.bind(item.value)
+                else -> Unit
+            }
         }
     }
 
-    override fun getItemCount(): Int = messages.size
+    override fun getItemCount(): Int = items.size
 
     @SuppressLint("NotifyDataSetChanged")
     fun updateData(newMessages: List<InquiryMessage>) {
-        messages = newMessages
+        items = buildItems(newMessages)
         notifyDataSetChanged()
+    }
+
+    private fun buildItems(messages: List<InquiryMessage>): List<Item> {
+        val result = mutableListOf<Item>()
+        var previousDateLabel: String? = null
+        messages.forEach { message ->
+            val dateLabel = formatDate(message.createdAt)
+            if (dateLabel != null && dateLabel != previousDateLabel) {
+                result += Item.DateHeader(dateLabel)
+                previousDateLabel = dateLabel
+            }
+            result += Item.Message(message)
+        }
+        return result
     }
 
     private fun bindTime(view: android.widget.TextView, raw: String?) {
@@ -90,10 +126,21 @@ class InquiryMessageAdapter(
         }.getOrNull()
     }
 
+    private fun formatDate(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        val cleaned = raw.substringBefore('[')
+        return runCatching {
+            OffsetDateTime.parse(cleaned).format(DATE_FORMATTER)
+        }.getOrNull()
+    }
+
     private companion object {
         const val TYPE_USER = 0
         const val TYPE_ADMIN = 1
         const val TYPE_SYSTEM = 2
+        const val TYPE_DATE_HEADER = 3
         val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+        val DATE_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("M월 d일 EEEE", Locale.KOREAN)
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -116,6 +116,11 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
                 ?.let(viewModel::setPresencePreviewCount)
         }
         binding.shuttleQuickSettingsButton.setOnClickListener { openQuickSettings() }
+        binding.inquiryButton.setOnClickListener {
+            findNavController().navigate(
+                ShuttleRealtimeFragmentDirections.actionShuttleRealtimeFragmentToInquiryChatFragment(),
+            )
+        }
         childFragmentManager.setFragmentResultListener(
             ShuttleQuickSettingsDialog.REQUEST_KEY,
             viewLifecycleOwner,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -20,6 +20,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.kobuggi.hyuabot.BuildConfig
 import app.kobuggi.hyuabot.R
@@ -230,6 +231,17 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
                     R.string.shuttle_presence_viewer_count,
                     viewerCount,
                 )
+                val availableSeats = viewModel.presenceAvailableSeats.value
+                val isWarning = availableSeats != null && viewerCount > availableSeats / 2
+                val isFull = availableSeats != null && viewerCount > availableSeats
+                binding.shuttlePresencePill.setCardBackgroundColor(ContextCompat.getColor(
+                    requireContext(),
+                    if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background,
+                ))
+                binding.shuttlePresenceCount.setTextColor(ContextCompat.getColor(
+                    requireContext(),
+                    if (isWarning) android.R.color.white else R.color.hanyang_blue,
+                ))
             } else {
                 binding.shuttlePresencePill.contentDescription = null
             }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -67,6 +67,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private val _subwayTransferDestination = MutableLiveData(HomeSubwayTransferDestination.SEOUL)
     private val _alternativeDisplayMode = MutableLiveData(ShuttleAlternativeDisplayMode.AUTOMATIC)
     private val _presenceViewerCount = MutableLiveData<Int?>(null)
+    private val _presenceAvailableSeats = MutableLiveData<Int?>(null)
     private var presenceJob: Job? = null
     private var selectedPresenceStop = PRESENCE_STOP_IDS.first()
     private var presencePreviewCount: Int? = null
@@ -97,6 +98,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     val subwayTransferDestination get() = _subwayTransferDestination
     val alternativeDisplayMode get() = _alternativeDisplayMode
     val presenceViewerCount get() = _presenceViewerCount
+    val presenceAvailableSeats get() = _presenceAvailableSeats
 
     init {
         viewModelScope.launch {
@@ -336,6 +338,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
         presenceJob?.cancel()
         presenceJob = null
         _presenceViewerCount.value = null
+        _presenceAvailableSeats.value = null
         if (!isStarted || !presencePreferenceLoaded || _showPresenceStatus.value != true) return
         presenceJob = viewModelScope.launch {
             presencePreviewCount?.let {
@@ -343,6 +346,8 @@ class ShuttleRealtimeViewModel @Inject constructor(
                 return@launch
             }
             while (isActive) {
+                val viewerCounts = shuttlePresenceService.viewerCounts()
+                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts)
                 _presenceViewerCount.value = shuttlePresenceService.heartbeat(selectedPresenceStop)
                 delay(30_000)
             }
@@ -354,7 +359,19 @@ class ShuttleRealtimeViewModel @Inject constructor(
         presenceJob?.cancel()
         presenceJob = null
         _presenceViewerCount.value = null
+        _presenceAvailableSeats.value = null
         _disposable.clear()
+    }
+
+    private fun estimatedAvailableSeats(viewerCounts: Map<String, Int>?): Int? {
+        val stop = _result.value?.firstOrNull { it.name == selectedPresenceStop } ?: return null
+        val routeStops = stop.timetable.order.firstOrNull()?.stops?.map { it.stop } ?: return null
+        val stopIndex = routeStops.indexOf(selectedPresenceStop)
+        if (viewerCounts == null || stopIndex < 0) return null
+        val onboard = routeStops.take(stopIndex).fold(0) { count, stopId ->
+            (if (stopId == "station") 0 else count) + viewerCounts.getOrDefault(stopId, 0)
+        }
+        return (45 - onboard).coerceAtLeast(0)
     }
 
     override fun onCleared() {

--- a/app/src/main/res/layout/fragment_bus_realtime.xml
+++ b/app/src/main/res/layout/fragment_bus_realtime.xml
@@ -89,6 +89,25 @@
             android:textStyle="bold" />
 
         <com.google.android.material.button.MaterialButton
+            android:id="@+id/inquiry_button"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:layout_marginEnd="8dp"
+            android:minHeight="36dp"
+            android:paddingHorizontal="12dp"
+            android:text="@string/inquiry_short"
+            android:textColor="@color/hanyang_blue"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:backgroundTint="@color/home_action_button_background"
+            app:icon="@drawable/ic_chat"
+            app:iconGravity="textStart"
+            app:iconPadding="6dp"
+            app:iconSize="16dp"
+            app:iconTint="@color/hanyang_blue" />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/help_button"
             style="@style/Widget.Material3.Button"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -370,8 +370,30 @@
         android:textSize="13sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/home_action_bar"
-        app:layout_constraintEnd_toStartOf="@id/legacy_shuttle_button"
+        app:layout_constraintEnd_toStartOf="@id/inquiry_button"
         app:layout_constraintStart_toStartOf="@id/home_action_bar"
+        app:layout_constraintTop_toTopOf="@id/home_action_bar" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/inquiry_button"
+        style="@style/Widget.Material3.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="40dp"
+        android:layout_marginEnd="8dp"
+        android:minHeight="36dp"
+        android:paddingHorizontal="12dp"
+        android:text="@string/inquiry_short"
+        android:textColor="@color/hanyang_blue"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:backgroundTint="@color/home_action_button_background"
+        app:icon="@drawable/ic_chat"
+        app:iconGravity="textStart"
+        app:iconPadding="6dp"
+        app:iconSize="16dp"
+        app:iconTint="@color/hanyang_blue"
+        app:layout_constraintBottom_toBottomOf="@id/home_action_bar"
+        app:layout_constraintEnd_toStartOf="@id/legacy_shuttle_button"
         app:layout_constraintTop_toTopOf="@id/home_action_bar" />
 
     <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/fragment_inquiry_chat.xml
+++ b/app/src/main/res/layout/fragment_inquiry_chat.xml
@@ -6,6 +6,17 @@
     android:background="@color/background"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/inquiry_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:background="@color/hanyang_blue"
+        app:navigationIcon="@drawable/ic_arrow_back"
+        app:navigationIconTint="@android:color/white"
+        app:title="@string/inquiry_title"
+        app:titleTextColor="@android:color/white"
+        app:titleCentered="true" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -42,7 +53,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="bottom"
+        android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingHorizontal="12dp"
         android:paddingVertical="8dp">
@@ -51,7 +62,7 @@
             android:id="@+id/inquiry_input_layout"
             style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="56dp"
             android:layout_weight="1"
             android:hint="@string/inquiry_input_hint"
             app:boxCornerRadiusBottomEnd="20dp"
@@ -62,7 +73,8 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/inquiry_input"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
                 android:imeOptions="actionSend"
                 android:inputType="textMultiLine|textCapSentences"
                 android:maxLines="4"
@@ -72,11 +84,12 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/inquiry_send_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
+            android:layout_width="64dp"
+            android:layout_height="56dp"
+            android:layout_gravity="center_vertical"
             android:layout_marginStart="8dp"
-            android:layout_marginBottom="4dp"
+            android:minWidth="0dp"
+            android:paddingHorizontal="8dp"
             android:text="@string/inquiry_send" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_shuttle_realtime.xml
+++ b/app/src/main/res/layout/fragment_shuttle_realtime.xml
@@ -90,6 +90,25 @@
             android:textStyle="bold" />
 
         <com.google.android.material.button.MaterialButton
+            android:id="@+id/inquiry_button"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:layout_marginEnd="8dp"
+            android:minHeight="36dp"
+            android:paddingHorizontal="12dp"
+            android:text="@string/inquiry_short"
+            android:textColor="@color/hanyang_blue"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:backgroundTint="@color/home_action_button_background"
+            app:icon="@drawable/ic_chat"
+            app:iconGravity="textStart"
+            app:iconPadding="6dp"
+            app:iconSize="16dp"
+            app:iconTint="@color/hanyang_blue" />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/shuttle_quick_settings_button"
             style="@style/Widget.Material3.Button"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_inquiry_message_date_header.xml
+++ b/app/src/main/res/layout/item_inquiry_message_date_header.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/inquiry_date_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:paddingTop="16dp"
+    android:paddingBottom="8dp"
+    android:textColor="@color/tertiary_text"
+    android:textSize="12sp" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -23,6 +23,18 @@
         <action
             android:id="@+id/action_homeFragment_to_noticeWebViewFragment"
             app:destination="@id/noticeWebViewFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_inquiryChatFragment"
+            app:destination="@id/inquiryChatFragment">
+            <argument
+                android:name="entryScreen"
+                android:defaultValue="home"
+                app:argType="string" />
+            <argument
+                android:name="entryScreenName"
+                android:defaultValue="홈"
+                app:argType="string" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/shuttleRealtimeFragment"
@@ -55,6 +67,18 @@
         <action
             android:id="@+id/action_shuttleRealtimeFragment_to_noticeWebViewFragment"
             app:destination="@id/noticeWebViewFragment" />
+        <action
+            android:id="@+id/action_shuttleRealtimeFragment_to_inquiryChatFragment"
+            app:destination="@id/inquiryChatFragment">
+            <argument
+                android:name="entryScreen"
+                android:defaultValue="shuttle"
+                app:argType="string" />
+            <argument
+                android:name="entryScreenName"
+                android:defaultValue="셔틀"
+                app:argType="string" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/shuttleTimetableFragment"
@@ -95,6 +119,18 @@
         <action
             android:id="@+id/action_busRealtimeFragment_to_busStopInfoFragment"
             app:destination="@id/busStopInfoFragment" />
+        <action
+            android:id="@+id/action_busRealtimeFragment_to_inquiryChatFragment"
+            app:destination="@id/inquiryChatFragment">
+            <argument
+                android:name="entryScreen"
+                android:defaultValue="bus"
+                app:argType="string" />
+            <argument
+                android:name="entryScreenName"
+                android:defaultValue="버스"
+                app:argType="string" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/busTimetableFragment"
@@ -235,6 +271,14 @@
         android:name="app.kobuggi.hyuabot.ui.inquiry.InquiryChatFragment"
         android:label="@string/inquiry_title"
         tools:layout="@layout/fragment_inquiry_chat">
+        <argument
+            android:name="entryScreen"
+            android:defaultValue="campus"
+            app:argType="string" />
+        <argument
+            android:name="entryScreenName"
+            android:defaultValue="캠퍼스"
+            app:argType="string" />
         <deepLink app:uri="hyuabot://inquiry" />
         <deepLink app:uri="https://hyuabot.app/inquiry" />
     </fragment>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -41,8 +41,8 @@
     <string name="home_destination_summary">Toward %1$s</string>
     <string name="home_cafeteria_detail">All menus</string>
     <string name="home_quick_settings_action_bar_title">Adjust what appears on Home</string>
-    <string name="home_quick_settings_button">Home options</string>
-    <string name="home_quick_settings_title">Home options</string>
+    <string name="home_quick_settings_button">Settings</string>
+    <string name="home_quick_settings_title">Settings</string>
     <string name="home_quick_settings_legacy_title">Previous shuttle screen</string>
     <string name="home_quick_settings_legacy_subtitle">Check full arrivals and timetables.</string>
     <string name="home_quick_settings_legacy_button">Previous shuttle screen</string>
@@ -139,8 +139,8 @@
     <string name="shuttle_footer_stop_info">Location &amp; First/Last</string>
     <string name="shuttle_footer_help">Shuttle Help</string>
     <string name="shuttle_action_bar_title">Shuttle display options</string>
-    <string name="shuttle_quick_settings_button">Quick settings</string>
-    <string name="shuttle_quick_settings_title">Shuttle quick settings</string>
+    <string name="shuttle_quick_settings_button">Settings</string>
+    <string name="shuttle_quick_settings_title">Settings</string>
     <string name="shuttle_quick_settings_arrival_by_time_subtitle">Show shuttle arrivals by remaining time.</string>
     <string name="shuttle_quick_settings_departure_time_subtitle">Show shuttle times by departure time.</string>
     <string name="shuttle_quick_settings_presence_title">Show fellow viewers</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -469,6 +469,7 @@
     <string name="menu_chat">Inquiries</string>
     <string name="menu_donate">Donate</string>
     <string name="inquiry_title">Inquiries</string>
+    <string name="inquiry_short">Inquiry</string>
     <string name="inquiry_input_hint">Type a message</string>
     <string name="inquiry_send">Send</string>
     <string name="inquiry_empty">No messages yet. Feel free to leave your question.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -446,6 +446,7 @@
     <string name="menu_chat">お問い合わせ</string>
     <string name="menu_donate">寄付する</string>
     <string name="inquiry_title">お問い合わせ</string>
+    <string name="inquiry_short">問い合わせ</string>
     <string name="inquiry_input_hint">メッセージを入力してください</string>
     <string name="inquiry_send">送信</string>
     <string name="inquiry_empty">まだ会話がありません。ご質問をお気軽にどうぞ。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -40,8 +40,8 @@
     <string name="home_destination_summary">%1$s方面</string>
     <string name="home_cafeteria_detail">全ての学食</string>
     <string name="home_quick_settings_action_bar_title">ホームの表示を調整できます</string>
-    <string name="home_quick_settings_button">ホーム設定</string>
-    <string name="home_quick_settings_title">ホーム設定</string>
+    <string name="home_quick_settings_button">設定</string>
+    <string name="home_quick_settings_title">設定</string>
     <string name="home_quick_settings_legacy_title">以前のシャトル画面</string>
     <string name="home_quick_settings_legacy_subtitle">到着情報と時刻表を確認します。</string>
     <string name="home_quick_settings_legacy_button">以前のシャトル画面</string>
@@ -135,8 +135,8 @@
     <string name="shuttle_footer_stop_info">停留所位置 &amp; 始発/終発</string>
     <string name="shuttle_footer_help">ヘルプ</string>
     <string name="shuttle_action_bar_title">シャトル表示オプション</string>
-    <string name="shuttle_quick_settings_button">簡単設定</string>
-    <string name="shuttle_quick_settings_title">シャトル簡単設定</string>
+    <string name="shuttle_quick_settings_button">設定</string>
+    <string name="shuttle_quick_settings_title">設定</string>
     <string name="shuttle_quick_settings_arrival_by_time_subtitle">残り時間でシャトル到着を表示します。</string>
     <string name="shuttle_quick_settings_departure_time_subtitle">出発時刻でシャトル時刻を表示します。</string>
     <string name="shuttle_quick_settings_presence_title">一緒に見ている人を表示</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -446,6 +446,7 @@
     <string name="menu_chat">联系我们</string>
     <string name="menu_donate">捐赠</string>
     <string name="inquiry_title">联系我们</string>
+    <string name="inquiry_short">咨询</string>
     <string name="inquiry_input_hint">请输入消息</string>
     <string name="inquiry_send">发送</string>
     <string name="inquiry_empty">还没有对话。欢迎留下您的问题。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -40,8 +40,8 @@
     <string name="home_destination_summary">前往%1$s</string>
     <string name="home_cafeteria_detail">全部食堂</string>
     <string name="home_quick_settings_action_bar_title">调整首页显示内容</string>
-    <string name="home_quick_settings_button">首页选项</string>
-    <string name="home_quick_settings_title">首页选项</string>
+    <string name="home_quick_settings_button">设置</string>
+    <string name="home_quick_settings_title">设置</string>
     <string name="home_quick_settings_legacy_title">旧版校车页面</string>
     <string name="home_quick_settings_legacy_subtitle">查看完整到达信息和时刻表。</string>
     <string name="home_quick_settings_legacy_button">旧版校车页面</string>
@@ -135,8 +135,8 @@
     <string name="shuttle_footer_stop_info">站点位置 &amp; 首/末班车</string>
     <string name="shuttle_footer_help">帮助</string>
     <string name="shuttle_action_bar_title">校车显示选项</string>
-    <string name="shuttle_quick_settings_button">快速设置</string>
-    <string name="shuttle_quick_settings_title">校车快速设置</string>
+    <string name="shuttle_quick_settings_button">设置</string>
+    <string name="shuttle_quick_settings_title">设置</string>
     <string name="shuttle_quick_settings_arrival_by_time_subtitle">按剩余时间显示校车到达信息。</string>
     <string name="shuttle_quick_settings_departure_time_subtitle">按发车时间显示校车时刻。</string>
     <string name="shuttle_quick_settings_presence_title">显示同时查看的人</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,8 @@
     <string name="home_destination_summary">%1$s 방면</string>
     <string name="home_cafeteria_detail">전체 학식</string>
     <string name="home_quick_settings_action_bar_title">홈에 보일 내용을 조정해요</string>
-    <string name="home_quick_settings_button">홈 옵션</string>
-    <string name="home_quick_settings_title">홈 옵션</string>
+    <string name="home_quick_settings_button">설정</string>
+    <string name="home_quick_settings_title">설정</string>
     <string name="home_quick_settings_legacy_title">기존 셔틀 화면</string>
     <string name="home_quick_settings_legacy_subtitle">전체 도착 정보와 시간표를 확인합니다.</string>
     <string name="home_quick_settings_legacy_button">기존 셔틀 화면</string>
@@ -139,8 +139,8 @@
     <string name="shuttle_footer_stop_info">정류장 위치 &amp; 첫차/막차</string>
     <string name="shuttle_footer_help">셔틀버스 도움말</string>
     <string name="shuttle_action_bar_title">셔틀 표시 옵션</string>
-    <string name="shuttle_quick_settings_button">빠른 설정</string>
-    <string name="shuttle_quick_settings_title">셔틀 빠른 설정</string>
+    <string name="shuttle_quick_settings_button">설정</string>
+    <string name="shuttle_quick_settings_title">설정</string>
     <string name="shuttle_quick_settings_arrival_by_time_subtitle">셔틀 도착 정보를 남은 시간 기준으로 보여줘요.</string>
     <string name="shuttle_quick_settings_departure_time_subtitle">셔틀 시간을 출발 시각 기준으로 보여줘요.</string>
     <string name="shuttle_quick_settings_presence_title">함께 보는 사람 표시</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="menu_chat">문의하기</string>
     <string name="menu_donate">기부하기</string>
     <string name="inquiry_title">문의하기</string>
+    <string name="inquiry_short">문의</string>
     <string name="inquiry_input_hint">메시지를 입력하세요</string>
     <string name="inquiry_send">전송</string>
     <string name="inquiry_empty">아직 대화가 없습니다. 궁금한 점을 남겨주세요.</string>


### PR DESCRIPTION
## Changes

### 문의하기

- 서버 전송 이벤트(SSE)로 현재 문의 스레드의 새 메시지를 즉시 갱신하고, 연결이 끊긴 경우에는 30초 폴링을 fallback으로 유지합니다.
- 메시지를 날짜별로 구분하고 전송 시각을 표시하며, 말풍선·입력 영역·전송 버튼을 정리합니다.
- 홈·버스 실시간·셔틀 실시간 화면에서 문의하기로 진입할 때 출처 화면 정보를 전달합니다.

### 셔틀·홈

- 셔틀 혼잡도를 잔여 좌석 수에 따라 색상으로 표시합니다.
- 홈 및 셔틀 설정 명칭을 정리합니다.

### Release

- 앱 버전을 5.2.1로 업데이트합니다.

## Checks

- CI 실행 대기 중