### PR TITLE
feat: Show log-based secondary arrival time for bus realtime

### DIFF
--- a/app/src/main/graphql/app/kobuggi/hyuabot/BusSecondaryEtaLogQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/BusSecondaryEtaLogQuery.graphql
@@ -1,11 +1,4 @@
-query BusRealtimePageQuery($language: String!, $dates: [Date!]!) {
-    notices(input: {language: $language, category: "버스"}) {
-        notices {
-            title
-            url
-            expiredAt
-        }
-    },
+query BusSecondaryEtaLogQuery($dates: [Date!]!) {
     bus (
         input: [
             { route: 216000068, stop: 216000138, limit: 3, dates: $dates },
@@ -57,17 +50,12 @@ query BusRealtimePageQuery($language: String!, $dates: [Date!]!) {
             { route: 216000016, stop: 216000152, limit: 3, dates: $dates },
         ]
     ) {
-        route { seq, name }
-        stop { seq, latitude, longitude }
-        order
-        arrival {
-            stops
-            seats
-            minutes
-            lowFloor
-            isRealtime
+        route { seq }
+        stop { seq }
+        log {
+            date
             time
-            arrivalTime
+            vehicle
         }
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepository.kt
@@ -387,6 +387,116 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
             }
     }
 
+    override suspend fun setShowBusSecondaryEta(show: Boolean) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[BUS_SHOW_SECONDARY_ETA_KEY] = show
+            }
+        }
+    }
+
+    override suspend fun getShowBusSecondaryEta(): Flow<Boolean> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[BUS_SHOW_SECONDARY_ETA_KEY] ?: true
+            }
+    }
+
+    override suspend fun setBusSeoulTargetStop(destination: String) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[BUS_SEOUL_TARGET_STOP_KEY] = destination
+            }
+        }
+    }
+
+    override suspend fun getBusSeoulTargetStop(): Flow<String> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[BUS_SEOUL_TARGET_STOP_KEY] ?: "gangnam"
+            }
+    }
+
+    override suspend fun setBusSeoulFirstStop(stopRes: Int) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[BUS_SEOUL_FIRST_STOP_KEY] = stopRes
+            }
+        }
+    }
+
+    override suspend fun getBusSeoulFirstStop(): Flow<Int> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[BUS_SEOUL_FIRST_STOP_KEY] ?: R.string.bus_stop_convention
+            }
+    }
+
+    override suspend fun setBusSeoulSecondStop(stopRes: Int) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[BUS_SEOUL_SECOND_STOP_KEY] = stopRes
+            }
+        }
+    }
+
+    override suspend fun getBusSeoulSecondStop(): Flow<Int> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[BUS_SEOUL_SECOND_STOP_KEY] ?: R.string.bus_stop_main_gate
+            }
+    }
+
+    override suspend fun setBusSuwonStop(stopRes: Int) {
+        Result.runCatching {
+            userDataStorePreferences.edit { preferences ->
+                preferences[BUS_SUWON_STOP_KEY] = stopRes
+            }
+        }
+    }
+
+    override suspend fun getBusSuwonStop(): Flow<Int> {
+        return userDataStorePreferences.data
+            .catch {
+                if (it is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw it
+                }
+            }
+            .map {
+                it[BUS_SUWON_STOP_KEY] ?: R.string.bus_stop_entrance
+            }
+    }
+
     override suspend fun setAnalyticsConsent(enabled: Boolean) {
         Result.runCatching {
             userDataStorePreferences.edit { preferences ->
@@ -495,6 +605,11 @@ class UserPreferencesRepository @Inject constructor(private val userDataStorePre
         private val HOME_SHOW_SUBWAY_TRANSFER_KEY = booleanPreferencesKey("home_show_subway_transfer")
         private val HOME_SUBWAY_TRANSFER_DESTINATION_KEY = stringPreferencesKey("home_subway_transfer_destination")
         private val SHUTTLE_ALTERNATIVE_DISPLAY_MODE_KEY = stringPreferencesKey("shuttle_alternative_display_mode")
+        private val BUS_SHOW_SECONDARY_ETA_KEY = booleanPreferencesKey("bus_show_secondary_eta")
+        private val BUS_SEOUL_TARGET_STOP_KEY = stringPreferencesKey("bus_seoul_target_stop")
+        private val BUS_SEOUL_FIRST_STOP_KEY = intPreferencesKey("bus_seoul_first_stop")
+        private val BUS_SEOUL_SECOND_STOP_KEY = intPreferencesKey("bus_seoul_second_stop")
+        private val BUS_SUWON_STOP_KEY = intPreferencesKey("bus_suwon_stop")
         private val ANALYTICS_CONSENT_KEY = booleanPreferencesKey("analytics_consent")
         private val LAUNCH_COUNT_KEY = intPreferencesKey("launch_count")
         private val REVIEW_REQUESTED_AT_KEY = longPreferencesKey("review_requested_at")

--- a/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/service/preferences/UserPreferencesRepositoryImpl.kt
@@ -27,6 +27,16 @@ interface UserPreferencesRepositoryImpl {
     suspend fun getHomeSubwayTransferDestination(): Flow<String>
     suspend fun setShuttleAlternativeDisplayMode(mode: String)
     suspend fun getShuttleAlternativeDisplayMode(): Flow<String>
+    suspend fun setShowBusSecondaryEta(show: Boolean)
+    suspend fun getShowBusSecondaryEta(): Flow<Boolean>
+    suspend fun setBusSeoulTargetStop(destination: String)
+    suspend fun getBusSeoulTargetStop(): Flow<String>
+    suspend fun setBusSeoulFirstStop(stopRes: Int)
+    suspend fun getBusSeoulFirstStop(): Flow<Int>
+    suspend fun setBusSeoulSecondStop(stopRes: Int)
+    suspend fun getBusSeoulSecondStop(): Flow<Int>
+    suspend fun setBusSuwonStop(stopRes: Int)
+    suspend fun getBusSuwonStop(): Flow<Int>
     suspend fun setAnalyticsConsent(enabled: Boolean)
     suspend fun incrementLaunchCount(): Int
     suspend fun resetLaunchCount()

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusArrivalItem.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusArrivalItem.kt
@@ -1,8 +1,30 @@
 package app.kobuggi.hyuabot.ui.bus.realtime
 
 import app.kobuggi.hyuabot.BusRealtimePageQuery
+import java.time.LocalTime
 
 data class BusArrivalItem(
     val route: String,
-    val item: BusRealtimePageQuery.Arrival
-)
+    val item: BusRealtimePageQuery.Arrival,
+    val secondaryArrivalTime: LocalTime? = null,
+) {
+    /**
+     * Minutes from now until arrival, computed the same way regardless of whether the estimate
+     * came from live GPS (`minutes`) or a timetable/log clock time (`arrivalTime`) — sorting by
+     * this instead of bucketing realtime-first keeps merged multi-route lists (e.g. Suwon's
+     * 7070/9090) in true chronological order.
+     */
+    val remainingMinutes: Double?
+        get() {
+            if (item.isRealtime) {
+                return item.minutes?.toDouble()
+            }
+            val arrival = item.arrivalTime ?: return null
+            val now = LocalTime.now()
+            fun serviceSeconds(time: LocalTime): Int {
+                val seconds = time.toSecondOfDay()
+                return if (seconds < 4 * 3600) seconds + 86400 else seconds
+            }
+            return (serviceSeconds(arrival) - serviceSeconds(now)) / 60.0
+        }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusQuickSettingsDialog.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusQuickSettingsDialog.kt
@@ -1,0 +1,115 @@
+package app.kobuggi.hyuabot.ui.bus.realtime
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.PopupMenu
+import app.kobuggi.hyuabot.databinding.DialogBusQuickSettingsBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class BusQuickSettingsDialog : BottomSheetDialogFragment() {
+    private var _binding: DialogBusQuickSettingsBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = DialogBusQuickSettingsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val showSecondaryEta = requireArguments().getBoolean(ARG_SHOW_SECONDARY_ETA, true)
+        var seoulTarget = BusSeoulTargetStop.from(requireArguments().getString(ARG_SEOUL_TARGET))
+
+        binding.showSecondaryEtaSwitch.isChecked = showSecondaryEta
+        binding.seoulTargetButton.setText(seoulTarget.titleRes)
+        binding.seoulTargetButton.isEnabled = showSecondaryEta
+        binding.seoulTargetButton.alpha = if (showSecondaryEta) 1f else DISABLED_ALPHA
+
+        binding.showSecondaryEtaSwitch.setOnCheckedChangeListener { _, isChecked ->
+            binding.seoulTargetButton.isEnabled = isChecked
+            binding.seoulTargetButton.alpha = if (isChecked) 1f else DISABLED_ALPHA
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply {
+                    putBoolean(KEY_SHOW_SECONDARY_ETA, isChecked)
+                },
+            )
+        }
+        binding.seoulTargetButton.setOnClickListener { anchor ->
+            PopupMenu(requireContext(), anchor).apply {
+                BusSeoulTargetStop.entries.forEachIndexed { index, destination ->
+                    menu.add(0, index, index, destination.titleRes)
+                }
+                setOnMenuItemClickListener { item ->
+                    seoulTarget = BusSeoulTargetStop.entries[item.itemId]
+                    binding.seoulTargetButton.setText(seoulTarget.titleRes)
+                    parentFragmentManager.setFragmentResult(
+                        REQUEST_KEY,
+                        Bundle().apply {
+                            putString(KEY_SEOUL_TARGET, seoulTarget.value)
+                        },
+                    )
+                    true
+                }
+                show()
+            }
+        }
+        binding.openHelpButton.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putBoolean(KEY_OPEN_HELP, true) },
+            )
+            dismiss()
+        }
+        binding.openInquiryButton.setOnClickListener {
+            parentFragmentManager.setFragmentResult(
+                REQUEST_KEY,
+                Bundle().apply { putBoolean(KEY_OPEN_INQUIRY, true) },
+            )
+            dismiss()
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return BottomSheetDialog(requireContext(), theme).apply {
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
+    companion object {
+        const val REQUEST_KEY = "bus_quick_settings"
+        const val KEY_SHOW_SECONDARY_ETA = "show_secondary_eta"
+        const val KEY_SEOUL_TARGET = "seoul_target"
+        const val KEY_OPEN_HELP = "open_help"
+        const val KEY_OPEN_INQUIRY = "open_inquiry"
+        private const val ARG_SHOW_SECONDARY_ETA = "arg_show_secondary_eta"
+        private const val ARG_SEOUL_TARGET = "arg_seoul_target"
+        private const val DISABLED_ALPHA = 0.38f
+
+        fun newInstance(
+            showSecondaryEta: Boolean,
+            seoulTarget: BusSeoulTargetStop,
+        ): BusQuickSettingsDialog {
+            return BusQuickSettingsDialog().apply {
+                arguments = Bundle().apply {
+                    putBoolean(ARG_SHOW_SECONDARY_ETA, showSecondaryEta)
+                    putString(ARG_SEOUL_TARGET, seoulTarget.value)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeFragment.kt
@@ -95,15 +95,27 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
             R.string.bus_tab_other
         )
         binding.viewPager.adapter = viewpagerAdapter
-        binding.helpButton.setOnClickListener {
-            AnalyticsManager.logSelect(AnalyticsItem.BUS_OPEN_HELP)
-            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusHelpDialogFragment().also {
-                findNavController().safeNavigate(it)
+        binding.busQuickSettingsButton.setOnClickListener { openQuickSettings() }
+        childFragmentManager.setFragmentResultListener(
+            BusQuickSettingsDialog.REQUEST_KEY,
+            viewLifecycleOwner,
+        ) { _, result ->
+            if (result.containsKey(BusQuickSettingsDialog.KEY_SHOW_SECONDARY_ETA)) {
+                viewModel.setShowSecondaryEta(result.getBoolean(BusQuickSettingsDialog.KEY_SHOW_SECONDARY_ETA))
             }
-        }
-        binding.inquiryButton.setOnClickListener {
-            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToInquiryChatFragment().also {
-                findNavController().safeNavigate(it)
+            result.getString(BusQuickSettingsDialog.KEY_SEOUL_TARGET)?.let {
+                viewModel.setSeoulTarget(BusSeoulTargetStop.from(it))
+            }
+            if (result.getBoolean(BusQuickSettingsDialog.KEY_OPEN_HELP, false)) {
+                AnalyticsManager.logSelect(AnalyticsItem.BUS_OPEN_HELP)
+                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusHelpDialogFragment().also {
+                    findNavController().safeNavigate(it)
+                }
+            }
+            if (result.getBoolean(BusQuickSettingsDialog.KEY_OPEN_INQUIRY, false)) {
+                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToInquiryChatFragment().also {
+                    findNavController().safeNavigate(it)
+                }
             }
         }
         binding.noticeViewPager.adapter = noticeAdapter
@@ -128,7 +140,7 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
                     R.string.coachmark_bus_tab_title, R.string.coachmark_bus_tab_desc
                 ),
                 CoachmarkStep(
-                    { binding.helpButton },
+                    { binding.busQuickSettingsButton },
                     R.string.coachmark_bus_stop_title, R.string.coachmark_bus_stop_desc,
                     shape = CoachmarkShape.ROUNDED_RECT
                 ),
@@ -148,6 +160,14 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
         return binding.root.also { disableViewStateSaving(it) }
     }
 
+    private fun openQuickSettings() {
+        if (childFragmentManager.findFragmentByTag(BUS_QUICK_SETTINGS_TAG) != null) return
+        BusQuickSettingsDialog.newInstance(
+            showSecondaryEta = viewModel.showSecondaryEta.value ?: true,
+            seoulTarget = viewModel.seoulTarget.value ?: BusSeoulTargetStop.GANGNAM,
+        ).show(childFragmentManager, BUS_QUICK_SETTINGS_TAG)
+    }
+
     private fun firstVisibleBusChildView(vararg ids: Int): View? {
         val root = childFragmentManager.findFragmentByTag("f${binding.viewPager.currentItem}")?.view ?: return null
         for (id in ids) {
@@ -159,31 +179,52 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
 
     @SuppressLint("MissingPermission")
     private fun moveToNearestStop(client: FusedLocationProviderClient) {
-        val stops = viewModel.result.value
-            ?.distinctBy { it.stop.seq }
-            ?.filter { it.stop.seq in listOf(216000379, 216000381, 216000383) }
-            ?.map { item ->
-                val resId = when (item.stop.seq) {
-                    216000379 -> R.string.bus_stop_convention
-                    216000381 -> R.string.bus_stop_cluster
-                    216000383 -> R.string.bus_stop_dormitory
-                    else -> -1
-                }
-                Triple(resId, item.stop.latitude, item.stop.longitude)
-            } ?: emptyList()
+        val allStops = viewModel.result.value?.distinctBy { it.stop.seq } ?: emptyList()
 
-        if (stops.isEmpty()) return
+        fun candidates(seqToRes: Map<Int, Int>): List<Triple<Int, Double, Double>> {
+            return allStops.filter { it.stop.seq in seqToRes.keys }.map { item ->
+                Triple(seqToRes.getValue(item.stop.seq), item.stop.latitude, item.stop.longitude)
+            }
+        }
+
+        val campusStopMap = mapOf(
+            216000379 to R.string.bus_stop_convention,
+            216000381 to R.string.bus_stop_cluster,
+            216000383 to R.string.bus_stop_dormitory,
+        )
+        val seoulRemoteStopMap = mapOf(
+            121000060 to R.string.bus_stop_seocho,
+            121000929 to R.string.bus_stop_gyodae,
+            121000974 to R.string.bus_stop_gangnam,
+            121000970 to R.string.bus_stop_yangjae,
+            121000220 to R.string.bus_stop_yangjae_forest,
+        )
+        val cityCandidates = candidates(campusStopMap)
+        val seoulFirstCandidates = candidates(campusStopMap + seoulRemoteStopMap)
+        val seoulSecondCandidates = candidates(mapOf(216000719 to R.string.bus_stop_main_gate) + seoulRemoteStopMap)
+        val suwonCandidates = candidates(
+            mapOf(
+                216000070 to R.string.bus_stop_entrance,
+                202000106 to R.string.bus_stop_suwon_station,
+            )
+        )
+
+        if (cityCandidates.isEmpty() && seoulFirstCandidates.isEmpty() && seoulSecondCandidates.isEmpty() && suwonCandidates.isEmpty()) return
+
+        fun nearestKey(candidateList: List<Triple<Int, Double, Double>>, location: Location): Int? {
+            return candidateList.minByOrNull { (_, lat, lng) ->
+                (lat - location.latitude) * (lat - location.latitude) +
+                    (lng - location.longitude) * (lng - location.longitude)
+            }?.first
+        }
 
         fun selectNearest(location: Location) {
             if (setClosestStop) return
-            val nearest = stops.minByOrNull { (_, lat, lng) ->
-                (lat - location.latitude) * (lat - location.latitude) +
-                    (lng - location.longitude) * (lng - location.longitude)
-            }
-            nearest?.let { (stopRes, _, _) ->
-                setClosestStop = true
-                viewModel.setSelectedStopID(stopRes)
-            }
+            setClosestStop = true
+            nearestKey(cityCandidates, location)?.let { viewModel.setSelectedStopID(it) }
+            nearestKey(seoulFirstCandidates, location)?.let { viewModel.setSeoulFirstStopID(it) }
+            nearestKey(seoulSecondCandidates, location)?.let { viewModel.setSeoulSecondStopID(it) }
+            nearestKey(suwonCandidates, location)?.let { viewModel.setSuwonStopID(it) }
         }
 
         client.lastLocation
@@ -246,5 +287,6 @@ class BusRealtimeFragment @Inject constructor() : Fragment() {
     companion object {
         private const val LOCATION_MAX_AGE_MILLIS = 60_000L
         private const val NOTICE_AUTO_SCROLL_INTERVAL_MILLIS = 5_000L
+        private const val BUS_QUICK_SETTINGS_TAG = "BusQuickSettingsDialog"
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeListAdapter.kt
@@ -19,9 +19,19 @@ class BusRealtimeListAdapter(
     private var arrivalList: List<BusArrivalItem> = emptyList(),
     private val maxCount: Int = 5,
 ) : RecyclerView.Adapter<BusRealtimeListAdapter.ViewHolder>() {
+    private var showSecondaryEta: Boolean = true
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setShowSecondaryEta(show: Boolean) {
+        if (showSecondaryEta == show) return
+        showSecondaryEta = show
+        notifyDataSetChanged()
+    }
+
     inner class ViewHolder(private val binding: ItemBusRealtimeBinding) : RecyclerView.ViewHolder(binding.root) {
         private val hourFormatter = DateTimeFormatter.ofPattern("HH")
         private val minuteFormatter = DateTimeFormatter.ofPattern("mm")
+        private val secondaryTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         private val godoTypeface by lazy {
             ResourcesCompat.getFont(binding.root.context, R.font.godo)
         }
@@ -30,6 +40,16 @@ class BusRealtimeListAdapter(
         fun bind(item: BusArrivalItem) {
             val routeName = item.route
             val arrival = item.item
+            val secondarySuffix = if (showSecondaryEta) {
+                item.secondaryArrivalTime?.let {
+                    binding.root.context.getString(
+                        R.string.bus_arrival_secondary_format,
+                        it.format(secondaryTimeFormatter)
+                    )
+                } ?: ""
+            } else {
+                ""
+            }
             binding.busLowFloorBadge.visibility = if (arrival.lowFloor == true) android.view.View.VISIBLE else android.view.View.GONE
             val item = arrival
             if (item.isRealtime) {
@@ -53,7 +73,7 @@ class BusRealtimeListAdapter(
                         item.stops
                     )
                 }
-                binding.busTimeText.applyRealtimeColor(realtimeText)
+                binding.busTimeText.applyRealtimeColor(realtimeText + secondarySuffix)
             } else {
                 binding.busRouteText.apply {
                     text = routeName
@@ -68,7 +88,7 @@ class BusRealtimeListAdapter(
                             if (s < 4 * 3600) s + 86400 else s
                         }
                         val remainingMinutes = (toServiceSec(arrivalTime) - toServiceSec(now)) / 60
-                        text = binding.root.context.getString(R.string.bus_arrival_estimated_format, remainingMinutes)
+                        text = binding.root.context.getString(R.string.bus_arrival_estimated_format, remainingMinutes) + secondarySuffix
                     }
                     setTextColor(binding.root.context.getColor(R.color.secondary_text))
                     setTypeface(godoTypeface, Typeface.NORMAL)

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRealtimeViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.kobuggi.hyuabot.BusRealtimePageQuery
+import app.kobuggi.hyuabot.BusSecondaryEtaLogQuery
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.util.QueryError
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.cache.normalized.FetchPolicy
+import com.apollographql.cache.normalized.doNotStore
 import com.apollographql.cache.normalized.fetchPolicy
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -26,22 +28,60 @@ class BusRealtimeViewModel @Inject constructor(
 ): ViewModel() {
     private val _isLoading = MutableLiveData(false)
     private val _result = MutableLiveData<List<BusRealtimePageQuery.Bus>>()
+    private val _logResult = MutableLiveData<List<BusSecondaryEtaLogQuery.Bus>>()
     private val _notices = MutableLiveData<List<BusRealtimePageQuery.Notice1>>()
 
     private val _disposable = CompositeDisposable()
     private val _selectedStopID = MutableLiveData<Int?>(null)
     private val _queryError = MutableLiveData<QueryError?>(null)
+    private val _showSecondaryEta = MutableLiveData(true)
+    private val _seoulTarget = MutableLiveData(BusSeoulTargetStop.GANGNAM)
+    private val _seoulFirstStopID = MutableLiveData<Int?>(null)
+    private val _seoulSecondStopID = MutableLiveData<Int?>(null)
+    private val _suwonStopID = MutableLiveData<Int?>(null)
 
     val result get() = _result
+    val logResult get() = _logResult
     val notices get() = _notices
     val isLoading get() = _isLoading
     val selectedStopID get() = _selectedStopID
     val queryError get() = _queryError
+    val showSecondaryEta get() = _showSecondaryEta
+    val seoulTarget get() = _seoulTarget
+    val seoulFirstStopID get() = _seoulFirstStopID
+    val seoulSecondStopID get() = _seoulSecondStopID
+    val suwonStopID get() = _suwonStopID
 
     fun initSelectedStopID() {
+        fetchLogDataOnce()
         viewModelScope.launch {
             userPreferencesRepository.getBusStop().collect {
                 _selectedStopID.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getShowBusSecondaryEta().collect {
+                _showSecondaryEta.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getBusSeoulTargetStop().collect {
+                _seoulTarget.value = BusSeoulTargetStop.from(it)
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getBusSeoulFirstStop().collect {
+                _seoulFirstStopID.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getBusSeoulSecondStop().collect {
+                _seoulSecondStopID.value = it
+            }
+        }
+        viewModelScope.launch {
+            userPreferencesRepository.getBusSuwonStop().collect {
+                _suwonStopID.value = it
             }
         }
     }
@@ -50,13 +90,54 @@ class BusRealtimeViewModel @Inject constructor(
         viewModelScope.launch { userPreferencesRepository.setBusStop(stopID) }
     }
 
+    fun setSeoulFirstStopID(stopRes: Int) {
+        _seoulFirstStopID.value = stopRes
+        viewModelScope.launch { userPreferencesRepository.setBusSeoulFirstStop(stopRes) }
+    }
+
+    fun setSeoulSecondStopID(stopRes: Int) {
+        _seoulSecondStopID.value = stopRes
+        viewModelScope.launch { userPreferencesRepository.setBusSeoulSecondStop(stopRes) }
+    }
+
+    fun setSuwonStopID(stopRes: Int) {
+        _suwonStopID.value = stopRes
+        viewModelScope.launch { userPreferencesRepository.setBusSuwonStop(stopRes) }
+    }
+
+    fun setShowSecondaryEta(show: Boolean) {
+        _showSecondaryEta.value = show
+        viewModelScope.launch { userPreferencesRepository.setShowBusSecondaryEta(show) }
+    }
+
+    fun setSeoulTarget(target: BusSeoulTargetStop) {
+        _seoulTarget.value = target
+        viewModelScope.launch { userPreferencesRepository.setBusSeoulTargetStop(target.value) }
+    }
+
+    private fun fetchLogDataOnce() {
+        if (_logResult.value != null) return
+        val dates = BusRecentDates.sameWeekdayType(count = 4)
+        viewModelScope.launch {
+            val response = apolloClient.query(BusSecondaryEtaLogQuery(dates))
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .doNotStore(true)
+                .execute()
+            response.data?.bus?.let { _logResult.value = it }
+        }
+    }
+
     fun fetchData() {
         if (_result.value == null) _isLoading.value = true
         val locale = AppCompatDelegate.getApplicationLocales().get(0)
         val appLanguage = locale?.language ?: Locale.getDefault().language
         val language = if (appLanguage == Locale.KOREAN.language) "KOREAN" else "ENGLISH"
+        val dates = BusRecentDates.sameWeekdayType(count = 4)
         viewModelScope.launch {
-            val response = apolloClient.query(BusRealtimePageQuery(language)).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+            val response = apolloClient.query(BusRealtimePageQuery(language, dates))
+                .fetchPolicy(FetchPolicy.NetworkOnly)
+                .doNotStore(true)
+                .execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.bus != null) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRecentDates.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusRecentDates.kt
@@ -1,0 +1,32 @@
+package app.kobuggi.hyuabot.ui.bus.realtime
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneId
+
+object BusRecentDates {
+    fun sameWeekdayType(
+        count: Int,
+        zoneId: ZoneId = ZoneId.of("Asia/Seoul"),
+        from: LocalDate = LocalDate.now(zoneId)
+    ): List<LocalDate> {
+        if (count <= 0) return emptyList()
+
+        val targetBucket = bucketOf(from)
+        return buildList(count) {
+            var current = from.minusDays(1)
+            while (size < count) {
+                if (bucketOf(current) == targetBucket) add(current)
+                current = current.minusDays(1)
+            }
+        }
+    }
+
+    private enum class Bucket { WEEKDAYS, SATURDAY, SUNDAY }
+
+    private fun bucketOf(date: LocalDate): Bucket = when (date.dayOfWeek) {
+        DayOfWeek.SATURDAY -> Bucket.SATURDAY
+        DayOfWeek.SUNDAY -> Bucket.SUNDAY
+        else -> Bucket.WEEKDAYS
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusSecondaryEta.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusSecondaryEta.kt
@@ -1,0 +1,29 @@
+package app.kobuggi.hyuabot.ui.bus.realtime
+
+import app.kobuggi.hyuabot.BusRealtimePageQuery
+import app.kobuggi.hyuabot.BusSecondaryEtaLogQuery
+import java.time.LocalTime
+
+/** Estimates a bus's clock arrival time from either live GPS data or a historical-log-derived duration. */
+object BusSecondaryEta {
+    fun estimatedArrivalTime(arrival: BusRealtimePageQuery.Arrival): LocalTime? {
+        arrival.arrivalTime?.let { return it }
+        if (!arrival.isRealtime) return null
+        val minutes = arrival.minutes ?: return null
+        return LocalTime.now().plusMinutes(minutes.toLong())
+    }
+
+    fun secondaryArrivalTime(
+        arrival: BusRealtimePageQuery.Arrival,
+        primaryLogs: List<BusSecondaryEtaLogQuery.Log>,
+        secondaryLogs: List<BusSecondaryEtaLogQuery.Log>?
+    ): LocalTime? {
+        if (secondaryLogs == null) return null
+        val primaryArrivalTime = estimatedArrivalTime(arrival) ?: return null
+        return BusTravelTimeEstimator.secondaryArrivalTime(
+            primaryArrivalTime,
+            primaryLogs.map { LogEntry(it.date, it.time, it.vehicle) },
+            secondaryLogs.map { LogEntry(it.date, it.time, it.vehicle) }
+        )
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusSeoulTargetStop.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusSeoulTargetStop.kt
@@ -1,0 +1,17 @@
+package app.kobuggi.hyuabot.ui.bus.realtime
+
+import app.kobuggi.hyuabot.R
+
+enum class BusSeoulTargetStop(val value: String, val titleRes: Int, val stopID: Int) {
+    SEOCHO("seocho", R.string.bus_stop_seocho, 121000060),
+    GYODAE("gyodae", R.string.bus_stop_gyodae, 121000929),
+    GANGNAM("gangnam", R.string.bus_stop_gangnam, 121000974),
+    YANGJAE("yangjae", R.string.bus_stop_yangjae, 121000970),
+    YANGJAE_CITIZENS_FOREST("yangjae_forest", R.string.bus_stop_yangjae_forest, 121000220);
+
+    companion object {
+        fun from(value: String?): BusSeoulTargetStop {
+            return entries.firstOrNull { it.value == value } ?: GANGNAM
+        }
+    }
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabCityFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabCityFragment.kt
@@ -25,6 +25,9 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentBusRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: BusRealtimeViewModel by viewModels({ requireParentFragment() })
 
+    private fun logsFor(route: Int, stop: Int) =
+        parentViewModel.logResult.value?.firstOrNull { it.route.seq == route && it.stop.seq == stop }?.log ?: emptyList()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -33,6 +36,10 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
         val decoration = DividerItemDecoration(requireContext(), VERTICAL)
         val busFirstAdapter = BusRealtimeListAdapter()
         val busSecondAdapter = BusRealtimeListAdapter()
+        parentViewModel.showSecondaryEta.observe(viewLifecycleOwner) {
+            busFirstAdapter.setShowSecondaryEta(it)
+            busSecondAdapter.setShowSecondaryEta(it)
+        }
         parentViewModel.selectedStopID.observe(viewLifecycleOwner) {
             if (it == null) return@observe
             when (it) {
@@ -64,7 +71,14 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                             binding.noRealtimeDataFirst.visibility = View.VISIBLE
                             return@observe
                         }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
+                        val secondaryLogs = logsFor(216000068, 216000138)
+                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
+                            BusArrivalItem(
+                                firstBusList.route.name,
+                                arrival,
+                                BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(firstBusList.route.seq, firstBusList.stop.seq), secondaryLogs)
+                            )
+                        })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
                 }
@@ -96,7 +110,14 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                             binding.noRealtimeDataFirst.visibility = View.VISIBLE
                             return@observe
                         }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
+                        val secondaryLogs = logsFor(216000068, 216000138)
+                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
+                            BusArrivalItem(
+                                firstBusList.route.name,
+                                arrival,
+                                BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(firstBusList.route.seq, firstBusList.stop.seq), secondaryLogs)
+                            )
+                        })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
                 }
@@ -128,7 +149,14 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
                             binding.noRealtimeDataFirst.visibility = View.VISIBLE
                             return@observe
                         }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
+                        val secondaryLogs = logsFor(216000068, 216000138)
+                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
+                            BusArrivalItem(
+                                firstBusList.route.name,
+                                arrival,
+                                BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(firstBusList.route.seq, firstBusList.stop.seq), secondaryLogs)
+                            )
+                        })
                         binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
                     }
                 }
@@ -151,9 +179,14 @@ class BusTabCityFragment @Inject constructor() : Fragment() {
             } else {
                 secondBusList.arrival.filter { arrival -> !arrival.isRealtime }
             }
+            val secondaryReturnLogs = logsFor(216000068, 216000378)
             busSecondAdapter.updateData(
-                (secondBusRealtime + secondBusTimetable).map {
-                    arrival -> BusArrivalItem(secondBusList.route.name, arrival)
+                (secondBusRealtime + secondBusTimetable).map { arrival ->
+                    BusArrivalItem(
+                        secondBusList.route.name,
+                        arrival,
+                        BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(secondBusList.route.seq, secondBusList.stop.seq), secondaryReturnLogs)
+                    )
                 }
             )
             binding.noRealtimeDataSecond.visibility = if (secondBusList.arrival.isEmpty()) View.VISIBLE else View.GONE

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabOtherFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabOtherFragment.kt
@@ -23,6 +23,9 @@ class BusTabOtherFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentBusRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: BusRealtimeViewModel by viewModels({ requireParentFragment() })
 
+    private fun logsFor(route: Int, stop: Int) =
+        parentViewModel.logResult.value?.firstOrNull { it.route.seq == route && it.stop.seq == stop }?.log ?: emptyList()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -31,6 +34,10 @@ class BusTabOtherFragment @Inject constructor() : Fragment() {
         val decoration = DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
         val busFirstAdapter = BusRealtimeListAdapter()
         val busSecondAdapter = BusRealtimeListAdapter()
+        parentViewModel.showSecondaryEta.observe(viewLifecycleOwner) {
+            busFirstAdapter.setShowSecondaryEta(it)
+            busSecondAdapter.setShowSecondaryEta(it)
+        }
         parentViewModel.result.observe(viewLifecycleOwner) { busList ->
             if (busList == null) return@observe
             val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000759 && bus.route.seq == 216000075 }
@@ -39,8 +46,13 @@ class BusTabOtherFragment @Inject constructor() : Fragment() {
                 busFirstAdapter.updateData(emptyList())
                 binding.noRealtimeDataFirst.visibility = View.VISIBLE
             } else {
+                val firstSecondaryLogs = logsFor(216000075, 213000487)
                 busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
-                    BusArrivalItem(firstBusList.route.name, arrival)
+                    BusArrivalItem(
+                        firstBusList.route.name,
+                        arrival,
+                        BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(firstBusList.route.seq, firstBusList.stop.seq), firstSecondaryLogs)
+                    )
                 })
                 binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
             }
@@ -48,8 +60,13 @@ class BusTabOtherFragment @Inject constructor() : Fragment() {
                 busSecondAdapter.updateData(emptyList())
                 binding.noRealtimeDataSecond.visibility = View.VISIBLE
             } else {
+                val secondSecondaryLogs = logsFor(216000075, 216000117)
                 busSecondAdapter.updateData(secondBusList.arrival.map { arrival ->
-                    BusArrivalItem(secondBusList.route.name, arrival)
+                    BusArrivalItem(
+                        secondBusList.route.name,
+                        arrival,
+                        BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(secondBusList.route.seq, secondBusList.stop.seq), secondSecondaryLogs)
+                    )
                 })
                 binding.noRealtimeDataSecond.visibility = if (secondBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
             }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSeoulFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSeoulFragment.kt
@@ -2,7 +2,6 @@ package app.kobuggi.hyuabot.ui.bus.realtime
 import app.kobuggi.hyuabot.util.AnalyticsManager
 import app.kobuggi.hyuabot.util.AnalyticsItem
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,14 +15,46 @@ import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentBusRealtimeTabBinding
 import app.kobuggi.hyuabot.util.NavControllerExtension.safeNavigate
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.LocalTime
 import javax.inject.Inject
 import app.kobuggi.hyuabot.util.disableViewStateSaving
+
+private val FIRST_SECTION_STOP_BY_RES = mapOf(
+    R.string.bus_stop_convention to 216000379,
+    R.string.bus_stop_cluster to 216000381,
+    R.string.bus_stop_dormitory to 216000383,
+    R.string.bus_stop_seocho to 121000060,
+    R.string.bus_stop_gyodae to 121000929,
+    R.string.bus_stop_gangnam to 121000974,
+    R.string.bus_stop_yangjae to 121000970,
+    R.string.bus_stop_yangjae_forest to 121000220,
+)
+private val SECOND_SECTION_STOP_BY_RES = mapOf(
+    R.string.bus_stop_main_gate to 216000719,
+    R.string.bus_stop_seocho to 121000060,
+    R.string.bus_stop_gyodae to 121000929,
+    R.string.bus_stop_gangnam to 121000974,
+    R.string.bus_stop_yangjae to 121000970,
+    R.string.bus_stop_yangjae_forest to 121000220,
+)
+private val SEOUL_REMOTE_RES_IDS = setOf(
+    R.string.bus_stop_seocho,
+    R.string.bus_stop_gyodae,
+    R.string.bus_stop_gangnam,
+    R.string.bus_stop_yangjae,
+    R.string.bus_stop_yangjae_forest,
+)
+// 3102's own return leg (Seoul-bound stop -> campus) uses a distinct stop from its outbound one.
+private const val SEOUL_FIRST_RETURN_STOP = 216000378
+// 3100/3101/3100N never stop at 216000379 (that's 3102-only); their return leg uses 216000048.
+private const val SEOUL_SECOND_RETURN_STOP = 216000048
 
 @AndroidEntryPoint
 class BusTabSeoulFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentBusRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: BusRealtimeViewModel by viewModels({ requireParentFragment() })
+
+    private fun logsFor(route: Int, stop: Int) =
+        parentViewModel.logResult.value?.firstOrNull { it.route.seq == route && it.stop.seq == stop }?.log ?: emptyList()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -33,163 +64,117 @@ class BusTabSeoulFragment @Inject constructor() : Fragment() {
         val decoration = DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
         val busFirstAdapter = BusRealtimeListAdapter()
         val busSecondAdapter = BusRealtimeListAdapter()
-        parentViewModel.selectedStopID.observe(viewLifecycleOwner) {
-            if (it == null) return@observe
-            when (it) {
-                R.string.bus_stop_convention -> {
-                    binding.apply {
-                        headerFirstTitle.text = getString(R.string.bus_header_format, "3102", getString(R.string.bus_stop_convention))
-                        headerFirstStopBtn.setOnClickListener {
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(216000379, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        departureLogFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(216000379, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        entireTimetableFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(216000379, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                    }
-                    parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000379 && bus.route.seq == 216000061 }
-                        if (firstBusList == null) {
-                            busFirstAdapter.updateData(emptyList())
-                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
-                            return@observe
-                        }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
-                        binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
+        parentViewModel.showSecondaryEta.observe(viewLifecycleOwner) {
+            busFirstAdapter.setShowSecondaryEta(it)
+            busSecondAdapter.setShowSecondaryEta(it)
+        }
+        parentViewModel.seoulFirstStopID.observe(viewLifecycleOwner) { stopRes ->
+            if (stopRes == null) return@observe
+            val stopSeq = FIRST_SECTION_STOP_BY_RES[stopRes] ?: return@observe
+            val stopName = getString(stopRes)
+            binding.apply {
+                headerFirstTitle.text = getString(R.string.bus_header_format, "3102", stopName)
+                headerFirstStopBtn.setOnClickListener {
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(stopSeq, 216000061).also { direction ->
+                        findNavController().safeNavigate(direction)
                     }
                 }
-                R.string.bus_stop_cluster -> {
-                    binding.apply {
-                        headerFirstTitle.text = getString(R.string.bus_header_format, "3102", getString(R.string.bus_stop_cluster))
-                        headerFirstStopBtn.setOnClickListener {
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(216000381, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        departureLogFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(216000381, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        entireTimetableFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(
-                                216000381,
-                                216000061
-                            ).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                    }
-                    parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000381 && bus.route.seq == 216000061 }
-                        if (firstBusList == null) {
-                            busFirstAdapter.updateData(emptyList())
-                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
-                            return@observe
-                        }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
-                        binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
+                departureLogFirst.setOnClickListener {
+                    AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(stopSeq, 216000061).also { direction ->
+                        findNavController().safeNavigate(direction)
                     }
                 }
-                R.string.bus_stop_dormitory -> {
-                    binding.apply {
-                        headerFirstTitle.text = getString(R.string.bus_header_format, "3102", getString(R.string.bus_stop_dormitory))
-                        headerFirstStopBtn.setOnClickListener {
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(216000383, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        departureLogFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(216000383, 216000061).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                        entireTimetableFirst.setOnClickListener {
-                            AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
-                            BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(
-                                216000383,
-                                216000061
-                            ).also { direction ->
-                                findNavController().safeNavigate(direction)
-                            }
-                        }
-                    }
-                    parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-                        val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == 216000383 && bus.route.seq == 216000061 }
-                        if (firstBusList == null) {
-                            busFirstAdapter.updateData(emptyList())
-                            binding.noRealtimeDataFirst.visibility = View.VISIBLE
-                            return@observe
-                        }
-                        busFirstAdapter.updateData(firstBusList.arrival.map { arrival -> BusArrivalItem(firstBusList.route.name, arrival) })
-                        binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
+                entireTimetableFirst.setOnClickListener {
+                    AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(stopSeq, 216000061).also { direction ->
+                        findNavController().safeNavigate(direction)
                     }
                 }
             }
+            parentViewModel.result.observe(viewLifecycleOwner) { busList ->
+                val firstBusList = busList.firstOrNull { bus -> bus.stop.seq == stopSeq && bus.route.seq == 216000061 }
+                if (firstBusList == null) {
+                    busFirstAdapter.updateData(emptyList())
+                    binding.noRealtimeDataFirst.visibility = View.VISIBLE
+                    return@observe
+                }
+                val secondaryTargetSeq = if (stopRes in SEOUL_REMOTE_RES_IDS) SEOUL_FIRST_RETURN_STOP else currentSeoulTargetStopID()
+                val secondaryLogs = logsFor(216000061, secondaryTargetSeq)
+                busFirstAdapter.updateData(firstBusList.arrival.map { arrival ->
+                    BusArrivalItem(
+                        firstBusList.route.name,
+                        arrival,
+                        BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(firstBusList.route.seq, firstBusList.stop.seq), secondaryLogs)
+                    )
+                })
+                binding.noRealtimeDataFirst.visibility = if (firstBusList.arrival.isEmpty()) View.VISIBLE else View.GONE
+            }
         }
-        parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-            if (busList == null) return@observe
-            val routes = busList.filter { route -> route.stop.seq == 216000719 && (route.route.seq == 216000096 || route.route.seq == 216000026 || route.route.seq == 216000043) }
-            val arrivalList = routes.flatMap { route -> route.arrival.map { BusArrivalItem(route.route.name, it) } }
-            busSecondAdapter.updateData(arrivalList.sortedWith(compareBy(
-                { it.item.minutes ?: Int.MAX_VALUE },
-                { it.item.arrivalTime?.let { time ->
-                    add24HoursAfterMidnight(time)
-                }}
-            )))
-            binding.noRealtimeDataSecond.visibility = if (arrivalList.isEmpty()) View.VISIBLE else View.GONE
+        parentViewModel.seoulSecondStopID.observe(viewLifecycleOwner) { stopRes ->
+            if (stopRes == null) return@observe
+            val stopSeq = SECOND_SECTION_STOP_BY_RES[stopRes] ?: return@observe
+            val stopName = getString(stopRes)
+            val isRemote = stopRes in SEOUL_REMOTE_RES_IDS
+            binding.apply {
+                headerSecondTitle.text = getString(R.string.bus_header_format, "3100/3101/3100N", stopName)
+                headerSecondStopBtn.setOnClickListener {
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(
+                        stopSeq, 216000096, 216000026, 216000043
+                    ).also { direction ->
+                        findNavController().safeNavigate(direction)
+                    }
+                }
+                departureLogSecond.setOnClickListener {
+                    AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(
+                        stopSeq, 216000096, 216000026, 216000043
+                    ).also { direction ->
+                        findNavController().safeNavigate(direction)
+                    }
+                }
+                entireTimetableSecond.setOnClickListener {
+                    AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(
+                        stopSeq, 216000096, 216000026, 216000043
+                    ).also { direction ->
+                        findNavController().safeNavigate(direction)
+                    }
+                }
+            }
+            parentViewModel.result.observe(viewLifecycleOwner) { busList ->
+                val routes = busList.filter { route ->
+                    route.stop.seq == stopSeq && (route.route.seq == 216000096 || route.route.seq == 216000026 || route.route.seq == 216000043)
+                }
+                val arrivalList = routes.flatMap { route ->
+                    val secondaryTargetSeq = if (isRemote) SEOUL_SECOND_RETURN_STOP else currentSeoulTargetStopID()
+                    val secondaryLogs = logsFor(route.route.seq, secondaryTargetSeq)
+                    route.arrival.map { arrival ->
+                        BusArrivalItem(
+                            route.route.name,
+                            arrival,
+                            BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(route.route.seq, route.stop.seq), secondaryLogs)
+                        )
+                    }
+                }
+                busSecondAdapter.updateData(
+                    arrivalList
+                        .sortedBy { it.remainingMinutes ?: Double.MAX_VALUE }
+                        .take(4)
+                )
+                binding.noRealtimeDataSecond.visibility = if (arrivalList.isEmpty()) View.VISIBLE else View.GONE
+            }
         }
         binding.apply {
-            headerFirstTitle.text = getString(R.string.bus_header_format, "3102", getString(R.string.bus_stop_convention))
             realtimeViewFirst.apply {
                 adapter = busFirstAdapter
                 addItemDecoration(decoration)
                 layoutManager = LinearLayoutManager(requireContext())
             }
-            headerSecondTitle.text = getString(R.string.bus_header_format, "3100/3101/3101N", getString(R.string.bus_stop_main_gate))
             realtimeViewSecond.apply {
                 adapter = busSecondAdapter
                 addItemDecoration(decoration)
                 layoutManager = LinearLayoutManager(requireContext())
-            }
-            headerSecondStopBtn.setOnClickListener {
-                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(
-                    216000719, 216000096, 216000026, 216000043
-                ).also { direction ->
-                    findNavController().safeNavigate(direction)
-                }
-            }
-            departureLogSecond.setOnClickListener {
-                AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
-                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(
-                    216000719,
-                    216000096,
-                    216000026,
-                    216000043
-                ).also { direction ->
-                    findNavController().safeNavigate(direction)
-                }
-            }
-            entireTimetableSecond.setOnClickListener {
-                AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_ENTIRE_TIMETABLE)
-                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusTimetableFragment(
-                    216000719, 216000096, 216000026, 216000043
-                ).also { direction ->
-                    findNavController().safeNavigate(direction)
-                }
             }
             headerThird.visibility = View.GONE
             realtimeViewThird.visibility = View.GONE
@@ -211,16 +196,8 @@ class BusTabSeoulFragment @Inject constructor() : Fragment() {
         return binding.root.also { disableViewStateSaving(it) }
     }
 
-    @SuppressLint("DefaultLocale")
-    private fun add24HoursAfterMidnight(time: LocalTime): String {
-        val hour = time.hour
-        val minute = time.minute
-        val second = time.second
-        return if (hour < 5) {
-            String.format("%02d:%02d:%02d", hour + 24, minute, second)
-        } else {
-            String.format("%02d:%02d:%02d", hour, minute, second)
-        }
+    private fun currentSeoulTargetStopID(): Int {
+        return (parentViewModel.seoulTarget.value ?: BusSeoulTargetStop.GANGNAM).stopID
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSuwonFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTabSuwonFragment.kt
@@ -15,14 +15,21 @@ import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.FragmentBusRealtimeTabBinding
 import app.kobuggi.hyuabot.util.NavControllerExtension.safeNavigate
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.LocalTime
 import javax.inject.Inject
 import app.kobuggi.hyuabot.util.disableViewStateSaving
+
+private val SUWON_STOP_BY_RES = mapOf(
+    R.string.bus_stop_entrance to 216000070,
+    R.string.bus_stop_suwon_station to 202000106,
+)
 
 @AndroidEntryPoint
 class BusTabSuwonFragment @Inject constructor() : Fragment() {
     private val binding by lazy { FragmentBusRealtimeTabBinding.inflate(layoutInflater) }
     private val parentViewModel: BusRealtimeViewModel by viewModels({ requireParentFragment() })
+
+    private fun logsFor(route: Int, stop: Int) =
+        parentViewModel.logResult.value?.firstOrNull { it.route.seq == route && it.stop.seq == stop }?.log ?: emptyList()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,34 +38,53 @@ class BusTabSuwonFragment @Inject constructor() : Fragment() {
     ): View {
         val decoration = DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
         val busSecondAdapter = BusRealtimeListAdapter(maxCount = 10)
-        parentViewModel.result.observe(viewLifecycleOwner) { busList ->
-            if (busList == null) return@observe
-            val routes = busList.filter { route -> route.stop.seq == 216000070 && (route.route.seq == 216000104 || route.route.seq == 200000015) }
-            val arrivalList = routes.flatMap { route -> route.arrival.map { BusArrivalItem(route.route.name, it) } }
-            busSecondAdapter.updateData(arrivalList.sortedWith(compareBy({ it.item.minutes ?: Int.MAX_VALUE }, { it.item.arrivalTime ?: LocalTime.MAX })))
-            binding.noRealtimeDataFirst.visibility = if (arrivalList.isEmpty()) View.VISIBLE else View.GONE
+        parentViewModel.showSecondaryEta.observe(viewLifecycleOwner) {
+            busSecondAdapter.setShowSecondaryEta(it)
+        }
+        parentViewModel.suwonStopID.observe(viewLifecycleOwner) { stopRes ->
+            if (stopRes == null) return@observe
+            val stopSeq = SUWON_STOP_BY_RES[stopRes] ?: return@observe
+            val secondaryTargetSeq = if (stopRes == R.string.bus_stop_suwon_station) 216000141 else 202000208
+            val stopName = getString(stopRes)
+            binding.apply {
+                headerFirstTitle.text = getString(R.string.bus_header_format, "7070/9090", stopName)
+                headerFirstStopBtn.setOnClickListener {
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(stopSeq, 216000104, 200000015).also { direction ->
+                        findNavController().safeNavigate(direction)
+                    }
+                }
+                departureLogFirst.setOnClickListener {
+                    AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
+                    BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(
+                        stopSeq,
+                        216000104,
+                        200000015
+                    ).also { direction ->
+                        findNavController().safeNavigate(direction)
+                    }
+                }
+            }
+            parentViewModel.result.observe(viewLifecycleOwner) { busList ->
+                val routes = busList.filter { route -> route.stop.seq == stopSeq && (route.route.seq == 216000104 || route.route.seq == 200000015) }
+                val arrivalList = routes.flatMap { route ->
+                    val secondaryLogs = logsFor(route.route.seq, secondaryTargetSeq)
+                    route.arrival.map { arrival ->
+                        BusArrivalItem(
+                            route.route.name,
+                            arrival,
+                            BusSecondaryEta.secondaryArrivalTime(arrival, logsFor(route.route.seq, route.stop.seq), secondaryLogs)
+                        )
+                    }
+                }
+                busSecondAdapter.updateData(arrivalList.sortedBy { it.remainingMinutes ?: Double.MAX_VALUE })
+                binding.noRealtimeDataFirst.visibility = if (arrivalList.isEmpty()) View.VISIBLE else View.GONE
+            }
         }
         binding.apply {
-            headerFirstTitle.text = getString(R.string.bus_header_format, "7070/9090", getString(R.string.bus_stop_entrance))
             realtimeViewFirst.apply {
                 adapter = busSecondAdapter
                 addItemDecoration(decoration)
                 layoutManager = LinearLayoutManager(context)
-            }
-            headerFirstStopBtn.setOnClickListener {
-                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusStopInfoFragment(216000070, 216000104, 200000015).also { direction ->
-                    findNavController().safeNavigate(direction)
-                }
-            }
-            departureLogFirst.setOnClickListener {
-                AnalyticsManager.logSelect(AnalyticsItem.BUS_SHOW_DEPARTURE_LOG)
-                BusRealtimeFragmentDirections.actionBusRealtimeFragmentToBusDepartureLogDialogFragment(
-                    216000070,
-                    216000104,
-                    200000015
-                ).also { direction ->
-                    findNavController().safeNavigate(direction)
-                }
             }
             entireTimetableFirst.isEnabled = false
             headerSecond.visibility = View.GONE

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTravelTimeEstimator.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/bus/realtime/BusTravelTimeEstimator.kt
@@ -1,0 +1,59 @@
+package app.kobuggi.hyuabot.ui.bus.realtime
+
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.math.abs
+
+data class LogEntry(val date: LocalDate, val time: LocalTime, val vehicle: String)
+
+object BusTravelTimeEstimator {
+    private data class Sample(val primaryMinutes: Double, val durationMinutes: Double)
+
+    private const val MAX_PLAUSIBLE_DURATION_MINUTES = 180.0
+    private val TIME_OF_DAY_WINDOWS = listOf(30.0, 60.0, 120.0)
+
+    fun secondaryArrivalTime(
+        primaryArrivalTime: LocalTime,
+        primaryLogs: List<LogEntry>,
+        secondaryLogs: List<LogEntry>
+    ): LocalTime? {
+        val samples = travelDurationSamples(primaryLogs, secondaryLogs)
+        if (samples.isEmpty()) return null
+
+        val targetMinutes = minutesSinceMidnight(primaryArrivalTime)
+        for (window in TIME_OF_DAY_WINDOWS) {
+            val nearby = samples.filter { abs(it.primaryMinutes - targetMinutes) <= window }
+            if (nearby.isEmpty()) continue
+            val averageDuration = nearby.sumOf { it.durationMinutes } / nearby.size.toDouble()
+            return offsetLocalTime(primaryArrivalTime, averageDuration)
+        }
+        return null
+    }
+
+    private fun travelDurationSamples(
+        primaryLogs: List<LogEntry>,
+        secondaryLogs: List<LogEntry>
+    ): List<Sample> {
+        val secondaryByDate = secondaryLogs.groupBy { it.date }
+        val samples = mutableListOf<Sample>()
+        for (primaryLog in primaryLogs) {
+            val sameDateSecondaryLogs = secondaryByDate[primaryLog.date] ?: continue
+            val laterMatches = sameDateSecondaryLogs.filter { it.vehicle == primaryLog.vehicle && it.time > primaryLog.time }
+            val matched = laterMatches.minByOrNull { it.time } ?: continue
+
+            val primaryMinutes = minutesSinceMidnight(primaryLog.time)
+            val duration = minutesSinceMidnight(matched.time) - primaryMinutes
+            if (duration <= 0 || duration >= MAX_PLAUSIBLE_DURATION_MINUTES) continue
+            samples.add(Sample(primaryMinutes, duration))
+        }
+        return samples
+    }
+
+    private fun minutesSinceMidnight(time: LocalTime): Double =
+        time.hour * 60.0 + time.minute + time.second / 60.0
+
+    private fun offsetLocalTime(time: LocalTime, minutes: Double): LocalTime {
+        // plusSeconds wraps around midnight automatically, matching LocalTime's circular semantics
+        return time.plusSeconds((minutes * 60).toLong())
+    }
+}

--- a/app/src/main/res/layout/dialog_bus_quick_settings.xml
+++ b/app/src/main/res/layout/dialog_bus_quick_settings.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/background"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="20dp"
+        android:paddingTop="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="12dp"
+        android:text="@string/bus_quick_settings_title"
+        android:textColor="@color/primary_text"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="18dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_home_row"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="14dp"
+                android:paddingEnd="10dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/bus_quick_settings_show_secondary_eta"
+                    android:textColor="@color/primary_text"
+                    android:textSize="15sp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/show_secondary_eta_switch"
+                    style="@style/Widget.App.Switch.Shuttle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/bus_quick_settings_show_secondary_eta" />
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/app_separator" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="14dp"
+                android:paddingEnd="10dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/bus_quick_settings_seoul_target"
+                    android:textColor="@color/primary_text"
+                    android:textSize="15sp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/seoul_target_button"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="40dp"
+                    android:minWidth="0dp"
+                    android:textColor="@color/plain_button_text"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    app:icon="@drawable/ic_chevron_down"
+                    app:iconGravity="textEnd"
+                    app:iconPadding="6dp"
+                    app:iconSize="16dp"
+                    app:iconTint="@color/plain_button_text" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_help_button"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:text="@string/common_help"
+            android:textColor="@color/hanyang_blue"
+            android:textSize="17sp"
+            android:textStyle="bold"
+            app:backgroundTint="@color/home_action_button_background"
+            app:icon="@drawable/ic_help"
+            app:iconGravity="textStart"
+            app:iconPadding="8dp"
+            app:iconTint="@color/hanyang_blue" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_inquiry_button"
+            style="@style/Widget.Material3.Button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:text="@string/inquiry_title"
+            android:textColor="@color/hanyang_blue"
+            android:textSize="17sp"
+            android:textStyle="bold"
+            app:backgroundTint="@color/home_action_button_background"
+            app:icon="@drawable/ic_chat"
+            app:iconGravity="textStart"
+            app:iconPadding="8dp"
+            app:iconTint="@color/hanyang_blue" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_bus_realtime.xml
+++ b/app/src/main/res/layout/fragment_bus_realtime.xml
@@ -70,60 +70,30 @@
         android:layout_width="match_parent"
         android:layout_height="54dp"
         android:background="@color/background"
-        android:gravity="center_vertical"
+        android:gravity="center_vertical|end"
         android:orientation="horizontal"
         android:paddingHorizontal="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
-        <TextView
-            android:id="@+id/bus_action_bar_title"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center_vertical"
-            android:text="@string/bus_action_bar_title"
-            android:textColor="@color/secondary_text"
-            android:textSize="13sp"
-            android:textStyle="bold" />
-
         <com.google.android.material.button.MaterialButton
-            android:id="@+id/inquiry_button"
+            android:id="@+id/bus_quick_settings_button"
             style="@style/Widget.Material3.Button"
             android:layout_width="wrap_content"
             android:layout_height="40dp"
-            android:layout_marginEnd="8dp"
+            android:contentDescription="@string/bus_quick_settings_title"
             android:minHeight="36dp"
             android:paddingHorizontal="12dp"
-            android:text="@string/inquiry_short"
+            android:text="@string/shuttle_quick_settings_button"
             android:textColor="@color/hanyang_blue"
             android:textSize="14sp"
             android:textStyle="bold"
             app:backgroundTint="@color/home_action_button_background"
-            app:icon="@drawable/ic_chat"
+            app:icon="@drawable/ic_settings"
             app:iconGravity="textStart"
             app:iconPadding="6dp"
-            app:iconSize="16dp"
             app:iconTint="@color/hanyang_blue" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/help_button"
-            style="@style/Widget.Material3.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="40dp"
-            android:contentDescription="@string/bus_help_title"
-            android:minHeight="36dp"
-            android:paddingHorizontal="12dp"
-            android:text="@string/common_help"
-            android:textColor="@color/hanyang_blue"
-            android:textSize="14sp"
-            android:textStyle="bold"
-            app:backgroundTint="@color/home_action_button_background"
-            app:icon="@drawable/ic_help"
-            app:iconGravity="textStart"
-            app:iconTint="@color/hanyang_blue"
-            app:iconPadding="6dp" />
     </LinearLayout>
 
     <com.faltenreich.skeletonlayout.SkeletonLayout

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -252,6 +252,15 @@
     <string name="bus_stop_entrance">Seongan High School</string>
     <string name="bus_stop_sangnoksu_station">Sangnoksu Stn.</string>
     <string name="bus_stop_terminal">Ansan Terminal</string>
+    <string name="bus_stop_seocho">Seocho Station</string>
+    <string name="bus_stop_gyodae">Gyodae Station</string>
+    <string name="bus_stop_gangnam">Gangnam Station</string>
+    <string name="bus_stop_yangjae">Yangjae Station</string>
+    <string name="bus_stop_yangjae_forest">Yangjae Citizens\' Forest Station</string>
+    <string name="bus_stop_suwon_station">Suwon Station</string>
+    <string name="bus_quick_settings_title">Bus settings</string>
+    <string name="bus_quick_settings_show_secondary_eta">Show arrival time</string>
+    <string name="bus_quick_settings_seoul_target">Seoul-bound destination</string>
     <!-- 노선 버스 정류장 선택 -->
     <string name="bus_stop_title">Stop Information</string>
     <string-array name="bus_stop_list">
@@ -279,6 +288,7 @@
     </plurals>
     <string name="bus_timetable_format_last">Departs at %1$s:%2$s (Last)</string>
     <string name="bus_arrival_estimated_format">%1$d min (scheduled)</string>
+    <string name="bus_arrival_secondary_format">" → arrives %1$s"</string>
     <!-- 노선버스 도착 정보 없음 -->
     <string name="bus_no_realtime_data">There are no buses scheduled to arrive.</string>
     <string name="bus_departure_log">Departure Log</string>
@@ -710,7 +720,6 @@
     <string name="language_suggestion_message">Your system language is %1$s. Would you like to switch the app language?</string>
     <string name="language_suggestion_keep_english">Keep English</string>
     <string name="bus_help_title">Bus Help</string>
-    <string name="bus_action_bar_title">Bus guide</string>
     <string name="bus_help_realtime_title">1. Checking Route Bus Arrival Information</string>
     <string name="bus_help_realtime_content">Route bus arrival information is displayed in the order of real-time arrival information and departure times from the terminal provided by the transportation company. If arrival information is not displayed on the electronic board at the stop, real-time arrival information can be checked after the terminal departure time.</string>
     <string name="bus_help_stop_title">2. Checking Route Bus Stop Information</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -235,6 +235,15 @@
     <string name="bus_stop_entrance">漢陽大入口</string>
     <string name="bus_stop_sangnoksu_station">常緑樹駅3番出口向かい</string>
     <string name="bus_stop_terminal">安山パークプルジオ</string>
+    <string name="bus_stop_seocho">瑞草駅</string>
+    <string name="bus_stop_gyodae">教大駅</string>
+    <string name="bus_stop_gangnam">江南駅</string>
+    <string name="bus_stop_yangjae">良才駅</string>
+    <string name="bus_stop_yangjae_forest">良才市民の森駅</string>
+    <string name="bus_stop_suwon_station">水原駅</string>
+    <string name="bus_quick_settings_title">バス設定</string>
+    <string name="bus_quick_settings_show_secondary_eta">到着時刻を表示</string>
+    <string name="bus_quick_settings_seoul_target">ソウル方面の目的地</string>
     <string name="bus_stop_title">路線バス停留所情報</string>
     <string-array name="bus_stop_list">
         <item>@string/bus_stop_dormitory</item>
@@ -260,6 +269,7 @@
     </plurals>
     <string name="bus_timetable_format_last">%1$s時%2$s分発（終バス）</string>
     <string name="bus_arrival_estimated_format">%1$d分（予定）</string>
+    <string name="bus_arrival_secondary_format">" → %1$s到着"</string>
     <string name="bus_no_realtime_data">到着予定のバスはありません。</string>
     <string name="bus_departure_log">到着記録</string>
     <string name="bus_log_title">路線バス通過情報</string>
@@ -687,7 +697,6 @@
     <string name="language_suggestion_message">システム言語が%1$sに設定されています。アプリの言語を変更しますか？</string>
     <string name="language_suggestion_keep_english">英語を維持</string>
     <string name="bus_help_title">バスのヘルプ</string>
-    <string name="bus_action_bar_title">バス利用案内</string>
     <string name="bus_help_realtime_title">1. 路線バス到着情報の確認</string>
     <string name="bus_help_realtime_content">路線バスの到着情報は、リアルタイム到着情報と運送会社が提供する終点出発時間の順に表示されます。停留所の電光掲示板に到着情報が表示されない場合、終点出発時間以降にリアルタイム到着情報を確認できます。</string>
     <string name="bus_help_stop_title">2. 路線バス停留所情報の確認</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -235,6 +235,15 @@
     <string name="bus_stop_entrance">汉阳大入口</string>
     <string name="bus_stop_sangnoksu_station">常绿树站3号出口对面</string>
     <string name="bus_stop_terminal">安山公园普鲁吉奥</string>
+    <string name="bus_stop_seocho">瑞草站</string>
+    <string name="bus_stop_gyodae">教大站</string>
+    <string name="bus_stop_gangnam">江南站</string>
+    <string name="bus_stop_yangjae">良才站</string>
+    <string name="bus_stop_yangjae_forest">良才市民之林站</string>
+    <string name="bus_stop_suwon_station">水原站</string>
+    <string name="bus_quick_settings_title">公交设置</string>
+    <string name="bus_quick_settings_show_secondary_eta">显示到达时间</string>
+    <string name="bus_quick_settings_seoul_target">首尔方向目的地</string>
     <string name="bus_stop_title">路线公交站点信息</string>
     <string-array name="bus_stop_list">
         <item>@string/bus_stop_dormitory</item>
@@ -260,6 +269,7 @@
     </plurals>
     <string name="bus_timetable_format_last">%1$s时%2$s分出发（末班）</string>
     <string name="bus_arrival_estimated_format">%1$d分（预计）</string>
+    <string name="bus_arrival_secondary_format">" → %1$s到达"</string>
     <string name="bus_no_realtime_data">暂无即将到达的公交。</string>
     <string name="bus_departure_log">到站记录</string>
     <string name="bus_log_title">路线公交通过信息</string>
@@ -687,7 +697,6 @@
     <string name="language_suggestion_message">您的系统语言设置为%1$s。是否切换应用语言？</string>
     <string name="language_suggestion_keep_english">保持英语</string>
     <string name="bus_help_title">公交帮助</string>
-    <string name="bus_action_bar_title">公交使用指南</string>
     <string name="bus_help_realtime_title">1. 查看路线公交到达信息</string>
     <string name="bus_help_realtime_content">路线公交到达信息按实时到达信息和运输公司提供的终点出发时间顺序显示。如果站内电子屏幕未显示到达信息，可在终点出发时间后查看实时到达信息。</string>
     <string name="bus_help_stop_title">2. 查看路线公交站点信息</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,15 @@
     <string name="bus_stop_entrance">한양대입구</string>
     <string name="bus_stop_sangnoksu_station">상록수역3번출구건너편</string>
     <string name="bus_stop_terminal">안산파크푸르지오</string>
+    <string name="bus_stop_seocho">서초역</string>
+    <string name="bus_stop_gyodae">교대역</string>
+    <string name="bus_stop_gangnam">강남역</string>
+    <string name="bus_stop_yangjae">양재역</string>
+    <string name="bus_stop_yangjae_forest">양재시민의숲역</string>
+    <string name="bus_stop_suwon_station">수원역</string>
+    <string name="bus_quick_settings_title">버스 설정</string>
+    <string name="bus_quick_settings_show_secondary_eta">도착 시간 표시</string>
+    <string name="bus_quick_settings_seoul_target">서울 방면 목적지</string>
     <!-- 노선 버스 정류장 선택 -->
     <string name="bus_stop_title">노선버스 정류장 정보</string>
     <string-array name="bus_stop_list">
@@ -317,6 +326,7 @@
         <item quantity="other">%1$d분 (%2$d전)</item>
     </plurals>
     <string name="bus_arrival_estimated_format">%1$d분 (예정)</string>
+    <string name="bus_arrival_secondary_format">" → %1$s 도착"</string>
     <string name="bus_timetable_format">%1$s시 %2$s분 출발</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d분 (%2$d전, %3$d석, 막차)</item>
@@ -769,7 +779,6 @@
     <string name="shortcut_map_long">캠퍼스 지도</string>
     <!-- Bus Help Dialog -->
     <string name="bus_help_title">노선버스 도움말</string>
-    <string name="bus_action_bar_title">버스 이용 안내</string>
     <string name="bus_help_realtime_title">1. 노선버스 도착 정보 확인</string>
     <string name="bus_help_realtime_content">노선버스 도착 정보는 실시간 도착 정보 및 운수 업체에서 제공한 회차지 출발 시간 순서로 표시합니다. 정류장 내 전광판에 도착 정보가 표시되지 않는 경우, 회차지 출발 시간 이후 실시간 도착 정보를 확인할 수 있습니다.</string>
     <string name="bus_help_stop_title">2. 노선버스 정류장 정보 확인</string>


### PR DESCRIPTION
## Changes

### 버스 실시간

- 서울·수원 방면 탭에 반대쪽 정류장의 도착 예정 시간을 과거 운행 로그 기반으로 추정해 함께 표시했습니다.
- GPS 최근접 정류장 선택 범위를 서울·수원 방면 원거리 정류장까지 확장했습니다.
- 보조 도착 예정 시간 표시 여부와 서울 방면 목적지를 고를 수 있는 빠른 설정 시트를 추가했습니다.
- 수원역 기준 정류장을 하차 전용(4번 출구) 대신 승차 전용(7번 출구)으로, 7070·9090 보조 목적지를 실제 복귀 방향 정류장으로 수정했습니다.
- 보조 ETA용 과거 로그 쿼리를 15초 폴링되는 실시간 쿼리에서 분리했습니다. 40여 개 정류장의 로그를 매 폴링마다 함께 받아오면서 정규화 캐시가 무한히 커져 OOM 크래시가 발생했기 때문입니다.

## Checks

- [x] Android 에뮬레이터에서 GPS 위치별 정류장 전환, 보조 ETA on/off, 목적지 변경 확인
- [x] iOS 앱과 동일 조건에서 보조 ETA 값 일치 확인