### PR TITLE
chore: Unify app and watch version to 26.08.07

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 29
         targetSdk = 37
-        versionCode = 521000000
-        versionName = "5.2.1"
+        versionCode = (project.property("APP_VERSION_CODE") as String).toInt()
+        versionName = project.property("APP_VERSION_NAME") as String
         signingConfig = signingConfigs.getByName("config")
         manifestPlaceholders["MAP_CLIENT_ID"] = props["MAP_CLIENT_ID"]?.toString() ?: ""
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,6 @@ android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
 android.builtInKotlin=true
 android.newDsl=true
+# Shared version for app and watch modules (kept in sync manually on release)
+APP_VERSION_NAME=26.08.07
+APP_VERSION_CODE=2026080700

--- a/watch/build.gradle.kts
+++ b/watch/build.gradle.kts
@@ -41,8 +41,8 @@ android {
         applicationId = "app.kobuggi.hyuabot"
         minSdk = 33
         targetSdk = 35
-        versionCode = 519100000
-        versionName = "5.1.9"
+        versionCode = (project.property("APP_VERSION_CODE") as String).toInt()
+        versionName = project.property("APP_VERSION_NAME") as String
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
     }


### PR DESCRIPTION
## Summary
- Move `versionName`/`versionCode` into `gradle.properties` as a single source shared by `app` and `watch`
- Unify both modules to `26.08.07` (date-based) so they no longer drift independently

## Test plan
- [x] `./gradlew :app:properties :watch:properties` configures without errors