### PR TITLE
fix: Refine home and shuttle controls

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.FloatingWindow
 import androidx.navigation.NavController
+import androidx.navigation.navOptions
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.onNavDestinationSelected
@@ -64,6 +65,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     }
     private val analyticsScreenDispatcher = AnalyticsScreenDispatcher {
         AnalyticsManager.logScreen(it, it.id)
+    }
+    private val homeExperiencePreferences by lazy {
+        getSharedPreferences(HOME_EXPERIENCE_PREFERENCES, MODE_PRIVATE)
     }
 
     @Inject
@@ -103,7 +107,14 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         openBirthDayDialog()
         requestInAppReview()
         syncShuttleServiceNotices()
-        navController.handleDeepLink(intent)
+        val handledDeepLink = navController.handleDeepLink(intent)
+        if (
+            savedInstanceState == null &&
+            !handledDeepLink &&
+            !homeExperiencePreferences.getBoolean(HOME_EXPERIENCE_ENABLED, true)
+        ) {
+            showLegacyShuttleAsRoot()
+        }
     }
 
     private fun setupTopAppBar() {
@@ -274,8 +285,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         val busItem = binding.bottomNavigation.menu.findItem(R.id.busRealtimeFragment)
         val subwayItem = binding.bottomNavigation.menu.findItem(R.id.subwayRealtimeFragment)
         val moreItem = binding.bottomNavigation.menu.findItem(R.id.menuFragment)
-        primaryItem.title = getString(R.string.home)
-        primaryItem.setIcon(R.drawable.ic_home)
+        val showsLegacyShuttle = !homeExperiencePreferences.getBoolean(HOME_EXPERIENCE_ENABLED, true)
+        primaryItem.title = getString(if (showsLegacyShuttle) R.string.shuttle_bus else R.string.home)
+        primaryItem.setIcon(if (showsLegacyShuttle) R.drawable.ic_bus else R.drawable.ic_home)
         when {
             destinationId == R.id.homeFragment || destinationId.isShuttleDestination() ->
                 primaryItem.isChecked = true
@@ -447,10 +459,42 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.homeFragment) {
+            if (!homeExperiencePreferences.getBoolean(HOME_EXPERIENCE_ENABLED, true)) {
+                showLegacyShuttleAsRoot()
+                return true
+            }
+        }
         tabItemForDestination(item.itemId)?.let {
             AnalyticsManager.logSelect(it, AnalyticsContentType.TAB)
         }
         return item.onNavDestinationSelected(navController)
+    }
+
+    fun showLegacyShuttleAsRoot() {
+        homeExperiencePreferences.edit { putBoolean(HOME_EXPERIENCE_ENABLED, false) }
+        navController.navigate(
+            R.id.shuttleRealtimeFragment,
+            null,
+            navOptions {
+                popUpTo(R.id.homeFragment) { inclusive = true }
+                launchSingleTop = true
+            },
+        )
+        updatePrimaryNavigationItem(navController.currentDestination?.id)
+    }
+
+    fun showHomeExperienceAsRoot() {
+        homeExperiencePreferences.edit { putBoolean(HOME_EXPERIENCE_ENABLED, true) }
+        navController.navigate(
+            R.id.homeFragment,
+            null,
+            navOptions {
+                popUpTo(R.id.shuttleRealtimeFragment) { inclusive = true }
+                launchSingleTop = true
+            },
+        )
+        updatePrimaryNavigationItem(navController.currentDestination?.id)
     }
 
     /** Maps a nav-graph destination id to its analytics screen (null = not tracked as a screen). */
@@ -538,6 +582,8 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     }
 
     companion object {
+        const val HOME_EXPERIENCE_PREFERENCES = "home_experience"
+        const val HOME_EXPERIENCE_ENABLED = "enabled"
         private const val STATUS_BAR_BACKGROUND_TAG = "status_bar_background"
         private const val LOCATION_PERMISSION_REQUEST_CODE = 1
         private const val BACKGROUND_LOCATION_PERMISSION_REQUEST_CODE = 2

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -49,6 +49,7 @@ import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentHomeBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeRowBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeTransferRowBinding
+import app.kobuggi.hyuabot.ui.MainActivity
 import app.kobuggi.hyuabot.util.AnalyticsContentType
 import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
@@ -164,11 +165,6 @@ class HomeFragment : Fragment() {
         binding.legacyShuttleButton.setOnClickListener {
             openQuickSettings()
         }
-        binding.inquiryButton.setOnClickListener {
-            findNavController().navigate(
-                HomeFragmentDirections.actionHomeFragmentToInquiryChatFragment(),
-            )
-        }
         setupNotices()
         childFragmentManager.setFragmentResultListener(
             HomeQuickSettingsDialog.REQUEST_KEY,
@@ -176,7 +172,12 @@ class HomeFragment : Fragment() {
         ) { _, result ->
             if (result.getBoolean(HomeQuickSettingsDialog.KEY_OPEN_LEGACY_SHUTTLE, false)) {
                 AnalyticsManager.logSelect(AnalyticsItem.HOME_OPEN_LEGACY_SHUTTLE)
-                findNavController().navigate(R.id.action_homeFragment_to_shuttleRealtimeFragment)
+                (activity as? MainActivity)?.showLegacyShuttleAsRoot()
+            }
+            if (result.getBoolean(HomeQuickSettingsDialog.KEY_OPEN_INQUIRY, false)) {
+                findNavController().navigate(
+                    HomeFragmentDirections.actionHomeFragmentToInquiryChatFragment(),
+                )
             }
             if (result.containsKey(HomeQuickSettingsDialog.KEY_SHOW_PRESENCE_STATUS)) {
                 viewModel.setShowPresenceStatus(result.getBoolean(HomeQuickSettingsDialog.KEY_SHOW_PRESENCE_STATUS))
@@ -225,30 +226,9 @@ class HomeFragment : Fragment() {
         viewModel.showSubwayTransfer.observe(viewLifecycleOwner) { render(viewModel.data.value) }
         viewModel.subwayTransferDestination.observe(viewLifecycleOwner) { render(viewModel.data.value) }
         viewModel.bus50TerminalLogTimes.observe(viewLifecycleOwner) { render(viewModel.data.value) }
-        viewModel.presenceViewerCount.observe(viewLifecycleOwner) { viewerCount ->
-            binding.homePresencePill.visibility = if (viewerCount == null) View.GONE else View.VISIBLE
-            if (viewerCount != null) {
-                binding.homePresenceCount.text = NumberFormat
-                    .getIntegerInstance(resources.configuration.locales[0])
-                    .format(viewerCount)
-                binding.homePresencePill.contentDescription = getString(
-                    R.string.shuttle_presence_viewer_count,
-                    viewerCount,
-                )
-                val availableSeats = viewModel.presenceAvailableSeats.value
-                val isWarning = availableSeats != null && viewerCount > availableSeats / 2
-                val isFull = availableSeats != null && viewerCount > availableSeats
-                binding.homePresencePill.setCardBackgroundColor(ContextCompat.getColor(
-                    requireContext(),
-                    if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background,
-                ))
-                binding.homePresenceCount.setTextColor(ContextCompat.getColor(
-                    requireContext(),
-                    if (isWarning) android.R.color.white else R.color.hanyang_blue,
-                ))
-            } else {
-                binding.homePresencePill.contentDescription = null
-            }
+        viewModel.presenceViewerCount.observe(viewLifecycleOwner, ::renderPresencePill)
+        viewModel.presenceAvailableSeats.observe(viewLifecycleOwner) {
+            renderPresencePill(viewModel.presenceViewerCount.value)
         }
         viewModel.queryError.observe(viewLifecycleOwner) {
             it?.let {
@@ -258,6 +238,29 @@ class HomeFragment : Fragment() {
         }
         refreshHome()
         return binding.root
+    }
+
+    private fun renderPresencePill(viewerCount: Int?) {
+        binding.homePresencePill.visibility = if (viewerCount == null) View.GONE else View.VISIBLE
+        if (viewerCount == null) {
+            binding.homePresencePill.contentDescription = null
+            return
+        }
+        binding.homePresenceCount.text = NumberFormat
+            .getIntegerInstance(resources.configuration.locales[0])
+            .format(viewerCount)
+        binding.homePresencePill.contentDescription = getString(
+            R.string.shuttle_presence_viewer_count,
+            viewerCount,
+        )
+        val availableSeats = viewModel.presenceAvailableSeats.value
+        val isWarning = availableSeats != null && viewerCount > availableSeats / 2
+        val isFull = availableSeats != null && viewerCount > availableSeats
+        val background = if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background
+        val foreground = if (isFull || isWarning) android.R.color.white else R.color.hanyang_blue
+        binding.homePresencePill.setCardBackgroundColor(ContextCompat.getColor(requireContext(), background))
+        binding.homePresenceCount.setTextColor(ContextCompat.getColor(requireContext(), foreground))
+        binding.homePresenceIcon.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), foreground))
     }
 
     override fun onResume() {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeQuickSettingsDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeQuickSettingsDialog.kt
@@ -74,6 +74,13 @@ class HomeQuickSettingsDialog : BottomSheetDialogFragment() {
             )
             dismiss()
         }
+        binding.inquiryRow.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putBoolean(KEY_OPEN_INQUIRY, true) },
+            )
+            dismiss()
+        }
     }
 
     private fun buttonIdFor(destination: HomeSubwayTransferDestination): Int {
@@ -97,6 +104,7 @@ class HomeQuickSettingsDialog : BottomSheetDialogFragment() {
     companion object {
         const val REQUEST_KEY = "HomeQuickSettingsDialog"
         const val KEY_OPEN_LEGACY_SHUTTLE = "openLegacyShuttle"
+        const val KEY_OPEN_INQUIRY = "openInquiry"
         const val KEY_SHOW_PRESENCE_STATUS = "showPresenceStatus"
         const val KEY_SHOW_BUS50_TRANSFER = "showBus50Transfer"
         const val KEY_SHOW_SUBWAY_TRANSFER = "showSubwayTransfer"

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -53,6 +53,7 @@ class HomeViewModel @Inject constructor(
     private var isFetching = false
     private var presenceJob: Job? = null
     private var selectedPresenceStop = "dormitory_o"
+    private var latestPresenceViewerCounts: Map<String, Int>? = null
     private var selectedPresenceDestination: String? = null
     private var presencePreviewCount: Int? = null
     private var presencePreferenceLoaded = false
@@ -221,7 +222,8 @@ class HomeViewModel @Inject constructor(
             }
             while (isActive) {
                 val viewerCounts = shuttlePresenceService.viewerCounts()
-                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts)
+                viewerCounts?.let { latestPresenceViewerCounts = it }
+                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts ?: latestPresenceViewerCounts)
                 _presenceViewerCount.value = shuttlePresenceService.heartbeat(selectedPresenceStop)
                 delay(PRESENCE_REFRESH_INTERVAL_MILLIS)
             }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleQuickSettingsDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleQuickSettingsDialog.kt
@@ -137,6 +137,13 @@ class ShuttleQuickSettingsDialog : BottomSheetDialogFragment() {
             )
             dismiss()
         }
+        binding.openInquiryButton.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putBoolean(KEY_OPEN_INQUIRY, true) },
+            )
+            dismiss()
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -160,6 +167,7 @@ class ShuttleQuickSettingsDialog : BottomSheetDialogFragment() {
         const val KEY_SUBWAY_DESTINATION = "subway_destination"
         const val KEY_ALTERNATIVE_MODE = "alternative_mode"
         const val KEY_OPEN_HOME = "open_home"
+        const val KEY_OPEN_INQUIRY = "open_inquiry"
         private const val ARG_SHOW_BY_DESTINATION = "arg_show_by_destination"
         private const val ARG_SHOW_DEPARTURE_TIME = "arg_show_departure_time"
         private const val ARG_SHOW_PRESENCE_STATUS = "arg_show_presence_status"

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.content.res.ColorStateList
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -24,6 +25,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import app.kobuggi.hyuabot.BuildConfig
 import app.kobuggi.hyuabot.R
+import app.kobuggi.hyuabot.ui.MainActivity
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.databinding.FragmentShuttleRealtimeBinding
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
@@ -117,11 +119,6 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
                 ?.let(viewModel::setPresencePreviewCount)
         }
         binding.shuttleQuickSettingsButton.setOnClickListener { openQuickSettings() }
-        binding.inquiryButton.setOnClickListener {
-            findNavController().navigate(
-                ShuttleRealtimeFragmentDirections.actionShuttleRealtimeFragmentToInquiryChatFragment(),
-            )
-        }
         childFragmentManager.setFragmentResultListener(
             ShuttleQuickSettingsDialog.REQUEST_KEY,
             viewLifecycleOwner,
@@ -148,7 +145,12 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
                 viewModel.setAlternativeDisplayMode(ShuttleAlternativeDisplayMode.from(it))
             }
             if (result.getBoolean(ShuttleQuickSettingsDialog.KEY_OPEN_HOME, false)) {
-                findNavController().navigate(R.id.homeFragment)
+                (activity as? MainActivity)?.showHomeExperienceAsRoot()
+            }
+            if (result.getBoolean(ShuttleQuickSettingsDialog.KEY_OPEN_INQUIRY, false)) {
+                findNavController().navigate(
+                    ShuttleRealtimeFragmentDirections.actionShuttleRealtimeFragmentToInquiryChatFragment(),
+                )
             }
         }
         binding.noticeViewPager.adapter = noticeAdapter
@@ -223,28 +225,9 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
         viewModel.result.observe(viewLifecycleOwner) { stops ->
             if (stops.isNotEmpty()) maybeShowCoachmark()
         }
-        viewModel.presenceViewerCount.observe(viewLifecycleOwner) { viewerCount ->
-            binding.shuttlePresencePill.isVisible = viewerCount != null
-            if (viewerCount != null) {
-                binding.shuttlePresenceCount.text = viewerCount.toString()
-                binding.shuttlePresencePill.contentDescription = getString(
-                    R.string.shuttle_presence_viewer_count,
-                    viewerCount,
-                )
-                val availableSeats = viewModel.presenceAvailableSeats.value
-                val isWarning = availableSeats != null && viewerCount > availableSeats / 2
-                val isFull = availableSeats != null && viewerCount > availableSeats
-                binding.shuttlePresencePill.setCardBackgroundColor(ContextCompat.getColor(
-                    requireContext(),
-                    if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background,
-                ))
-                binding.shuttlePresenceCount.setTextColor(ContextCompat.getColor(
-                    requireContext(),
-                    if (isWarning) android.R.color.white else R.color.hanyang_blue,
-                ))
-            } else {
-                binding.shuttlePresencePill.contentDescription = null
-            }
+        viewModel.presenceViewerCount.observe(viewLifecycleOwner, ::renderPresencePill)
+        viewModel.presenceAvailableSeats.observe(viewLifecycleOwner) {
+            renderPresencePill(viewModel.presenceViewerCount.value)
         }
         viewModel.viewModelScope.apply {
             launch {
@@ -263,6 +246,27 @@ class ShuttleRealtimeFragment @Inject constructor() : Fragment() {
                 }
             }
         }
+    }
+
+    private fun renderPresencePill(viewerCount: Int?) {
+        binding.shuttlePresencePill.isVisible = viewerCount != null
+        if (viewerCount == null) {
+            binding.shuttlePresencePill.contentDescription = null
+            return
+        }
+        binding.shuttlePresenceCount.text = viewerCount.toString()
+        binding.shuttlePresencePill.contentDescription = getString(
+            R.string.shuttle_presence_viewer_count,
+            viewerCount,
+        )
+        val availableSeats = viewModel.presenceAvailableSeats.value
+        val isWarning = availableSeats != null && viewerCount > availableSeats / 2
+        val isFull = availableSeats != null && viewerCount > availableSeats
+        val background = if (isFull) R.color.red_bus else if (isWarning) R.color.hanyang_orange else R.color.home_action_button_background
+        val foreground = if (isFull || isWarning) android.R.color.white else R.color.hanyang_blue
+        binding.shuttlePresencePill.setCardBackgroundColor(ContextCompat.getColor(requireContext(), background))
+        binding.shuttlePresenceCount.setTextColor(ContextCompat.getColor(requireContext(), foreground))
+        binding.shuttlePresenceIcon.imageTintList = ColorStateList.valueOf(ContextCompat.getColor(requireContext(), foreground))
     }
 
     override fun onPause() {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -70,6 +70,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private val _presenceAvailableSeats = MutableLiveData<Int?>(null)
     private var presenceJob: Job? = null
     private var selectedPresenceStop = PRESENCE_STOP_IDS.first()
+    private var latestPresenceViewerCounts: Map<String, Int>? = null
     private var presencePreviewCount: Int? = null
     private var presencePreferenceLoaded = false
     private var isStarted = false
@@ -347,7 +348,8 @@ class ShuttleRealtimeViewModel @Inject constructor(
             }
             while (isActive) {
                 val viewerCounts = shuttlePresenceService.viewerCounts()
-                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts)
+                viewerCounts?.let { latestPresenceViewerCounts = it }
+                _presenceAvailableSeats.value = estimatedAvailableSeats(viewerCounts ?: latestPresenceViewerCounts)
                 _presenceViewerCount.value = shuttlePresenceService.heartbeat(selectedPresenceStop)
                 delay(30_000)
             }

--- a/app/src/main/res/layout/dialog_home_quick_settings.xml
+++ b/app/src/main/res/layout/dialog_home_quick_settings.xml
@@ -250,10 +250,28 @@
     </LinearLayout>
 
     <TextView
-        android:id="@+id/legacy_shuttle_row"
+        android:id="@+id/inquiry_row"
         android:layout_width="match_parent"
         android:layout_height="52dp"
         android:layout_marginTop="14dp"
+        android:background="@drawable/bg_rounded_home_action"
+        android:clickable="true"
+        android:focusable="true"
+        android:drawableStart="@drawable/ic_chat"
+        android:drawablePadding="8dp"
+        android:drawableTint="@color/hanyang_blue"
+        android:gravity="center_vertical"
+        android:paddingHorizontal="14dp"
+        android:text="@string/inquiry_title"
+        android:textColor="@color/hanyang_blue"
+        android:textSize="17sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/legacy_shuttle_row"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:layout_marginTop="12dp"
         android:background="@drawable/bg_rounded_home_action"
         android:clickable="true"
         android:focusable="true"

--- a/app/src/main/res/layout/dialog_shuttle_quick_settings.xml
+++ b/app/src/main/res/layout/dialog_shuttle_quick_settings.xml
@@ -291,6 +291,23 @@
                 android:textSize="12sp" />
 
             <com.google.android.material.button.MaterialButton
+                android:id="@+id/open_inquiry_button"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_marginTop="12dp"
+                android:gravity="center_vertical"
+                android:text="@string/inquiry_title"
+                android:textColor="@color/hanyang_blue"
+                android:textSize="17sp"
+                android:textStyle="bold"
+                app:backgroundTint="@color/home_action_button_background"
+                app:icon="@drawable/ic_chat"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="@color/hanyang_blue" />
+
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/open_home_button"
                 style="@style/Widget.Material3.Button"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -206,6 +206,7 @@
                                     android:paddingHorizontal="10dp">
 
                                     <ImageView
+                                        android:id="@+id/home_presence_icon"
                                         android:layout_width="15dp"
                                         android:layout_height="12dp"
                                         android:contentDescription="@null"
@@ -370,30 +371,8 @@
         android:textSize="13sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/home_action_bar"
-        app:layout_constraintEnd_toStartOf="@id/inquiry_button"
-        app:layout_constraintStart_toStartOf="@id/home_action_bar"
-        app:layout_constraintTop_toTopOf="@id/home_action_bar" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/inquiry_button"
-        style="@style/Widget.Material3.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="40dp"
-        android:layout_marginEnd="8dp"
-        android:minHeight="36dp"
-        android:paddingHorizontal="12dp"
-        android:text="@string/inquiry_short"
-        android:textColor="@color/hanyang_blue"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        app:backgroundTint="@color/home_action_button_background"
-        app:icon="@drawable/ic_chat"
-        app:iconGravity="textStart"
-        app:iconPadding="6dp"
-        app:iconSize="16dp"
-        app:iconTint="@color/hanyang_blue"
-        app:layout_constraintBottom_toBottomOf="@id/home_action_bar"
         app:layout_constraintEnd_toStartOf="@id/legacy_shuttle_button"
+        app:layout_constraintStart_toStartOf="@id/home_action_bar"
         app:layout_constraintTop_toTopOf="@id/home_action_bar" />
 
     <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/fragment_shuttle_realtime.xml
+++ b/app/src/main/res/layout/fragment_shuttle_realtime.xml
@@ -70,43 +70,12 @@
         android:layout_width="match_parent"
         android:layout_height="54dp"
         android:background="@color/background"
-        android:gravity="center_vertical"
+        android:gravity="center_vertical|end"
         android:orientation="horizontal"
         android:paddingHorizontal="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
-
-        <TextView
-            android:id="@+id/shuttle_action_bar_title"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center_vertical"
-            android:maxLines="1"
-            android:text="@string/shuttle_action_bar_title"
-            android:textColor="@color/secondary_text"
-            android:textSize="13sp"
-            android:textStyle="bold" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/inquiry_button"
-            style="@style/Widget.Material3.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="40dp"
-            android:layout_marginEnd="8dp"
-            android:minHeight="36dp"
-            android:paddingHorizontal="12dp"
-            android:text="@string/inquiry_short"
-            android:textColor="@color/hanyang_blue"
-            android:textSize="14sp"
-            android:textStyle="bold"
-            app:backgroundTint="@color/home_action_button_background"
-            app:icon="@drawable/ic_chat"
-            app:iconGravity="textStart"
-            app:iconPadding="6dp"
-            app:iconSize="16dp"
-            app:iconTint="@color/hanyang_blue" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/shuttle_quick_settings_button"
@@ -146,15 +115,15 @@
         android:id="@+id/shuttle_presence_pill"
         android:layout_width="wrap_content"
         android:layout_height="30dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="10dp"
+        android:layout_marginStart="16dp"
         android:importantForAccessibility="yes"
         android:visibility="gone"
         app:cardBackgroundColor="@color/home_action_button_background"
         app:cardCornerRadius="15dp"
         app:cardElevation="0dp"
-        app:layout_constraintBottom_toTopOf="@id/shuttle_action_bar"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/shuttle_action_bar"
+        app:layout_constraintStart_toStartOf="@id/shuttle_action_bar"
+        app:layout_constraintTop_toTopOf="@id/shuttle_action_bar"
         app:strokeWidth="0dp">
 
         <LinearLayout
@@ -165,6 +134,7 @@
             android:paddingHorizontal="10dp">
 
             <ImageView
+                android:id="@+id/shuttle_presence_icon"
                 android:layout_width="15dp"
                 android:layout_height="12dp"
                 android:contentDescription="@null"


### PR DESCRIPTION
## Changes

### 홈·셔틀

- 홈 및 셔틀의 함께 보는 사람 칩이 최근 집계값을 유지하고 혼잡도 상태를 일관되게 표시하도록 정리했습니다.
- 문의하기를 홈·셔틀 빠른 설정 시트로 옮기고, 하단 액션바 구성을 정리했습니다.
- 기존 셔틀과 새 홈 전환 시 시작 화면 및 하단 첫 탭의 아이콘·라벨을 함께 갱신합니다.

## Checks

- [x] `./gradlew ktlintCheck :app:assembleProductionRelease`
- [x] Android 릴리스 에뮬레이터 설치 확인
