### PR TITLE
chore: switch changelog sync to manual draft-PR workflow

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,17 +1,10 @@
-name: Sync Changelog to Docs
+name: Draft Changelog on Docs
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - gradle.properties
-
-concurrency:
-  group: android-sync-changelog
-  cancel-in-progress: false
+  workflow_dispatch:
 
 jobs:
-  sync:
+  draft:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,20 +12,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect version change
+      - name: Read current version
         id: version
         run: |
-          NEW_VERSION=$(grep '^APP_VERSION_NAME=' gradle.properties | cut -d= -f2)
-          OLD_VERSION=$(git show HEAD^:gradle.properties 2>/dev/null | grep '^APP_VERSION_NAME=' | cut -d= -f2 || echo "")
-          if [ "$NEW_VERSION" = "$OLD_VERSION" ] || [ -z "$NEW_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          VERSION=$(grep '^APP_VERSION_NAME=' gradle.properties | cut -d= -f2)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read APP_VERSION_NAME from gradle.properties"
+            exit 1
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Find previous version-bump commit
-        if: steps.version.outputs.changed == 'true'
         id: range
         run: |
           PREV_COMMIT=$(git log --skip=1 -n 1 --format=%H -- gradle.properties)
@@ -42,7 +32,6 @@ jobs:
           echo "prev=$PREV_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Build changelog body
-        if: steps.version.outputs.changed == 'true'
         id: body
         run: |
           git log ${{ steps.range.outputs.prev }}..HEAD --no-merges --format='%s' \
@@ -77,21 +66,27 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout docs site
-        if: steps.version.outputs.changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: hyuabot-developers/hyuabot-developers.github.io
           token: ${{ secrets.DOCS_SYNC_TOKEN }}
           path: docs-site
 
-      - name: Write changelog entry
-        if: steps.version.outputs.changed == 'true'
+      - name: Create draft branch and file
+        id: draft
         env:
           VERSION: ${{ steps.version.outputs.version }}
           BODY: ${{ steps.body.outputs.body }}
+        working-directory: docs-site
         run: |
+          BRANCH="changelog-draft/android-v${VERSION}"
           DATE=$(date +%Y-%m-%d)
-          FILE="docs-site/changelog/android/${DATE}-v${VERSION}.md"
+          FILE="changelog/android/${DATE}-v${VERSION}.md"
+
+          git config user.name "hyuabot-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+
           {
             echo '---'
             echo "slug: v${VERSION}"
@@ -103,18 +98,33 @@ jobs:
             echo "$BODY"
           } > "$FILE"
 
-      - name: Commit and push
-        if: steps.version.outputs.changed == 'true'
+          git add "$FILE"
+          if git diff --cached --quiet; then
+            echo "No changes to draft"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "docs: draft Android v${VERSION} changelog"
+            git push -f origin "$BRANCH"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update draft PR
+        if: steps.draft.outputs.has_changes == 'true'
         working-directory: docs-site
         env:
+          GH_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.draft.outputs.branch }}
         run: |
-          git config user.name "hyuabot-bot"
-          git config user.email "actions@users.noreply.github.com"
-          git add changelog/android
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR already exists for $BRANCH"
           else
-            git commit -m "docs: add Android v${VERSION} changelog"
-            git push
+            gh pr create \
+              --title "docs: Android v${VERSION} changelog draft" \
+              --body "커밋 로그로 자동 생성한 초안입니다. 필요하면 내용을 수정한 뒤 머지해 주세요." \
+              --base main \
+              --head "$BRANCH" \
+              --label documentation \
+              --assignee jil8885
           fi


### PR DESCRIPTION
## Summary
- Replace the automatic push-triggered changelog sync with a manually dispatched workflow (Actions tab → Run workflow)
- Instead of pushing directly to the docs site's main branch, it now opens a draft PR so the changelog wording can be reviewed/edited before publishing

## Test plan
- [ ] Run workflow manually from the Actions tab
- [ ] Confirm a draft PR appears on hyuabot-developers.github.io