### PR TITLE
fix: broaden version-bump commit filter in changelog body

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -35,7 +35,7 @@ jobs:
         id: body
         run: |
           git log ${{ steps.range.outputs.prev }}..HEAD --no-merges --format='%s' \
-            | grep -Eiv '^(chore: )?(bump|unify)( app)?( and watch)?( and widget)? version' \
+            | grep -Eiv '^(chore: )?(bump|unify).*version' \
             > /tmp/commits.txt || true
 
           {


### PR DESCRIPTION
## Summary
- The body-filter regex only matched a few hardcoded phrasings, so "Unify app, watch, and widget version to X" slipped into the 기타 변경 사항 section of the iOS draft
- Match the same broad pattern already used for range detection

## Test plan
- [x] Verified locally that the new pattern excludes the observed message