### PR TITLE
feat: add help entry linking to docs site in settings

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
@@ -47,6 +47,10 @@ class SettingFragment @Inject constructor() : Fragment(), DialogInterface.OnDism
             settingLanguage.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.SETTING_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM, name = "language"); openLanguageDialog() }
             settingTheme.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.SETTING_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM, name = "theme"); openThemeDialog() }
             appInfo.setOnClickListener { AnalyticsManager.logSelect(AnalyticsItem.SETTING_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM, name = "info"); openInfoDialog() }
+            settingHelp.setOnClickListener {
+                AnalyticsManager.logSelect(AnalyticsItem.SETTING_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM, name = "help")
+                openHelp()
+            }
             settingPrivacyPolicy.setOnClickListener {
                 AnalyticsManager.logSelect(AnalyticsItem.SETTING_SELECT_ROW, type = AnalyticsContentType.LIST_ITEM, name = "privacy_policy")
                 openPrivacyPolicy()
@@ -166,6 +170,24 @@ class SettingFragment @Inject constructor() : Fragment(), DialogInterface.OnDism
 
     private fun openInfoDialog() {
         SettingFragmentDirections.actionSettingFragmentToSettingDeveloperDialogFragment().also {
+            findNavController().safeNavigate(it)
+        }
+    }
+
+    private fun openHelp() {
+        val appLanguage = AppCompatDelegate.getApplicationLocales()[0]?.language
+            ?: resources.configuration.locales[0].language
+        val docsLocalePath = when (appLanguage) {
+            "en" -> "en/"
+            "ja" -> "ja/"
+            "zh" -> "zh-Hans/"
+            else -> ""
+        }
+        val url = "${getString(R.string.docs_site_base_url)}/$docsLocalePath" + "docs/android"
+        SettingFragmentDirections.actionSettingFragmentToNoticeWebViewFragment(
+            url,
+            getString(R.string.help),
+        ).also {
             findNavController().safeNavigate(it)
         }
     }

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -195,6 +195,54 @@
         android:layout_height="1dp"
         android:background="@color/app_separator"/>
     <LinearLayout
+        android:id="@+id/setting_help"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingVertical="16dp">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:backgroundTint="@color/app_separator"
+            android:contentDescription="@string/help"
+            android:src="@drawable/ic_question_circle"
+            app:tint="@color/plain_button_text"/>
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="20dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/help"
+                android:textColor="@color/primary_text"
+                android:textFontWeight="700"
+                android:textSize="18sp"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/help_description"
+                android:textColor="@color/secondary_text"
+                android:textSize="12sp"/>
+        </LinearLayout>
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@string/help"
+            android:src="@drawable/ic_arrow_right"
+            app:tint="@color/plain_button_text"/>
+    </LinearLayout>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/app_separator"/>
+    <LinearLayout
         android:id="@+id/setting_privacy_policy"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -562,6 +562,8 @@
     <string name="about">App Information</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="privacy_policy_description">Learn what information is collected and why.</string>
+    <string name="help">Help</string>
+    <string name="help_description">View app usage guides on the docs site.</string>
     <string name="open_source_licenses">Open Source Licenses</string>
     <string name="open_source_licenses_description">View the open source software used by the app.</string>
     <string name="developer_name">Developer: Jeongin Lee</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -541,6 +541,8 @@
     <string name="about">アプリ情報</string>
     <string name="privacy_policy">プライバシーポリシー</string>
     <string name="privacy_policy_description">収集する情報と利用目的を確認します。</string>
+    <string name="help">ヘルプ</string>
+    <string name="help_description">アプリの使い方をドキュメントサイトで確認します。</string>
     <string name="open_source_licenses">オープンソースライセンス</string>
     <string name="open_source_licenses_description">アプリで使用しているオープンソースソフトウェアを確認します。</string>
     <string name="developer_name">開発者: イ・ジョンイン</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -541,6 +541,8 @@
     <string name="about">应用信息</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="privacy_policy_description">了解所收集的信息及其用途。</string>
+    <string name="help">帮助</string>
+    <string name="help_description">在文档网站上查看应用使用说明。</string>
     <string name="open_source_licenses">开源许可</string>
     <string name="open_source_licenses_description">查看本应用使用的开源软件。</string>
     <string name="developer_name">开发者: 李正仁</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -624,6 +624,9 @@
     <string name="privacy_policy">개인정보처리방침</string>
     <string name="privacy_policy_description">수집 정보와 이용 목적을 확인합니다.</string>
     <string name="privacy_policy_url" translatable="false">https://jil8885.github.io/privacy_policy</string>
+    <string name="help">도움말</string>
+    <string name="help_description">앱 사용법을 문서 사이트에서 확인합니다.</string>
+    <string name="docs_site_base_url" translatable="false">https://hyuabot-developers.github.io</string>
     <string name="open_source_licenses">오픈소스 라이선스</string>
     <string name="open_source_licenses_description">앱에서 사용하는 오픈소스 소프트웨어를 확인합니다.</string>
     <string name="developer_name">개발자: 이정인</string>


### PR DESCRIPTION
## Summary
- Add a "Help" row in Settings, positioned above Privacy Policy, using the existing `NoticeWebviewFragment` component
- Opens `https://hyuabot-developers.github.io/{lang}/docs/android` based on the app's current language setting (ko has no locale prefix, matching the docs site's default locale)

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin` succeeds
- [ ] Manually verify the Help row opens the correct localized docs page for ko/en/ja/zh