### PR TITLE
feat: localize subway station names

### DIFF
--- a/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
@@ -86,7 +86,7 @@ query HomePageQuery(
             isRealtime
         }
     }
-    subway(input: { keys: [
+    subway(input: { language: $language, keys: [
         { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K258", direction: ["down"], weekdays: [$weekday], limit: 12 },

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
@@ -66,7 +66,7 @@ query ShuttleRealtimePageQuery(
             }
         }
     }
-    subway(input: { keys: [
+    subway(input: { language: $language, keys: [
         { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K450", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleTransferQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleTransferQuery.graphql
@@ -1,5 +1,5 @@
-query ShuttleTransferQuery($weekday: String!) {
-    subway(input: { keys: [
+query ShuttleTransferQuery($weekday: String!, $language: String!) {
+    subway(input: { language: $language, keys: [
         { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 2 },
         { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 2 },
     ]}) {

--- a/app/src/main/graphql/app/kobuggi/hyuabot/SubwayRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/SubwayRealtimePageQuery.graphql
@@ -1,6 +1,7 @@
-query SubwayRealtimePageQuery($weekday: String!) {
+query SubwayRealtimePageQuery($weekday: String!, $language: String!) {
     subway (
         input: {
+            language: $language,
             keys: [
                 { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 4 },
                 { stationID: "K456", direction: ["up", "down"], weekdays: [$weekday], limit: null },

--- a/app/src/main/graphql/app/kobuggi/hyuabot/SubwayTimetablePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/SubwayTimetablePageQuery.graphql
@@ -1,6 +1,7 @@
-query SubwayTimetablePageQuery($station: String!, $direction: [String!]!) {
+query SubwayTimetablePageQuery($station: String!, $direction: [String!]!, $language: String!) {
     subway (
         input: {
+            language: $language,
             keys: [
                 { stationID: $station, direction: $direction, weekdays: ["weekdays", "weekends"] },
             ]

--- a/app/src/main/graphql/schema.graphqls
+++ b/app/src/main/graphql/schema.graphqls
@@ -925,7 +925,8 @@ type SubwayArrivalGroup {
  전철 정보를 반환하는 쿼리입니다.
 """
 input SubwayInput {
-  keys: [SubwayStationInput!]!
+    keys: [SubwayStationInput!]!
+    language: String
 }
 
 type SubwayOriginTerminal {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeListAdapter.kt
@@ -27,13 +27,13 @@ class SubwayRealtimeListAdapter(
                     binding.subwayDestinationText.apply {
                         text = context.getString(
                             R.string.subway_realtime_destination_format_last,
-                            getTerminalString(arrival.terminal.stationID),
+                            arrival.terminal.name,
                         )
                     }
                 } else {
                     binding.subwayDestinationText.text = context.getString(
                         R.string.subway_realtime_destination_format,
-                        getTerminalString(arrival.terminal.stationID),
+                        arrival.terminal.name,
                     )
                 }
                 val realtimeText = if (arrival.stops != null && arrival.stops > 0) {
@@ -56,7 +56,7 @@ class SubwayRealtimeListAdapter(
                 binding.apply {
                     subwayDestinationText.text = context.getString(
                         R.string.subway_realtime_destination_format,
-                        getTerminalString(arrival.terminal.stationID),
+                        arrival.terminal.name,
                     )
                     subwayTimeText.text = context.resources.getQuantityString(
                         R.plurals.subway_realtime_timetable_format,
@@ -101,23 +101,4 @@ class SubwayRealtimeListAdapter(
         notifyDataSetChanged()
     }
 
-    private fun getTerminalString(terminal: String): String {
-        return when (terminal) {
-            "K209" -> context.getString(R.string.subway_station_K209)
-            "K210" -> context.getString(R.string.subway_station_K210)
-            "K233" -> context.getString(R.string.subway_station_K233)
-            "K246" -> context.getString(R.string.subway_station_K246)
-            "K258" -> context.getString(R.string.subway_station_K258)
-            "K272" -> context.getString(R.string.subway_station_K272)
-            "K409" -> context.getString(R.string.subway_station_K409)
-            "K411" -> context.getString(R.string.subway_station_K411)
-            "K419" -> context.getString(R.string.subway_station_K419)
-            "K433" -> context.getString(R.string.subway_station_K433)
-            "K443" -> context.getString(R.string.subway_station_K443)
-            "K444" -> context.getString(R.string.subway_station_K444)
-            "K453" -> context.getString(R.string.subway_station_K453)
-            "K456" -> context.getString(R.string.subway_station_K456)
-            else -> terminal
-        }
-    }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import app.kobuggi.hyuabot.SubwayRealtimePageQuery
+import app.kobuggi.hyuabot.service.translation.DynamicTextTranslator
 import app.kobuggi.hyuabot.util.QueryError
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.cache.normalized.FetchPolicy
@@ -53,7 +54,8 @@ class SubwayRealtimeViewModel @Inject constructor(private val apolloClient: Apol
         val localDate = LocalDate.now()
         viewModelScope.launch {
             val response = apolloClient.query(SubwayRealtimePageQuery(
-                weekday = if (localDate.dayOfWeek.value in 1..5) "weekdays" else "weekends"
+                weekday = if (localDate.dayOfWeek.value in 1..5) "weekdays" else "weekends",
+                language = DynamicTextTranslator.currentAppLanguageTag(),
             )).fetchPolicy(FetchPolicy.NetworkOnly).execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayTransferListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayTransferListAdapter.kt
@@ -20,7 +20,7 @@ class SubwayTransferListAdapter(
         fun bind(transfer: SubwayTransferItem) {
             binding.firstDestinationText.text = context.getString(
                 R.string.subway_transfer_destination_format,
-                getTerminalString(transfer.take.terminal.stationID)
+                transfer.take.terminal.name
             )
             binding.firstTimeText.text = minutesAfter(transfer.take.minutes)
             binding.firstMetaText.text = if (transfer.transfer == null) {
@@ -50,7 +50,7 @@ class SubwayTransferListAdapter(
             )
             binding.secondDestinationText.text = context.getString(
                 R.string.subway_transfer_destination_format,
-                getTerminalString(secondLeg.terminal.stationID)
+                secondLeg.terminal.name
             )
             binding.secondTimeText.text = minutesAfter(secondLeg.minutes)
             binding.secondLineIndicator.backgroundTintList = ColorStateList.valueOf(getLineColor(secondLeg.terminal.stationID))
@@ -72,29 +72,6 @@ class SubwayTransferListAdapter(
     fun updateData(newArrivals: List<SubwayTransferItem>) {
         arrivals = newArrivals
         notifyDataSetChanged()
-    }
-
-    private fun getTerminalString(terminal: String): String {
-        return when (terminal) {
-            "K209" -> context.getString(R.string.subway_station_K209)
-            "K210" -> context.getString(R.string.subway_station_K210)
-            "K233" -> context.getString(R.string.subway_station_K233)
-            "K246" -> context.getString(R.string.subway_station_K246)
-            "K258" -> context.getString(R.string.subway_station_K258)
-            "K272" -> context.getString(R.string.subway_station_K272)
-            "K409" -> context.getString(R.string.subway_station_K409)
-            "K411" -> context.getString(R.string.subway_station_K411)
-            "K419" -> context.getString(R.string.subway_station_K419)
-            "K433" -> context.getString(R.string.subway_station_K433)
-            "K443" -> context.getString(R.string.subway_station_K443)
-            "K444" -> context.getString(R.string.subway_station_K444)
-            "K453" -> context.getString(R.string.subway_station_K453)
-            "K456" -> context.getString(R.string.subway_station_K456)
-            "S07" -> context.getString(R.string.subway_station_S07)
-            "S11" -> context.getString(R.string.subway_station_S11)
-            "S16" -> context.getString(R.string.subway_station_S16)
-            else -> terminal
-        }
     }
 
     private fun getTransferStationString(): String {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableListAdapter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableListAdapter.kt
@@ -15,7 +15,7 @@ class SubwayTimetableListAdapter(
     inner class ViewHolder(private val binding: ItemSubwayTimetableBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(timetable: SubwayTimetableItem) {
             binding.apply {
-                subwayDestinationText.text = getTerminalString(timetable.terminal.stationID)
+                subwayDestinationText.text = timetable.terminal.name
                 subwayTimeText.text = context.getString(
                     R.string.subway_timetable_time_format,
                     timetable.time.substring(0, 2),
@@ -42,23 +42,4 @@ class SubwayTimetableListAdapter(
         notifyDataSetChanged()
     }
 
-    private fun getTerminalString(terminal: String): String {
-        return when (terminal) {
-            "K209" -> context.getString(R.string.subway_station_K209)
-            "K210" -> context.getString(R.string.subway_station_K210)
-            "K233" -> context.getString(R.string.subway_station_K233)
-            "K246" -> context.getString(R.string.subway_station_K246)
-            "K258" -> context.getString(R.string.subway_station_K258)
-            "K272" -> context.getString(R.string.subway_station_K272)
-            "K409" -> context.getString(R.string.subway_station_K409)
-            "K411" -> context.getString(R.string.subway_station_K411)
-            "K419" -> context.getString(R.string.subway_station_K419)
-            "K433" -> context.getString(R.string.subway_station_K433)
-            "K443" -> context.getString(R.string.subway_station_K443)
-            "K444" -> context.getString(R.string.subway_station_K444)
-            "K453" -> context.getString(R.string.subway_station_K453)
-            "K456" -> context.getString(R.string.subway_station_K456)
-            else -> terminal
-        }
-    }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.kobuggi.hyuabot.SubwayTimetablePageQuery
+import app.kobuggi.hyuabot.service.translation.DynamicTextTranslator
 import app.kobuggi.hyuabot.util.QueryError
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.cache.normalized.FetchPolicy
@@ -26,7 +27,13 @@ class SubwayTimetableViewModel @Inject constructor(private val apolloClient: Apo
     fun fetchData(stationID: String, heading: String) {
         _heading.value = heading
         viewModelScope.launch {
-            val response = apolloClient.query(SubwayTimetablePageQuery(stationID, listOf(heading))).fetchPolicy(FetchPolicy.CacheFirst).execute()
+            val response = apolloClient.query(
+                SubwayTimetablePageQuery(
+                    stationID,
+                    listOf(heading),
+                    DynamicTextTranslator.currentAppLanguageTag(),
+                ),
+            ).fetchPolicy(FetchPolicy.CacheFirst).execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.subway != null) {

--- a/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleTransferWidgetProvider.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleTransferWidgetProvider.kt
@@ -101,7 +101,12 @@ class ShuttleTransferWidgetProvider : AppWidgetProvider() {
 
             val transitData = runCatching {
                 entryPoint.apolloClient()
-                    .query(ShuttleTransferQuery(currentShuttleWeekday()))
+                    .query(
+                        ShuttleTransferQuery(
+                            currentShuttleWeekday(),
+                            ctx.resources.configuration.locales[0].toLanguageTag(),
+                        ),
+                    )
                     .execute()
                     .data
             }.getOrNull()

--- a/watch/src/main/graphql/schema.graphqls
+++ b/watch/src/main/graphql/schema.graphqls
@@ -856,7 +856,8 @@ type SubwayArrivalGroup {
  전철 정보를 반환하는 쿼리입니다.
 """
 input SubwayInput {
-  keys: [SubwayStationInput!]!
+    keys: [SubwayStationInput!]!
+    language: String
 }
 
 type SubwayOriginTerminal {


### PR DESCRIPTION
## Summary
- Send the current app locale with every subway GraphQL request used by the app and widgets.
- Display backend-localized station and terminal names instead of client hardcoded maps.
- Update the bundled GraphQL schemas for the language argument.

## Test plan
- [x] `./gradlew ktlintCheck`
- [x] `./gradlew testDevDebugUnitTest app:koverVerifyDevDebug app:koverHtmlReportDevDebug app:koverXmlReportDevDebug`
- [x] `./gradlew :app:compileDevDebugKotlin`
- [x] Verified no new user-facing copy; existing UI localization remains unchanged.