### PR TITLE
fix: match version-bump commits by message, not file touch

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Find previous version-bump commit
         id: range
         run: |
-          PREV_COMMIT=$(git log --skip=1 -n 1 --format=%H -- gradle.properties)
+          PREV_COMMIT=$(git log --no-merges --skip=1 -n 1 --format=%H -i -E --grep='^(chore: )?(bump|unify).*version')
           if [ -z "$PREV_COMMIT" ]; then
             PREV_COMMIT=$(git rev-list --max-parents=0 HEAD)
           fi


### PR DESCRIPTION
## Summary
- The draft-changelog workflow found the previous version bump by looking at gradle.properties history, but that file wasn't touched on every past bump — the first real run pulled in the entire commit log
- Match commit messages (\`bump/unify ... version\`) instead, excluding merge commits (their body duplicates the squashed message and double-matched)

## Test plan
- [x] Verified locally that the new git log command resolves to the correct previous bump commit