### PR TITLE
fix: improve localized subway displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ All data is fetched via **GraphQL** from the HYUabot backend.
 | Protocol | GraphQL                               |
 | Client   | Apollo Client 4.4.3                   |
 
-Custom scalar adapters are registered for `Date` → `LocalDate`, `LocalTime` → `LocalTime`, and `DateTime` → `ZonedDateTime`.
+Custom scalar adapters are registered for `Date` ▶ `LocalDate`, `LocalTime` ▶ `LocalTime`, and `DateTime` ▶ `ZonedDateTime`.
 
 GraphQL query files live in `app/src/main/graphql/` (shuttle, bus, subway, cafeteria, reading room, calendar, contact, building, etc.).
 
@@ -179,8 +179,8 @@ Two GitHub Actions workflows run on a **self-hosted** runner:
 
 | Workflow        | Trigger                                    | Steps                                                                                           |
 |-----------------|--------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `build.yml`     | Push to `main`, merged PR, manual dispatch | JDK 17 setup → decode keystore & `google-services.json` → `bundleRelease` → upload AAB artifact |
-| `codecheck.yml` | Push to any non-main branch, PR            | JDK 17 setup → `ktlintCheck`                                                                    |
+| `build.yml`     | Push to `main`, merged PR, manual dispatch | JDK 17 setup ▶ decode keystore & `google-services.json` ▶ `bundleRelease` ▶ upload AAB artifact |
+| `codecheck.yml` | Push to any non-main branch, PR            | JDK 17 setup ▶ `ktlintCheck`                                                                    |
 
 Secrets required in the repository:
 - `BASE64_KEYSTORE` — base64-encoded `.jks` signing keystore

--- a/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/HomePageQuery.graphql
@@ -1,5 +1,6 @@
 query HomePageQuery(
     $language: String!
+    $subwayLanguage: String!
     $after: LocalTime
     $weekday: String!
     $date: Date!
@@ -86,7 +87,7 @@ query HomePageQuery(
             isRealtime
         }
     }
-    subway(input: { language: $language, keys: [
+    subway(input: { language: $subwayLanguage, keys: [
         { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K258", direction: ["down"], weekdays: [$weekday], limit: 12 },

--- a/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
+++ b/app/src/main/graphql/app/kobuggi/hyuabot/ShuttleRealtimePageQuery.graphql
@@ -1,5 +1,6 @@
 query ShuttleRealtimePageQuery(
     $language: String!
+    $subwayLanguage: String!
     $after: LocalTime
     $weekday: String!
     $logDates: [Date!]
@@ -66,7 +67,7 @@ query ShuttleRealtimePageQuery(
             }
         }
     }
-    subway(input: { language: $language, keys: [
+    subway(input: { language: $subwayLanguage, keys: [
         { stationID: "K449", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K251", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },
         { stationID: "K450", direction: ["up", "down"], weekdays: [$weekday], limit: 12 },

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import app.kobuggi.hyuabot.HomePageQuery
 import app.kobuggi.hyuabot.service.ShuttlePresenceService
 import app.kobuggi.hyuabot.service.alarm.ShuttleServiceNoticeScheduler
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
+import app.kobuggi.hyuabot.service.translation.DynamicTextTranslator
 import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleGeoCoordinate
 import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleInitialStopRuleCandidate
 import app.kobuggi.hyuabot.type.BusRouteStopInput
@@ -51,6 +52,7 @@ class HomeViewModel @Inject constructor(
     private val _presenceViewerCount = MutableLiveData<Int?>(null)
     private val _presenceAvailableSeats = MutableLiveData<Int?>(null)
     private var isFetching = false
+    private var loadedSubwayLanguage: String? = null
     private var presenceJob: Job? = null
     private var selectedPresenceStop = "dormitory_o"
     private var latestPresenceViewerCounts: Map<String, Int>? = null
@@ -98,6 +100,11 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             if (isFetching) return@launch
             isFetching = true
+            val subwayLanguage = DynamicTextTranslator.currentAppLanguageTag()
+            if (loadedSubwayLanguage != subwayLanguage) {
+                _data.value = null
+                loadedSubwayLanguage = subwayLanguage
+            }
             if (_data.value == null) _isLoading.value = true
             try {
                 val now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
@@ -105,6 +112,7 @@ class HomeViewModel @Inject constructor(
                 val response = apolloClient.query(
                     HomePageQuery(
                         language = currentNoticeLanguage(),
+                        subwayLanguage = subwayLanguage,
                         after = Optional.present(LocalTime.now(ZoneId.of("Asia/Seoul"))),
                         weekday = currentSubwayWeekday(now),
                         date = mealDate,

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleRealtimeViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.ShuttleRealtimePageQuery
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
+import app.kobuggi.hyuabot.service.translation.DynamicTextTranslator
 import app.kobuggi.hyuabot.service.ShuttlePresenceService
 import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
 import app.kobuggi.hyuabot.ui.shuttle.initialstop.ShuttleGeoCoordinate
@@ -74,6 +75,7 @@ class ShuttleRealtimeViewModel @Inject constructor(
     private var presencePreviewCount: Int? = null
     private var presencePreferenceLoaded = false
     private var isStarted = false
+    private var loadedSubwayLanguage: String? = null
 
     val result get() = _result
     val initialStopRules get() = _initialStopRules
@@ -137,9 +139,16 @@ class ShuttleRealtimeViewModel @Inject constructor(
         val locale = AppCompatDelegate.getApplicationLocales().get(0)
         val appLanguage = locale?.language ?: Locale.getDefault().language
         val language = if (appLanguage == Locale.KOREAN.language) "KOREAN" else "ENGLISH"
+        val subwayLanguage = DynamicTextTranslator.currentAppLanguageTag()
+        if (loadedSubwayLanguage != subwayLanguage) {
+            _transfer.value = null
+            _isLoading.value = true
+            loadedSubwayLanguage = subwayLanguage
+        }
         viewModelScope.launch {
             val response = apolloClient.query(ShuttleRealtimePageQuery(
                 language,
+                subwayLanguage,
                 Optional.present(LocalTime.now()),
                 currentShuttleWeekday(),
                 Optional.present(shuttleBusLogReferenceDates()),

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/realtime/SubwayRealtimeViewModel.kt
@@ -32,6 +32,7 @@ class SubwayRealtimeViewModel @Inject constructor(private val apolloClient: Apol
     private val _chojiSeohae = MutableLiveData<SubwayRealtimePageQuery.Subway?>()
     private val _queryError = MutableLiveData<QueryError?>(null)
     private val _disposable = CompositeDisposable()
+    private var loadedLanguage: String? = null
 
     val isLoading get() = _isLoading
     val queryError get() = _queryError
@@ -52,10 +53,20 @@ class SubwayRealtimeViewModel @Inject constructor(private val apolloClient: Apol
 
     fun fetchData() {
         val localDate = LocalDate.now()
+        val language = DynamicTextTranslator.currentAppLanguageTag()
+        if (loadedLanguage != language) {
+            _campusYellow.value = null
+            _campusBlue.value = null
+            _oidoYellow.value = null
+            _oidoBlue.value = null
+            _chojiSeohae.value = null
+            _isLoading.value = true
+            loadedLanguage = language
+        }
         viewModelScope.launch {
             val response = apolloClient.query(SubwayRealtimePageQuery(
                 weekday = if (localDate.dayOfWeek.value in 1..5) "weekdays" else "weekends",
-                language = DynamicTextTranslator.currentAppLanguageTag(),
+                language = language,
             )).fetchPolicy(FetchPolicy.NetworkOnly).execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableViewModel.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/subway/timetable/SubwayTimetableViewModel.kt
@@ -26,6 +26,8 @@ class SubwayTimetableViewModel @Inject constructor(private val apolloClient: Apo
 
     fun fetchData(stationID: String, heading: String) {
         _heading.value = heading
+        _timetable.value = emptyList()
+        _isLoading.value = true
         viewModelScope.launch {
             val response = apolloClient.query(
                 SubwayTimetablePageQuery(
@@ -33,7 +35,7 @@ class SubwayTimetableViewModel @Inject constructor(private val apolloClient: Apo
                     listOf(heading),
                     DynamicTextTranslator.currentAppLanguageTag(),
                 ),
-            ).fetchPolicy(FetchPolicy.CacheFirst).execute()
+            ).fetchPolicy(FetchPolicy.NetworkOnly).execute()
             if (response.data == null || response.exception != null) {
                 _queryError.value = QueryError.SERVER_ERROR
             } else if (response.data?.subway != null) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -85,9 +85,9 @@
     <string name="home_transfer_subway_oido_connector">Oido</string>
     <string name="home_support_default">Only if urgent</string>
     <string name="home_support_emphasized">Alternatives / transfers</string>
-    <string name="home_destination_station">Handaeap</string>
+    <string name="home_destination_station">Station</string>
     <string name="home_destination_terminal">Terminal</string>
-    <string name="home_destination_jungang">Jungang</string>
+    <string name="home_destination_jungang">Jungang Stn.</string>
     <string name="home_destination_dormitory">Dormitory</string>
     <string name="home_route_format">%1$s → %2$s</string>
     <string name="home_departure_format">Departs %1$s</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -89,7 +89,7 @@
     <string name="home_destination_terminal">Terminal</string>
     <string name="home_destination_jungang">Jungang Stn.</string>
     <string name="home_destination_dormitory">Dormitory</string>
-    <string name="home_route_format">%1$s → %2$s</string>
+    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">Departs %1$s</string>
     <string name="home_minutes">%1$d min</string>
     <string name="home_check">Check</string>
@@ -222,7 +222,7 @@
     <!-- 셔틀버스 시간표 -->
     <string name="shuttle_timetable_tab_weekdays">Weekdays</string>
     <string name="shuttle_timetable_tab_weekends">Weekends</string>
-    <string name="timetable_route_title">%1$s → %2$s</string>
+    <string name="timetable_route_title">%1$s ▶ %2$s</string>
     <string name="shuttle_timetable_empty">Out of service</string>
     <!-- 셔틀버스 시간표 필터 -->
     <string name="shuttle_timetable_filter_title">Search timetable</string>
@@ -288,7 +288,7 @@
     </plurals>
     <string name="bus_timetable_format_last">Departs at %1$s:%2$s (Last)</string>
     <string name="bus_arrival_estimated_format">%1$d min (scheduled)</string>
-    <string name="bus_arrival_secondary_format">" → arrives %1$s"</string>
+    <string name="bus_arrival_secondary_format">" ▶ arrives %1$s"</string>
     <!-- 노선버스 도착 정보 없음 -->
     <string name="bus_no_realtime_data">There are no buses scheduled to arrive.</string>
     <string name="bus_departure_log">Departure Log</string>
@@ -330,21 +330,21 @@
     <string name="subway_transfer_incheon_oido">Incheon·Oido</string>
     <string name="subway_transfer_ilsan_bucheon">Ilsan·Bucheon</string>
     <plurals name="subway_transfer_up_item_format">
-        <item quantity="one">[%1$s] %2$s\n→ [%3$s] %4$d min (Oido)</item>
-        <item quantity="other">[%1$s] %2$s\n→ [%3$s] %4$d mins (Oido)</item>
+        <item quantity="one">[%1$s] %2$s\n▶ [%3$s] %4$d min (Oido)</item>
+        <item quantity="other">[%1$s] %2$s\n▶ [%3$s] %4$d mins (Oido)</item>
     </plurals>
     <string name="subway_transfer_up_item_format_no_transfer">[%1$s] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
-        <item quantity="one">[%1$s] %2$d min (%3$s)\n→ [%4$s] %5$d min (Oido)</item>
-        <item quantity="other">[%1$s] %2$d mins (%3$s)\n→ [%4$s] %5$d mins (Oido)</item>
+        <item quantity="one">[%1$s] %2$d min (%3$s)\n▶ [%4$s] %5$d min (Oido)</item>
+        <item quantity="other">[%1$s] %2$d mins (%3$s)\n▶ [%4$s] %5$d mins (Oido)</item>
     </plurals>
     <plurals name="subway_transfer_down_item_format_no_transfer">
         <item quantity="one">[%1$s] %2$d min (%3$s)</item>
         <item quantity="other">[%1$s] %2$d mins (%3$s)</item>
     </plurals>
     <plurals name="subway_transfer_choji_item_format">
-        <item quantity="one">[%1$s] %2$d min\n→ [%3$s] %4$d min (Choji)</item>
-        <item quantity="other">[%1$s] %2$d mins\n→ [%3$s] %4$d mins (Choji)</item>
+        <item quantity="one">[%1$s] %2$d min\n▶ [%3$s] %4$d min (Choji)</item>
+        <item quantity="other">[%1$s] %2$d mins\n▶ [%3$s] %4$d mins (Choji)</item>
     </plurals>
     <string name="subway_transfer_destination_format">To %1$s</string>
     <string name="subway_transfer_board_at_hanyang">Board at Hanyang Univ. at Ansan</string>
@@ -599,12 +599,12 @@
     <string name="shuttle_via_title">Route of shuttle bus</string>
     <string name="bus_timetable_empty">Timetable not provided</string>
     <string name="bus_stop_gwangmyeong_station">Gwangmyeong Stn.</string>
-    <string name="shuttle_via_format_6_stops">(→ %1$s → %2$s → %3$s → %4$s → %5$s → %6$s)</string>
-    <string name="shuttle_via_format_5_stops">(→ %1$s → %2$s → %3$s → %4$s → %5$s)</string>
-    <string name="shuttle_via_format_4_stops">(→ %1$s → %2$s → %3$s → %4$s)</string>
-    <string name="shuttle_via_format_3_stops">(→ %1$s → %2$s → %3$s)</string>
-    <string name="shuttle_via_format_2_stops">(→ %1$s → %2$s)</string>
-    <string name="shuttle_via_format_1_stop">(→ %1$s)</string>
+    <string name="shuttle_via_format_6_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s ▶ %5$s ▶ %6$s)</string>
+    <string name="shuttle_via_format_5_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s ▶ %5$s)</string>
+    <string name="shuttle_via_format_4_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s)</string>
+    <string name="shuttle_via_format_3_stops">(▶ %1$s ▶ %2$s ▶ %3$s)</string>
+    <string name="shuttle_via_format_2_stops">(▶ %1$s ▶ %2$s)</string>
+    <string name="shuttle_via_format_1_stop">(▶ %1$s)</string>
     <string name="previous_day">Prev</string>
     <string name="next_day">Next</string>
     <string name="show_by_destination">By Destination/Time</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -8,7 +8,6 @@
     <string name="shuttle_bus">Shuttle</string>
     <string name="bus">Bus</string>
     <string name="tabbar_bus">Bus</string>
-    <string name="tabbar_more">More</string>
     <string name="tabbar_campus">Campus</string>
     <!-- Home -->
     <string name="home_hero_title">Only what you need now</string>
@@ -35,7 +34,6 @@
     <string name="home_weather_confidence_low">Forecast may change</string>
     <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">Move now</string>
-    <string name="home_movement_detail">Shuttle details</string>
     <string name="home_movement_timetable">Full timetable</string>
     <string name="home_departure_selector_description">Select departure stop: %1$s</string>
     <string name="home_destination_summary">Toward %1$s</string>
@@ -43,8 +41,6 @@
     <string name="home_quick_settings_action_bar_title">Adjust what appears on Home</string>
     <string name="home_quick_settings_button">Settings</string>
     <string name="home_quick_settings_title">Settings</string>
-    <string name="home_quick_settings_legacy_title">Previous shuttle screen</string>
-    <string name="home_quick_settings_legacy_subtitle">Check full arrivals and timetables.</string>
     <string name="home_quick_settings_legacy_button">Previous shuttle screen</string>
     <string name="home_quick_settings_bus50_transfer_title">Show Bus 50 transfers</string>
     <string name="home_quick_settings_bus50_transfer_subtitle">Shows Bus 50 arrivals from Yesulin to Gwangmyeong Station.</string>
@@ -56,15 +52,9 @@
     <string name="home_quick_settings_subway_destination_oido">Oido</string>
     <string name="home_quick_settings_subway_destination_sosa">Ilsan/Bucheon</string>
     <string name="home_transfer_bus50_badge">50</string>
-    <string name="home_transfer_bus50_title">Expected at %1$s</string>
-    <string name="home_transfer_bus50_subtitle">Transfer to bus at Yesulin</string>
-    <string name="home_transfer_buffer">+%1$d min</string>
     <string name="home_transfer_subway_suin_bundang_badge">Suin</string>
     <string name="home_transfer_subway_seohae_badge">Seohae</string>
     <string name="home_transfer_subway_title">To %1$s</string>
-    <string name="home_transfer_subway_subtitle">Transfer at Hanyang Univ. at Ansan</string>
-    <string name="home_transfer_subway_oido_subtitle">Transfer at Oido Station</string>
-    <string name="home_transfer_subway_choji_subtitle">Transfer at Choji Station</string>
     <string name="home_transfer_bus50_connector">Yesulin</string>
     <string name="home_transfer_wait_minutes">%1$d min wait</string>
     <string name="home_transfer_wait_immediate">Board now</string>
@@ -89,15 +79,12 @@
     <string name="home_destination_terminal">Terminal</string>
     <string name="home_destination_jungang">Jungang Stn.</string>
     <string name="home_destination_dormitory">Dormitory</string>
-    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">Departs %1$s</string>
     <string name="home_minutes">%1$d min</string>
     <string name="home_check">Check</string>
     <string name="home_shuttle_last_run_subtitle">Last run · %1$s</string>
     <string name="home_no_data_title">No shuttle available now</string>
     <string name="home_no_data_message">Check again later or use an alternative route below.</string>
-    <string name="home_bus_title_format">Bus %1$s</string>
-    <string name="home_bus_subtitle_format">%1$s stop</string>
     <string name="home_alt_bus_direction">Toward %1$s</string>
     <string name="home_alt_dormitory_nearby">Hanyang Univ. Dormitory Front</string>
     <string name="home_alt_gyeonggi_technopark">Gyeonggi Techno Park</string>
@@ -115,7 +102,6 @@
     <string name="home_meal_dinner">Dinner</string>
     <string name="home_meal_period_selector_description">Select meal period: %1$s</string>
     <string name="home_meal_tomorrow_format">Tomorrow %1$s</string>
-    <string name="home_meal_tomorrow_breakfast">Tomorrow breakfast</string>
     <string name="home_meal_empty_title">%1$s menu is unavailable</string>
     <string name="home_meal_empty_message">Check other meal times in all menus.</string>
     <!-- 셔틀버스 도착 정보 탭 -->
@@ -138,11 +124,8 @@
     <string name="shuttle_footer_entire_timetable_jungang_station">Entire Timetable (Jungang Stn.)</string>
     <string name="shuttle_footer_stop_info">Location &amp; First/Last</string>
     <string name="shuttle_footer_help">Shuttle Help</string>
-    <string name="shuttle_action_bar_title">Shuttle display options</string>
     <string name="shuttle_quick_settings_button">Settings</string>
     <string name="shuttle_quick_settings_title">Settings</string>
-    <string name="shuttle_quick_settings_arrival_by_time_subtitle">Show shuttle arrivals by remaining time.</string>
-    <string name="shuttle_quick_settings_departure_time_subtitle">Show shuttle times by departure time.</string>
     <string name="shuttle_quick_settings_presence_title">Show fellow viewers</string>
     <string name="shuttle_quick_settings_presence_subtitle">Show how many people are viewing the same stop information.</string>
     <string name="shuttle_quick_settings_section_display">Shuttle display</string>
@@ -157,14 +140,6 @@
     <string name="shuttle_quick_settings_alternative_mode_hidden">Hide</string>
     <string name="shuttle_connection_transfer_format">Transfer at %1$s</string>
     <string name="shuttle_presence_viewer_count">Viewing together: %1$d</string>
-    <string name="shuttle_display_order_title">Display order</string>
-    <string name="shuttle_display_order_subtitle">Organize shuttle arrivals by time or destination.</string>
-    <string name="shuttle_display_time_order">By time</string>
-    <string name="shuttle_display_destination_order">By destination</string>
-    <string name="shuttle_time_display_title">Time display</string>
-    <string name="shuttle_time_display_subtitle">Show shuttle times as remaining time or departure time.</string>
-    <string name="shuttle_time_remaining">Remaining</string>
-    <string name="shuttle_time_departure">Departure</string>
     <string name="home_experience_new">Try the new home</string>
     <!-- 셔틀버스 도착 정보 없음 -->
     <string name="shuttle_no_realtime_data">Out out service</string>
@@ -192,7 +167,6 @@
     <string name="shuttle_type_dormitory_direct">Dormitory (Direct)</string>
     <string name="shuttle_type_shuttlecock_circular">Shuttlecock (Circular)</string>
     <string name="shuttle_type_dormitory_circular">Dormitory (Circular)</string>
-    <string name="shuttle_type_jungang_circular">Dormitory (Jungang Stn.)</string>
     <string name="shuttle_type_shuttlecock_finishing">Shuttlecock</string>
     <!-- 셔틀버스 첫막차 시간 -->
     <string name="shuttle_first_last_time_title">First &amp; Last</string>
@@ -277,7 +251,6 @@
         <item quantity="one">%1$d min (%2$d stops)</item>
         <item quantity="other">%1$d min (%2$d stops)</item>
     </plurals>
-    <string name="bus_timetable_format">Departs at %1$s:%2$s</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d min (%2$d stops, %3$d seats, Last)</item>
         <item quantity="other">%1$d min (%2$d stops, %3$d seats, Last)</item>
@@ -286,7 +259,6 @@
         <item quantity="one">%1$d min (%2$d stops, Last)</item>
         <item quantity="other">%1$d min (%2$d stops, Last)</item>
     </plurals>
-    <string name="bus_timetable_format_last">Departs at %1$s:%2$s (Last)</string>
     <string name="bus_arrival_estimated_format">%1$d min (scheduled)</string>
     <string name="bus_arrival_secondary_format">" ▶ arrives %1$s"</string>
     <!-- 노선버스 도착 정보 없음 -->
@@ -325,15 +297,12 @@
     <string name="subway_blue_down">Line 4 (Oido)</string>
     <string name="subway_yellow_up">Suin Line (Suwon)</string>
     <string name="subway_yellow_down">Suin Line (Incheon)</string>
-    <string name="subway_transfer_up">To Incheon</string>
-    <string name="subway_transfer_down">To Campus</string>
     <string name="subway_transfer_incheon_oido">Incheon·Oido</string>
     <string name="subway_transfer_ilsan_bucheon">Ilsan·Bucheon</string>
     <plurals name="subway_transfer_up_item_format">
         <item quantity="one">[%1$s] %2$s\n▶ [%3$s] %4$d min (Oido)</item>
         <item quantity="other">[%1$s] %2$s\n▶ [%3$s] %4$d mins (Oido)</item>
     </plurals>
-    <string name="subway_transfer_up_item_format_no_transfer">[%1$s] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
         <item quantity="one">[%1$s] %2$d min (%3$s)\n▶ [%4$s] %5$d min (Oido)</item>
         <item quantity="other">[%1$s] %2$d mins (%3$s)\n▶ [%4$s] %5$d mins (Oido)</item>
@@ -358,7 +327,6 @@
         <item quantity="one">%1$d min wait</item>
         <item quantity="other">%1$d mins wait</item>
     </plurals>
-    <string name="subway_no_realtime_data">Out of service</string>
     <string name="subway_realtime_destination_format">To %1$s</string>
     <string name="subway_realtime_destination_format_last">To %1$s (Last train)</string>
     <plurals name="subway_realtime_format">
@@ -479,16 +447,12 @@
     <string name="menu_chat">Inquiries</string>
     <string name="menu_donate">Donate</string>
     <string name="inquiry_title">Inquiries</string>
-    <string name="inquiry_short">Inquiry</string>
     <string name="inquiry_input_hint">Type a message</string>
     <string name="inquiry_send">Send</string>
     <string name="inquiry_empty">No messages yet. Feel free to leave your question.</string>
     <string name="inquiry_read">Read</string>
     <string name="inquiry_load_failed">Failed to load the conversation.</string>
     <string name="menu_review">Rate this App</string>
-    <string name="menu_section_school_life">School life</string>
-    <string name="menu_section_support">Support and settings</string>
-    <string name="menu_section_external">External links</string>
     <string name="menu_map">Campus Map</string>
     <string name="campus_tools_title">Campus tools</string>
     <string name="campus_tools_subtitle">Quickly find the campus services you need.</string>
@@ -513,7 +477,6 @@
     <string name="reading_room_alarm_3_hour">3-hour alarm</string>
     <string name="reading_room_alarm_4_hour">4-hour alarm</string>
     <string name="reading_room_alarm_cancel">Cancel alarm</string>
-    <string name="reading_room_seat_format">%1$d/%2$d</string>
     <string name="reading_room_available_seat_format">%1$d seats available · %2$d total</string>
     <string name="reading_room_full_seat_format">Full · %1$d total seats</string>
     <string name="default_notification_channel_id">HYUabot Notification Channel ID</string>
@@ -545,11 +508,9 @@
     <string name="reading_room_extend_noti_content">Your reading room usage expires in 10 minutes. Please renew if needed.</string>
     <string name="reading_room_alarm_extend">Reading room extension notification!</string>
     <string name="reading_room_alarm_format">Alarm set for %1$s</string>
-    <string name="shuttle_realtime_location_error">Failed to find the nearest stop.</string>
     <string name="campus_settings">Campus Settings</string>
     <string name="language_settings">Language Settings</string>
     <string name="theme_settings">Theme Settings</string>
-    <string name="theme_settings_description">Please select a theme.</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_system">System</string>
@@ -568,21 +529,17 @@
     <string name="open_source_licenses_description">View the open source software used by the app.</string>
     <string name="developer_name">Developer: Jeongin Lee</string>
     <string name="developer_belong">Department: Software Studies, Class of \'17</string>
-    <string name="contact_loading">Loading contacts…</string>
     <string name="contact_search_guide">Search name / phone</string>
     <string name="month_header">%1$d/%2$d</string>
-    <string name="event_date_format">%1$d/%2$d</string>
     <string name="event_date_range_format">%1$d/%2$d - %3$d/%4$d</string>
     <string name="calendar_select_date_hint">Tap a date to see events</string>
     <string name="calendar_upcoming_empty">No upcoming events</string>
     <string name="calendar_previous_month">Previous month</string>
     <string name="calendar_next_month">Next month</string>
     <string name="calendar_event_ongoing">Ongoing</string>
-    <string name="calendar_loading">Loading academic calendar…</string>
     <string name="do_not_show_again_this_year">Do not show this year.</string>
     <string name="dialog_title">Developer\'s birthday</string>
     <string name="dialog_message">Hello, I\'m Jeongin Lee, developer of HYUABOT.\n\nToday is my birthday.\n\nPlease wish me a happy birthday!</string>
-    <string name="bus_departure_log_error">Failed to load departure log.</string>
     <string name="bus_realtime_error">Failed to load bus arrival information.</string>
     <string name="bus_route_info_error">Failed to load bus route information.</string>
     <string name="bus_timetable_error">Failed to load bus timetable.</string>
@@ -599,12 +556,6 @@
     <string name="shuttle_via_title">Route of shuttle bus</string>
     <string name="bus_timetable_empty">Timetable not provided</string>
     <string name="bus_stop_gwangmyeong_station">Gwangmyeong Stn.</string>
-    <string name="shuttle_via_format_6_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s ▶ %5$s ▶ %6$s)</string>
-    <string name="shuttle_via_format_5_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s ▶ %5$s)</string>
-    <string name="shuttle_via_format_4_stops">(▶ %1$s ▶ %2$s ▶ %3$s ▶ %4$s)</string>
-    <string name="shuttle_via_format_3_stops">(▶ %1$s ▶ %2$s ▶ %3$s)</string>
-    <string name="shuttle_via_format_2_stops">(▶ %1$s ▶ %2$s)</string>
-    <string name="shuttle_via_format_1_stop">(▶ %1$s)</string>
     <string name="previous_day">Prev</string>
     <string name="next_day">Next</string>
     <string name="show_by_destination">By Destination/Time</string>
@@ -731,7 +682,6 @@
     <string name="bus_help_departure_title">4. Checking Route Bus Departure Time</string>
     <string name="bus_help_departure_content">Provides the stop passing times for each route as provided by Gyeonggi-do. Even if real-time arrival information is not available, this can be referenced to estimate the bus arrival time.</string>
     <string name="bus_stop_info_title">Stop Information</string>
-    <string name="bus_stop_info_empty">Stop information is unavailable.</string>
     <string name="bus_stop_info_error">Failed to load information.</string>
     <string name="bus_first_last_up">Northbound: First %1$s / Last %2$s</string>
     <string name="bus_first_last_down">Southbound: First %1$s / Last %2$s</string>
@@ -747,19 +697,11 @@
     <string name="shuttle_alarm_alighting_live_arrival">Arrives at %1$s</string>
     <string name="shuttle_alarm_alighting_tracking">Checking distance</string>
     <string name="shuttle_alarm_boarding_initial">Departs in %1$d min</string>
-    <string name="shuttle_alarm_boarding_initial_checkpoint">Departs in %1$d min · passed %2$s</string>
-    <string name="shuttle_alarm_boarding_content">%1$d min · %2$s direction %3$s</string>
-    <string name="shuttle_alarm_boarding_content_checkpoint">%1$d min · passed %2$s · %3$s direction %4$s</string>
-    <string name="shuttle_alarm_boarding_short">%1$d min</string>
     <string name="shuttle_alarm_checkpoint_waiting">Waiting at %1$s</string>
     <string name="shuttle_alarm_checkpoint_departed">Departed %1$s</string>
     <string name="shuttle_alarm_checkpoint_approaching">Approaching %1$s</string>
-    <string name="shuttle_alarm_now">It\'s time to board.</string>
     <string name="shuttle_alarm_alighting_title">Shuttle Bus Alighting Alert</string>
-    <string name="shuttle_alarm_alighting_preparing">Monitoring alighting stop</string>
     <string name="shuttle_alarm_alighting_content">About %1$s to the stop</string>
-    <string name="shuttle_alarm_alighting_checkpoint_distance">%1$s, %3$s to %2$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_tracking">%1$s, checking distance to %2$s</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">Tracking</string>
     <string name="shuttle_alarm_alighting_alert_title">Prepare to get off!</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -88,7 +88,7 @@
     <string name="home_destination_terminal">ターミナル</string>
     <string name="home_destination_jungang">中央駅</string>
     <string name="home_destination_dormitory">寮</string>
-    <string name="home_route_format">%1$s → %2$s</string>
+    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 発</string>
     <string name="home_minutes">%1$d分</string>
     <string name="home_check">確認</string>
@@ -212,7 +212,7 @@
     <string name="shuttle_help_departure_content">画面上部のスイッチをオンにしてください！各バスの出発時刻を確認できます。</string>
     <string name="shuttle_timetable_tab_weekdays">平日</string>
     <string name="shuttle_timetable_tab_weekends">週末</string>
-    <string name="timetable_route_title">%1$s → %2$s</string>
+    <string name="timetable_route_title">%1$s ▶ %2$s</string>
     <string name="shuttle_timetable_empty">運行予定のシャトルバスはありません。</string>
     <string name="shuttle_timetable_filter_title">シャトル時刻表を検索</string>
     <string name="shuttle_period">運行期間</string>
@@ -269,7 +269,7 @@
     </plurals>
     <string name="bus_timetable_format_last">%1$s時%2$s分発（終バス）</string>
     <string name="bus_arrival_estimated_format">%1$d分（予定）</string>
-    <string name="bus_arrival_secondary_format">" → %1$s到着"</string>
+    <string name="bus_arrival_secondary_format">" ▶ %1$s到着"</string>
     <string name="bus_no_realtime_data">到着予定のバスはありません。</string>
     <string name="bus_departure_log">到着記録</string>
     <string name="bus_log_title">路線バス通過情報</string>
@@ -302,26 +302,26 @@
     <string name="subway_blue_down">4号線 (安山・オイド)</string>
     <string name="subway_yellow_up">水仁線 (水原)</string>
     <string name="subway_yellow_down">水仁線 (仁川)</string>
-    <string name="subway_transfer_up">仁川→韓大前</string>
-    <string name="subway_transfer_down">韓大前→仁川</string>
+    <string name="subway_transfer_up">仁川▶韓大前</string>
+    <string name="subway_transfer_down">韓大前▶仁川</string>
     <string name="subway_transfer_incheon_oido">仁川・烏耳島</string>
     <string name="subway_transfer_ilsan_bucheon">一山・富川</string>
     <plurals name="subway_transfer_up_item_format">
-        <item quantity="one">[%1$s行] %2$s\n→ [%3$s行] %4$d分後（五耳島）</item>
-        <item quantity="other">[%1$s行] %2$s\n→ [%3$s行] %4$d分後（五耳島）</item>
+        <item quantity="one">[%1$s行] %2$s\n▶ [%3$s行] %4$d分後（五耳島）</item>
+        <item quantity="other">[%1$s行] %2$s\n▶ [%3$s行] %4$d分後（五耳島）</item>
     </plurals>
     <string name="subway_transfer_up_item_format_no_transfer">[%1$s行] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
-        <item quantity="one">[%1$s行] %2$d分後（%3$s）\n→ [%4$s行] %5$d分後（五耳島）</item>
-        <item quantity="other">[%1$s行] %2$d分後（%3$s）\n→ [%4$s行] %5$d分後（五耳島）</item>
+        <item quantity="one">[%1$s行] %2$d分後（%3$s）\n▶ [%4$s行] %5$d分後（五耳島）</item>
+        <item quantity="other">[%1$s行] %2$d分後（%3$s）\n▶ [%4$s行] %5$d分後（五耳島）</item>
     </plurals>
     <plurals name="subway_transfer_down_item_format_no_transfer">
         <item quantity="one">[%1$s行] %2$d分後（%3$s）</item>
         <item quantity="other">[%1$s行] %2$d分後（%3$s）</item>
     </plurals>
     <plurals name="subway_transfer_choji_item_format">
-        <item quantity="one">[%1$s行] %2$d分後\n→ [%3$s行] %4$d分後（草芝）</item>
-        <item quantity="other">[%1$s行] %2$d分後\n→ [%3$s行] %4$d分後（草芝）</item>
+        <item quantity="one">[%1$s行] %2$d分後\n▶ [%3$s行] %4$d分後（草芝）</item>
+        <item quantity="other">[%1$s行] %2$d分後\n▶ [%3$s行] %4$d分後（草芝）</item>
     </plurals>
     <string name="subway_transfer_destination_format">%1$s行</string>
     <string name="subway_transfer_board_at_hanyang">漢大前で乗車</string>
@@ -578,11 +578,11 @@
     <string name="shuttle_via_title">車両別経路</string>
     <string name="bus_timetable_empty">時刻表が提供されていない路線です。</string>
     <string name="bus_stop_gwangmyeong_station">光明駅</string>
-    <string name="shuttle_via_format_6_stops">%1$s→%2$s→%3$s→%4$s→%5$s→%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s→%2$s→%3$s→%4$s→%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s→%2$s→%3$s→%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s→%2$s→%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s→%2$s</string>
+    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
+    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
+    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
+    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
+    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
     <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">前へ</string>
     <string name="next_day">次へ</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -8,7 +8,6 @@
     <string name="shuttle_bus">シャトルバス</string>
     <string name="bus">路線バス</string>
     <string name="tabbar_bus">バス</string>
-    <string name="tabbar_more">もっと見る</string>
     <string name="tabbar_campus">キャンパス</string>
     <string name="home_hero_title">今必要なものだけ</string>
     <string name="home_hero_subtitle">移動から食事まで、今の状況に合う情報を表示します。</string>
@@ -34,7 +33,6 @@
     <string name="home_weather_confidence_low">予報が変わる可能性があります</string>
     <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">今すぐ移動</string>
-    <string name="home_movement_detail">シャトル詳細</string>
     <string name="home_movement_timetable">全時刻表</string>
     <string name="home_departure_selector_description">出発停留所を選択：%1$s</string>
     <string name="home_destination_summary">%1$s方面</string>
@@ -42,8 +40,6 @@
     <string name="home_quick_settings_action_bar_title">ホームの表示を調整できます</string>
     <string name="home_quick_settings_button">設定</string>
     <string name="home_quick_settings_title">設定</string>
-    <string name="home_quick_settings_legacy_title">以前のシャトル画面</string>
-    <string name="home_quick_settings_legacy_subtitle">到着情報と時刻表を確認します。</string>
     <string name="home_quick_settings_legacy_button">以前のシャトル画面</string>
     <string name="home_quick_settings_bus50_transfer_title">50番乗り換えを表示</string>
     <string name="home_quick_settings_bus50_transfer_subtitle">芸術人から光明駅へ向かう50番の到着情報を表示します。</string>
@@ -55,15 +51,9 @@
     <string name="home_quick_settings_subway_destination_oido">烏耳島</string>
     <string name="home_quick_settings_subway_destination_sosa">一山・富川</string>
     <string name="home_transfer_bus50_badge">50番</string>
-    <string name="home_transfer_bus50_title">%1$s 到着予定</string>
-    <string name="home_transfer_bus50_subtitle">芸術人でバスに乗り換え</string>
-    <string name="home_transfer_buffer">+%1$d分</string>
     <string name="home_transfer_subway_suin_bundang_badge">水仁盆唐</string>
     <string name="home_transfer_subway_seohae_badge">西海線</string>
     <string name="home_transfer_subway_title">%1$s 行き</string>
-    <string name="home_transfer_subway_subtitle">韓大前で地下鉄に乗り換え</string>
-    <string name="home_transfer_subway_oido_subtitle">烏耳島駅で地下鉄に乗り換え</string>
-    <string name="home_transfer_subway_choji_subtitle">草芝駅で地下鉄に乗り換え</string>
     <string name="home_transfer_bus50_connector">芸術人</string>
     <string name="home_transfer_wait_minutes">待ち時間%1$d分</string>
     <string name="home_transfer_wait_immediate">すぐ乗車</string>
@@ -88,15 +78,12 @@
     <string name="home_destination_terminal">ターミナル</string>
     <string name="home_destination_jungang">中央駅</string>
     <string name="home_destination_dormitory">寮</string>
-    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 発</string>
     <string name="home_minutes">%1$d分</string>
     <string name="home_check">確認</string>
     <string name="home_shuttle_last_run_subtitle">終車 · %1$s</string>
     <string name="home_no_data_title">今乗れるシャトルがありません</string>
     <string name="home_no_data_message">しばらくしてから再確認するか、下の代替ルートを確認してください。</string>
-    <string name="home_bus_title_format">%1$s番バス</string>
-    <string name="home_bus_subtitle_format">%1$s 停留所</string>
     <string name="home_alt_bus_direction">%1$s方面</string>
     <string name="home_alt_dormitory_nearby">漢陽大寄宿舎前</string>
     <string name="home_alt_gyeonggi_technopark">京畿テクノパーク</string>
@@ -114,7 +101,6 @@
     <string name="home_meal_dinner">夕食</string>
     <string name="home_meal_period_selector_description">食事時間帯を選択：%1$s</string>
     <string name="home_meal_tomorrow_format">明日の%1$s</string>
-    <string name="home_meal_tomorrow_breakfast">明日の朝食</string>
     <string name="home_meal_empty_title">%1$sメニューがありません</string>
     <string name="home_meal_empty_message">全ての学食で他の時間帯のメニューを確認できます。</string>
     <string name="shuttle_tab_dormitory_out">寮</string>
@@ -134,11 +120,8 @@
     <string name="shuttle_footer_entire_timetable_jungang_station">全時刻表 (中央駅)</string>
     <string name="shuttle_footer_stop_info">停留所位置 &amp; 始発/終発</string>
     <string name="shuttle_footer_help">ヘルプ</string>
-    <string name="shuttle_action_bar_title">シャトル表示オプション</string>
     <string name="shuttle_quick_settings_button">設定</string>
     <string name="shuttle_quick_settings_title">設定</string>
-    <string name="shuttle_quick_settings_arrival_by_time_subtitle">残り時間でシャトル到着を表示します。</string>
-    <string name="shuttle_quick_settings_departure_time_subtitle">出発時刻でシャトル時刻を表示します。</string>
     <string name="shuttle_quick_settings_presence_title">一緒に見ている人を表示</string>
     <string name="shuttle_quick_settings_presence_subtitle">同じ停留所の情報を見ている人数を表示します。</string>
     <string name="shuttle_quick_settings_section_display">シャトル表示</string>
@@ -153,14 +136,6 @@
     <string name="shuttle_quick_settings_alternative_mode_hidden">非表示</string>
     <string name="shuttle_connection_transfer_format">%1$sで乗り換え</string>
     <string name="shuttle_presence_viewer_count">%1$d人が一緒に閲覧中</string>
-    <string name="shuttle_display_order_title">表示順</string>
-    <string name="shuttle_display_order_subtitle">シャトル到着を時間順または行先別に整理します。</string>
-    <string name="shuttle_display_time_order">時間順</string>
-    <string name="shuttle_display_destination_order">行先別</string>
-    <string name="shuttle_time_display_title">時刻表示</string>
-    <string name="shuttle_time_display_subtitle">シャトル時刻を残り時間または出発時刻で表示します。</string>
-    <string name="shuttle_time_remaining">残り時間</string>
-    <string name="shuttle_time_departure">出発時刻</string>
     <string name="home_experience_new">新しいホームを体験</string>
     <string name="shuttle_no_realtime_data">到着予定のシャトルバスはありません。</string>
     <string name="shuttle_time_type_1">%1$s時%2$s分発</string>
@@ -185,7 +160,6 @@
     <string name="shuttle_type_dormitory_direct">寮（直行）</string>
     <string name="shuttle_type_shuttlecock_circular">シャトルコック（循環）</string>
     <string name="shuttle_type_dormitory_circular">寮（循環）</string>
-    <string name="shuttle_type_jungang_circular">寮（中央駅）</string>
     <string name="shuttle_type_shuttlecock_finishing">Shuttlecock (終着)</string>
     <string name="shuttle_first_last_time_title">始発 &amp; 終発</string>
     <string name="shuttle_first_last_time_no_data_weekdays">--:--（平日）</string>
@@ -258,7 +232,6 @@
         <item quantity="one">%1$d分（%2$d前）</item>
         <item quantity="other">%1$d分（%2$d前）</item>
     </plurals>
-    <string name="bus_timetable_format">%1$s時%2$s分発</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d分（%2$d前、%3$d席、終バス）</item>
         <item quantity="other">%1$d分（%2$d前、%3$d席、終バス）</item>
@@ -267,7 +240,6 @@
         <item quantity="one">%1$d分（%2$d前、終バス）</item>
         <item quantity="other">%1$d分（%2$d前、終バス）</item>
     </plurals>
-    <string name="bus_timetable_format_last">%1$s時%2$s分発（終バス）</string>
     <string name="bus_arrival_estimated_format">%1$d分（予定）</string>
     <string name="bus_arrival_secondary_format">" ▶ %1$s到着"</string>
     <string name="bus_no_realtime_data">到着予定のバスはありません。</string>
@@ -302,15 +274,12 @@
     <string name="subway_blue_down">4号線 (安山・オイド)</string>
     <string name="subway_yellow_up">水仁線 (水原)</string>
     <string name="subway_yellow_down">水仁線 (仁川)</string>
-    <string name="subway_transfer_up">仁川▶韓大前</string>
-    <string name="subway_transfer_down">韓大前▶仁川</string>
     <string name="subway_transfer_incheon_oido">仁川・烏耳島</string>
     <string name="subway_transfer_ilsan_bucheon">一山・富川</string>
     <plurals name="subway_transfer_up_item_format">
         <item quantity="one">[%1$s行] %2$s\n▶ [%3$s行] %4$d分後（五耳島）</item>
         <item quantity="other">[%1$s行] %2$s\n▶ [%3$s行] %4$d分後（五耳島）</item>
     </plurals>
-    <string name="subway_transfer_up_item_format_no_transfer">[%1$s行] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
         <item quantity="one">[%1$s行] %2$d分後（%3$s）\n▶ [%4$s行] %5$d分後（五耳島）</item>
         <item quantity="other">[%1$s行] %2$d分後（%3$s）\n▶ [%4$s行] %5$d分後（五耳島）</item>
@@ -335,7 +304,6 @@
         <item quantity="one">%1$d分待ち</item>
         <item quantity="other">%1$d分待ち</item>
     </plurals>
-    <string name="subway_no_realtime_data">到着予定の電鉄情報がありません。</string>
     <string name="subway_realtime_destination_format">%1$s行</string>
     <string name="subway_realtime_destination_format_last">%1$s行（終電）</string>
     <plurals name="subway_realtime_format">
@@ -456,16 +424,12 @@
     <string name="menu_chat">お問い合わせ</string>
     <string name="menu_donate">寄付する</string>
     <string name="inquiry_title">お問い合わせ</string>
-    <string name="inquiry_short">問い合わせ</string>
     <string name="inquiry_input_hint">メッセージを入力してください</string>
     <string name="inquiry_send">送信</string>
     <string name="inquiry_empty">まだ会話がありません。ご質問をお気軽にどうぞ。</string>
     <string name="inquiry_read">既読</string>
     <string name="inquiry_load_failed">会話を読み込めませんでした。</string>
     <string name="menu_review">アプリ評価</string>
-    <string name="menu_section_school_life">学校生活</string>
-    <string name="menu_section_support">サポート・設定</string>
-    <string name="menu_section_external">外部リンク</string>
     <string name="menu_map">キャンパスマップ</string>
     <string name="campus_tools_title">キャンパスツール</string>
     <string name="campus_tools_subtitle">学校生活に必要な機能をすばやく見つけられます。</string>
@@ -490,7 +454,6 @@
     <string name="reading_room_alarm_3_hour">3時間後に通知</string>
     <string name="reading_room_alarm_4_hour">4時間後に通知</string>
     <string name="reading_room_alarm_cancel">通知をキャンセル</string>
-    <string name="reading_room_seat_format">%1$d/%2$d 席</string>
     <string name="reading_room_available_seat_format">残り %1$d 席 · 全 %2$d 席</string>
     <string name="reading_room_full_seat_format">満席 · 全 %1$d 席</string>
     <string name="default_notification_channel_id">HYUabot notification channel ID</string>
@@ -522,11 +485,9 @@
     <string name="reading_room_extend_noti_content">閲覧室の利用時間が10分後に終了します。延長が必要な場合はご確認ください。</string>
     <string name="reading_room_alarm_extend">閲覧室延長通知です！</string>
     <string name="reading_room_alarm_format">%1$s に通知が設定されています</string>
-    <string name="shuttle_realtime_location_error">最寄りバス停の取得に失敗しました。</string>
     <string name="campus_settings">キャンパス設定</string>
     <string name="language_settings">言語設定</string>
     <string name="theme_settings">テーマ設定</string>
-    <string name="theme_settings_description">テーマを選択してください。</string>
     <string name="theme_light">ライト</string>
     <string name="theme_dark">ダーク</string>
     <string name="theme_system">システム</string>
@@ -547,21 +508,17 @@
     <string name="open_source_licenses_description">アプリで使用しているオープンソースソフトウェアを確認します。</string>
     <string name="developer_name">開発者: イ・ジョンイン</string>
     <string name="developer_belong">所属: ソフトウェア学部 17期</string>
-    <string name="contact_loading">連絡先リストを読み込み中…</string>
     <string name="contact_search_guide">名前 / 電話番号を検索</string>
     <string name="month_header">%1$d年%2$d月</string>
-    <string name="event_date_format">%1$d月%2$d日</string>
     <string name="event_date_range_format">%1$d月%2$d日 〜 %3$d月%4$d日</string>
     <string name="calendar_select_date_hint">日付をタップすると日程が表示されます</string>
     <string name="calendar_upcoming_empty">今後の予定はありません</string>
     <string name="calendar_previous_month">前の月</string>
     <string name="calendar_next_month">次の月</string>
     <string name="calendar_event_ongoing">進行中</string>
-    <string name="calendar_loading">学事暦を読み込み中です。</string>
     <string name="do_not_show_again_this_year">今年は表示しない</string>
     <string name="dialog_title">開発者の誕生日のお知らせ</string>
     <string name="dialog_message">本日（12/12）は開発者の誕生日です。\n\nいつもご利用いただきありがとうございます。より良いサービスを提供できるよう努力してまいります。\n\nありがとうございます。</string>
-    <string name="bus_departure_log_error">到着記録の読み込みに失敗しました。</string>
     <string name="bus_realtime_error">バス到着情報の読み込みに失敗しました。</string>
     <string name="bus_route_info_error">バス路線情報の読み込みに失敗しました。</string>
     <string name="bus_timetable_error">バス時刻表の読み込みに失敗しました。</string>
@@ -578,12 +535,6 @@
     <string name="shuttle_via_title">車両別経路</string>
     <string name="bus_timetable_empty">時刻表が提供されていない路線です。</string>
     <string name="bus_stop_gwangmyeong_station">光明駅</string>
-    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
-    <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">前へ</string>
     <string name="next_day">次へ</string>
     <string name="show_by_destination">目的地/時間順</string>
@@ -708,7 +659,6 @@
     <string name="bus_help_departure_title">4. 路線バス出発時刻の確認</string>
     <string name="bus_help_departure_content">京畿道が提供する各路線の停留所通過時間を提供します。リアルタイム到着情報がない場合でも、バス到着時間の目安として参考にできます。</string>
     <string name="bus_stop_info_title">停留所情報</string>
-    <string name="bus_stop_info_empty">停留所情報を読み込めません。</string>
     <string name="bus_stop_info_error">情報の読み込みに失敗しました。</string>
     <string name="bus_first_last_up">上り: 始発 %1$s / 終バス %2$s</string>
     <string name="bus_first_last_down">下り: 始発 %1$s / 終バス %2$s</string>
@@ -724,19 +674,11 @@
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 到着</string>
     <string name="shuttle_alarm_alighting_tracking">距離確認中</string>
     <string name="shuttle_alarm_boarding_initial">%1$d分後に出発</string>
-    <string name="shuttle_alarm_boarding_initial_checkpoint">%1$d分後に出発 · %2$s通過</string>
-    <string name="shuttle_alarm_boarding_content">%1$d分 · %2$s方向 %3$s</string>
-    <string name="shuttle_alarm_boarding_content_checkpoint">%1$d分 · %2$s通過 · %3$s方向 %4$s</string>
-    <string name="shuttle_alarm_boarding_short">%1$d分</string>
     <string name="shuttle_alarm_checkpoint_waiting">%1$s待機</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s出発</string>
     <string name="shuttle_alarm_checkpoint_approaching">%1$s接近</string>
-    <string name="shuttle_alarm_now">乗車時刻です。</string>
     <string name="shuttle_alarm_alighting_title">シャトルバス降車アラート</string>
-    <string name="shuttle_alarm_alighting_preparing">降車停留所を監視中</string>
     <string name="shuttle_alarm_alighting_content">停留所まで約%1$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_distance">%1$s、%2$sまで%3$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_tracking">%1$s、%2$sまでの距離を確認中</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">追跡中</string>
     <string name="shuttle_alarm_alighting_alert_title">降車準備をしてください！</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -8,7 +8,6 @@
     <string name="shuttle_bus">校车</string>
     <string name="bus">路线公交</string>
     <string name="tabbar_bus">公交</string>
-    <string name="tabbar_more">更多</string>
     <string name="tabbar_campus">校园</string>
     <string name="home_hero_title">只看现在需要的内容</string>
     <string name="home_hero_subtitle">从出行到用餐，显示适合当前情况的信息。</string>
@@ -34,7 +33,6 @@
     <string name="home_weather_confidence_low">预报可能会变化</string>
     <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">现在出发</string>
-    <string name="home_movement_detail">校车详情</string>
     <string name="home_movement_timetable">完整时刻表</string>
     <string name="home_departure_selector_description">选择出发站：%1$s</string>
     <string name="home_destination_summary">前往%1$s</string>
@@ -42,8 +40,6 @@
     <string name="home_quick_settings_action_bar_title">调整首页显示内容</string>
     <string name="home_quick_settings_button">设置</string>
     <string name="home_quick_settings_title">设置</string>
-    <string name="home_quick_settings_legacy_title">旧版校车页面</string>
-    <string name="home_quick_settings_legacy_subtitle">查看完整到达信息和时刻表。</string>
     <string name="home_quick_settings_legacy_button">旧版校车页面</string>
     <string name="home_quick_settings_bus50_transfer_title">显示50路换乘</string>
     <string name="home_quick_settings_bus50_transfer_subtitle">显示从艺术人前往光明站的50路到达信息。</string>
@@ -55,15 +51,9 @@
     <string name="home_quick_settings_subway_destination_oido">乌耳岛</string>
     <string name="home_quick_settings_subway_destination_sosa">一山·富川</string>
     <string name="home_transfer_bus50_badge">50路</string>
-    <string name="home_transfer_bus50_title">预计%1$s到达</string>
-    <string name="home_transfer_bus50_subtitle">在艺术人换乘公交</string>
-    <string name="home_transfer_buffer">+%1$d分</string>
     <string name="home_transfer_subway_suin_bundang_badge">水仁盆唐</string>
     <string name="home_transfer_subway_seohae_badge">西海线</string>
     <string name="home_transfer_subway_title">开往 %1$s</string>
-    <string name="home_transfer_subway_subtitle">在汉大前换乘地铁</string>
-    <string name="home_transfer_subway_oido_subtitle">在乌耳岛站换乘地铁</string>
-    <string name="home_transfer_subway_choji_subtitle">在草芝站换乘地铁</string>
     <string name="home_transfer_bus50_connector">艺术人</string>
     <string name="home_transfer_wait_minutes">等待%1$d分钟</string>
     <string name="home_transfer_wait_immediate">立即乘车</string>
@@ -88,15 +78,12 @@
     <string name="home_destination_terminal">客运站</string>
     <string name="home_destination_jungang">中央站</string>
     <string name="home_destination_dormitory">宿舍</string>
-    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 出发</string>
     <string name="home_minutes">%1$d分钟</string>
     <string name="home_check">查看</string>
     <string name="home_shuttle_last_run_subtitle">末班 · %1$s</string>
     <string name="home_no_data_title">现在暂无可乘坐的校车</string>
     <string name="home_no_data_message">请稍后再确认，或查看下方替代路线。</string>
-    <string name="home_bus_title_format">%1$s路公交</string>
-    <string name="home_bus_subtitle_format">%1$s 站</string>
     <string name="home_alt_bus_direction">%1$s方向</string>
     <string name="home_alt_dormitory_nearby">汉阳大宿舍前</string>
     <string name="home_alt_gyeonggi_technopark">京畿科技园</string>
@@ -114,7 +101,6 @@
     <string name="home_meal_dinner">晚餐</string>
     <string name="home_meal_period_selector_description">选择餐次：%1$s</string>
     <string name="home_meal_tomorrow_format">明天%1$s</string>
-    <string name="home_meal_tomorrow_breakfast">明天早餐</string>
     <string name="home_meal_empty_title">暂无%1$s菜单</string>
     <string name="home_meal_empty_message">可在全部食堂中查看其他时段菜单。</string>
     <string name="shuttle_tab_dormitory_out">宿舍</string>
@@ -134,11 +120,8 @@
     <string name="shuttle_footer_entire_timetable_jungang_station">完整时刻表 (中央站)</string>
     <string name="shuttle_footer_stop_info">站点位置 &amp; 首/末班车</string>
     <string name="shuttle_footer_help">帮助</string>
-    <string name="shuttle_action_bar_title">校车显示选项</string>
     <string name="shuttle_quick_settings_button">设置</string>
     <string name="shuttle_quick_settings_title">设置</string>
-    <string name="shuttle_quick_settings_arrival_by_time_subtitle">按剩余时间显示校车到达信息。</string>
-    <string name="shuttle_quick_settings_departure_time_subtitle">按发车时间显示校车时刻。</string>
     <string name="shuttle_quick_settings_presence_title">显示同时查看的人</string>
     <string name="shuttle_quick_settings_presence_subtitle">显示正在查看同一站点信息的人数。</string>
     <string name="shuttle_quick_settings_section_display">校车显示</string>
@@ -153,14 +136,6 @@
     <string name="shuttle_quick_settings_alternative_mode_hidden">隐藏</string>
     <string name="shuttle_connection_transfer_format">在%1$s换乘</string>
     <string name="shuttle_presence_viewer_count">%1$d人同时查看</string>
-    <string name="shuttle_display_order_title">显示顺序</string>
-    <string name="shuttle_display_order_subtitle">按时间或目的地整理校车到达信息。</string>
-    <string name="shuttle_display_time_order">按时间</string>
-    <string name="shuttle_display_destination_order">按目的地</string>
-    <string name="shuttle_time_display_title">时间显示</string>
-    <string name="shuttle_time_display_subtitle">以剩余时间或发车时间显示校车时刻。</string>
-    <string name="shuttle_time_remaining">剩余时间</string>
-    <string name="shuttle_time_departure">发车时间</string>
     <string name="home_experience_new">体验新版首页</string>
     <string name="shuttle_no_realtime_data">暂无即将到达的校车。</string>
     <string name="shuttle_time_type_1">%1$s时%2$s分出发</string>
@@ -185,7 +160,6 @@
     <string name="shuttle_type_dormitory_direct">宿舍（直达）</string>
     <string name="shuttle_type_shuttlecock_circular">羽毛球场（循环）</string>
     <string name="shuttle_type_dormitory_circular">宿舍（循环）</string>
-    <string name="shuttle_type_jungang_circular">宿舍（中央站）</string>
     <string name="shuttle_type_shuttlecock_finishing">Shuttlecock (终点)</string>
     <string name="shuttle_first_last_time_title">首班 &amp; 末班</string>
     <string name="shuttle_first_last_time_no_data_weekdays">--:--（工作日）</string>
@@ -258,7 +232,6 @@
         <item quantity="one">%1$d分（%2$d前）</item>
         <item quantity="other">%1$d分（%2$d前）</item>
     </plurals>
-    <string name="bus_timetable_format">%1$s时%2$s分出发</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d分（%2$d前，%3$d席，末班）</item>
         <item quantity="other">%1$d分（%2$d前，%3$d席，末班）</item>
@@ -267,7 +240,6 @@
         <item quantity="one">%1$d分（%2$d前，末班）</item>
         <item quantity="other">%1$d分（%2$d前，末班）</item>
     </plurals>
-    <string name="bus_timetable_format_last">%1$s时%2$s分出发（末班）</string>
     <string name="bus_arrival_estimated_format">%1$d分（预计）</string>
     <string name="bus_arrival_secondary_format">" ▶ %1$s到达"</string>
     <string name="bus_no_realtime_data">暂无即将到达的公交。</string>
@@ -302,15 +274,12 @@
     <string name="subway_blue_down">4号线 (安山·오이도)</string>
     <string name="subway_yellow_up">水仁线 (水原)</string>
     <string name="subway_yellow_down">水仁线 (仁川)</string>
-    <string name="subway_transfer_up">仁川▶汉大前</string>
-    <string name="subway_transfer_down">汉大前▶仁川</string>
     <string name="subway_transfer_incheon_oido">仁川·五耳岛</string>
     <string name="subway_transfer_ilsan_bucheon">一山·富川</string>
     <plurals name="subway_transfer_up_item_format">
         <item quantity="one">[%1$s行] %2$s\n▶ [%3$s行] %4$d分钟后（五耳岛）</item>
         <item quantity="other">[%1$s行] %2$s\n▶ [%3$s行] %4$d分钟后（五耳岛）</item>
     </plurals>
-    <string name="subway_transfer_up_item_format_no_transfer">[%1$s行] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
         <item quantity="one">[%1$s行] %2$d分钟后（%3$s）\n▶ [%4$s行] %5$d分钟后（五耳岛）</item>
         <item quantity="other">[%1$s行] %2$d分钟后（%3$s）\n▶ [%4$s行] %5$d分钟后（五耳岛）</item>
@@ -335,7 +304,6 @@
         <item quantity="one">等候%1$d分钟</item>
         <item quantity="other">等候%1$d分钟</item>
     </plurals>
-    <string name="subway_no_realtime_data">暂无即将到达的地铁信息。</string>
     <string name="subway_realtime_destination_format">%1$s方向</string>
     <string name="subway_realtime_destination_format_last">%1$s方向（末班）</string>
     <plurals name="subway_realtime_format">
@@ -456,16 +424,12 @@
     <string name="menu_chat">联系我们</string>
     <string name="menu_donate">捐赠</string>
     <string name="inquiry_title">联系我们</string>
-    <string name="inquiry_short">咨询</string>
     <string name="inquiry_input_hint">请输入消息</string>
     <string name="inquiry_send">发送</string>
     <string name="inquiry_empty">还没有对话。欢迎留下您的问题。</string>
     <string name="inquiry_read">已读</string>
     <string name="inquiry_load_failed">无法加载对话。</string>
     <string name="menu_review">评价应用</string>
-    <string name="menu_section_school_life">校园生活</string>
-    <string name="menu_section_support">支持与设置</string>
-    <string name="menu_section_external">外部链接</string>
     <string name="menu_map">校园地图</string>
     <string name="campus_tools_title">校园工具</string>
     <string name="campus_tools_subtitle">快速查找校园生活所需的功能。</string>
@@ -490,7 +454,6 @@
     <string name="reading_room_alarm_3_hour">3小时后提醒</string>
     <string name="reading_room_alarm_4_hour">4小时后提醒</string>
     <string name="reading_room_alarm_cancel">取消提醒</string>
-    <string name="reading_room_seat_format">%1$d/%2$d 席</string>
     <string name="reading_room_available_seat_format">剩余 %1$d 座 · 共 %2$d 座</string>
     <string name="reading_room_full_seat_format">已满 · 共 %1$d 座</string>
     <string name="default_notification_channel_id">HYUabot notification channel ID</string>
@@ -522,11 +485,9 @@
     <string name="reading_room_extend_noti_content">阅览室使用时间将在10分钟后到期，如需延长请确认。</string>
     <string name="reading_room_alarm_extend">阅览室延长提醒！</string>
     <string name="reading_room_alarm_format">已设置 %1$s 提醒</string>
-    <string name="shuttle_realtime_location_error">获取最近站点失败。</string>
     <string name="campus_settings">校区设置</string>
     <string name="language_settings">语言设置</string>
     <string name="theme_settings">主题设置</string>
-    <string name="theme_settings_description">请选择主题。</string>
     <string name="theme_light">浅色</string>
     <string name="theme_dark">深色</string>
     <string name="theme_system">系统</string>
@@ -547,21 +508,17 @@
     <string name="open_source_licenses_description">查看本应用使用的开源软件。</string>
     <string name="developer_name">开发者: 李正仁</string>
     <string name="developer_belong">所属: 软件学院 17届</string>
-    <string name="contact_loading">正在加载联系方式列表…</string>
     <string name="contact_search_guide">搜索姓名 / 电话号码</string>
     <string name="month_header">%1$d年%2$d月</string>
-    <string name="event_date_format">%1$d月%2$d日</string>
     <string name="event_date_range_format">%1$d月%2$d日 - %3$d月%4$d日</string>
     <string name="calendar_select_date_hint">点击日期查看日程</string>
     <string name="calendar_upcoming_empty">暂无即将到来的日程</string>
     <string name="calendar_previous_month">上个月</string>
     <string name="calendar_next_month">下个月</string>
     <string name="calendar_event_ongoing">进行中</string>
-    <string name="calendar_loading">正在加载学事历。</string>
     <string name="do_not_show_again_this_year">今年不再显示</string>
     <string name="dialog_title">开发者生日通知</string>
     <string name="dialog_message">今天（12/12）是开发者的生日。\n\n感谢您一直以来的使用。我们将继续努力提供更好的服务。\n\n谢谢。</string>
-    <string name="bus_departure_log_error">加载到站记录失败。</string>
     <string name="bus_realtime_error">加载公交到达信息失败。</string>
     <string name="bus_route_info_error">加载公交路线信息失败。</string>
     <string name="bus_timetable_error">加载公交时刻表失败。</string>
@@ -578,12 +535,6 @@
     <string name="shuttle_via_title">按车辆查看路线</string>
     <string name="bus_timetable_empty">该路线不提供时刻表。</string>
     <string name="bus_stop_gwangmyeong_station">光明站</string>
-    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
-    <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">上一天</string>
     <string name="next_day">下一天</string>
     <string name="show_by_destination">目的地/时间顺序</string>
@@ -708,7 +659,6 @@
     <string name="bus_help_departure_title">4. 查看路线公交出发时刻</string>
     <string name="bus_help_departure_content">提供京畿道提供的各路线站点通过时间。即使没有实时到达信息，也可作为参考估算公交到达时间。</string>
     <string name="bus_stop_info_title">站点信息</string>
-    <string name="bus_stop_info_empty">无法加载站点信息。</string>
     <string name="bus_stop_info_error">信息加载失败。</string>
     <string name="bus_first_last_up">上行: 首班 %1$s / 末班 %2$s</string>
     <string name="bus_first_last_down">下行: 首班 %1$s / 末班 %2$s</string>
@@ -724,19 +674,11 @@
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 到达</string>
     <string name="shuttle_alarm_alighting_tracking">正在确认距离</string>
     <string name="shuttle_alarm_boarding_initial">%1$d分钟后出发</string>
-    <string name="shuttle_alarm_boarding_initial_checkpoint">%1$d分钟后出发 · 已经过%2$s</string>
-    <string name="shuttle_alarm_boarding_content">%1$d分钟 · %2$s方向 %3$s</string>
-    <string name="shuttle_alarm_boarding_content_checkpoint">%1$d分钟 · 已经过%2$s · %3$s方向 %4$s</string>
-    <string name="shuttle_alarm_boarding_short">%1$d分钟</string>
     <string name="shuttle_alarm_checkpoint_waiting">%1$s等待</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s出发</string>
     <string name="shuttle_alarm_checkpoint_approaching">接近%1$s</string>
-    <string name="shuttle_alarm_now">已到上车时间。</string>
     <string name="shuttle_alarm_alighting_title">校车下车提醒</string>
-    <string name="shuttle_alarm_alighting_preparing">正在监控下车站</string>
     <string name="shuttle_alarm_alighting_content">距站点约%1$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_distance">%1$s，距%2$s %3$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_tracking">%1$s，正在确认到%2$s的距离</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">追踪中</string>
     <string name="shuttle_alarm_alighting_alert_title">请准备下车！</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -88,7 +88,7 @@
     <string name="home_destination_terminal">客运站</string>
     <string name="home_destination_jungang">中央站</string>
     <string name="home_destination_dormitory">宿舍</string>
-    <string name="home_route_format">%1$s → %2$s</string>
+    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 出发</string>
     <string name="home_minutes">%1$d分钟</string>
     <string name="home_check">查看</string>
@@ -212,7 +212,7 @@
     <string name="shuttle_help_departure_content">打开页面上方的开关！即可查看该班车的出发时间。</string>
     <string name="shuttle_timetable_tab_weekdays">工作日</string>
     <string name="shuttle_timetable_tab_weekends">周末</string>
-    <string name="timetable_route_title">%1$s → %2$s</string>
+    <string name="timetable_route_title">%1$s ▶ %2$s</string>
     <string name="shuttle_timetable_empty">暂无运行校车。</string>
     <string name="shuttle_timetable_filter_title">搜索校车时刻表</string>
     <string name="shuttle_period">运行期间</string>
@@ -269,7 +269,7 @@
     </plurals>
     <string name="bus_timetable_format_last">%1$s时%2$s分出发（末班）</string>
     <string name="bus_arrival_estimated_format">%1$d分（预计）</string>
-    <string name="bus_arrival_secondary_format">" → %1$s到达"</string>
+    <string name="bus_arrival_secondary_format">" ▶ %1$s到达"</string>
     <string name="bus_no_realtime_data">暂无即将到达的公交。</string>
     <string name="bus_departure_log">到站记录</string>
     <string name="bus_log_title">路线公交通过信息</string>
@@ -302,26 +302,26 @@
     <string name="subway_blue_down">4号线 (安山·오이도)</string>
     <string name="subway_yellow_up">水仁线 (水原)</string>
     <string name="subway_yellow_down">水仁线 (仁川)</string>
-    <string name="subway_transfer_up">仁川→汉大前</string>
-    <string name="subway_transfer_down">汉大前→仁川</string>
+    <string name="subway_transfer_up">仁川▶汉大前</string>
+    <string name="subway_transfer_down">汉大前▶仁川</string>
     <string name="subway_transfer_incheon_oido">仁川·五耳岛</string>
     <string name="subway_transfer_ilsan_bucheon">一山·富川</string>
     <plurals name="subway_transfer_up_item_format">
-        <item quantity="one">[%1$s行] %2$s\n→ [%3$s行] %4$d分钟后（五耳岛）</item>
-        <item quantity="other">[%1$s行] %2$s\n→ [%3$s行] %4$d分钟后（五耳岛）</item>
+        <item quantity="one">[%1$s行] %2$s\n▶ [%3$s行] %4$d分钟后（五耳岛）</item>
+        <item quantity="other">[%1$s行] %2$s\n▶ [%3$s行] %4$d分钟后（五耳岛）</item>
     </plurals>
     <string name="subway_transfer_up_item_format_no_transfer">[%1$s行] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
-        <item quantity="one">[%1$s行] %2$d分钟后（%3$s）\n→ [%4$s行] %5$d分钟后（五耳岛）</item>
-        <item quantity="other">[%1$s行] %2$d分钟后（%3$s）\n→ [%4$s行] %5$d分钟后（五耳岛）</item>
+        <item quantity="one">[%1$s行] %2$d分钟后（%3$s）\n▶ [%4$s行] %5$d分钟后（五耳岛）</item>
+        <item quantity="other">[%1$s行] %2$d分钟后（%3$s）\n▶ [%4$s行] %5$d分钟后（五耳岛）</item>
     </plurals>
     <plurals name="subway_transfer_down_item_format_no_transfer">
         <item quantity="one">[%1$s行] %2$d分钟后（%3$s）</item>
         <item quantity="other">[%1$s行] %2$d分钟后（%3$s）</item>
     </plurals>
     <plurals name="subway_transfer_choji_item_format">
-        <item quantity="one">[%1$s行] %2$d分钟后\n→ [%3$s行] %4$d分钟后（草芝）</item>
-        <item quantity="other">[%1$s行] %2$d分钟后\n→ [%3$s行] %4$d分钟后（草芝）</item>
+        <item quantity="one">[%1$s行] %2$d分钟后\n▶ [%3$s行] %4$d分钟后（草芝）</item>
+        <item quantity="other">[%1$s行] %2$d分钟后\n▶ [%3$s行] %4$d分钟后（草芝）</item>
     </plurals>
     <string name="subway_transfer_destination_format">开往%1$s</string>
     <string name="subway_transfer_board_at_hanyang">在汉大前上车</string>
@@ -578,11 +578,11 @@
     <string name="shuttle_via_title">按车辆查看路线</string>
     <string name="bus_timetable_empty">该路线不提供时刻表。</string>
     <string name="bus_stop_gwangmyeong_station">光明站</string>
-    <string name="shuttle_via_format_6_stops">%1$s→%2$s→%3$s→%4$s→%5$s→%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s→%2$s→%3$s→%4$s→%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s→%2$s→%3$s→%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s→%2$s→%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s→%2$s</string>
+    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
+    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
+    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
+    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
+    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
     <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">上一天</string>
     <string name="next_day">下一天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
     <string name="home_destination_terminal">예술인</string>
     <string name="home_destination_jungang">중앙역</string>
     <string name="home_destination_dormitory">기숙사</string>
-    <string name="home_route_format">%1$s → %2$s</string>
+    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 출발</string>
     <string name="home_minutes">%1$d분</string>
     <string name="home_check">확인</string>
@@ -270,7 +270,7 @@
     <!-- 셔틀버스 시간표 -->
     <string name="shuttle_timetable_tab_weekdays">평일</string>
     <string name="shuttle_timetable_tab_weekends">주말</string>
-    <string name="timetable_route_title">%1$s → %2$s</string>
+    <string name="timetable_route_title">%1$s ▶ %2$s</string>
     <string name="shuttle_timetable_empty">운행 예정인 셔틀버스가 없습니다.</string>
     <!-- 셔틀버스 시간표 필터 -->
     <string name="shuttle_timetable_filter_title">셔틀 시간표 검색</string>
@@ -326,7 +326,7 @@
         <item quantity="other">%1$d분 (%2$d전)</item>
     </plurals>
     <string name="bus_arrival_estimated_format">%1$d분 (예정)</string>
-    <string name="bus_arrival_secondary_format">" → %1$s 도착"</string>
+    <string name="bus_arrival_secondary_format">" ▶ %1$s 도착"</string>
     <string name="bus_timetable_format">%1$s시 %2$s분 출발</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d분 (%2$d전, %3$d석, 막차)</item>
@@ -373,26 +373,26 @@
     <string name="subway_blue_down">4호선 (안산.오이도)</string>
     <string name="subway_yellow_up">수인선 (왕십리.수원)</string>
     <string name="subway_yellow_down">수인선 (오이도.인천)</string>
-    <string name="subway_transfer_up">인천→한대앞</string>
-    <string name="subway_transfer_down">한대앞→인천</string>
+    <string name="subway_transfer_up">인천▶한대앞</string>
+    <string name="subway_transfer_down">한대앞▶인천</string>
     <string name="subway_transfer_incheon_oido">인천·오이도</string>
     <string name="subway_transfer_ilsan_bucheon">일산·부천</string>
     <plurals name="subway_transfer_up_item_format">
-        <item quantity="one">[%1$s행] %2$s\n→ [%3$s행] %4$d분 후 (오이도)</item>
-        <item quantity="other">[%1$s행] %2$s\n→ [%3$s행] %4$d분 후 (오이도)</item>
+        <item quantity="one">[%1$s행] %2$s\n▶ [%3$s행] %4$d분 후 (오이도)</item>
+        <item quantity="other">[%1$s행] %2$s\n▶ [%3$s행] %4$d분 후 (오이도)</item>
     </plurals>
     <string name="subway_transfer_up_item_format_no_transfer">[%1$s행] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
-        <item quantity="one">[%1$s행] %2$d분 후 (%3$s)\n→ [%4$s행] %5$d분 후 (오이도)</item>
-        <item quantity="other">[%1$s행] %2$d분 후 (%3$s)\n→ [%4$s행] %5$d분 후 (오이도)</item>
+        <item quantity="one">[%1$s행] %2$d분 후 (%3$s)\n▶ [%4$s행] %5$d분 후 (오이도)</item>
+        <item quantity="other">[%1$s행] %2$d분 후 (%3$s)\n▶ [%4$s행] %5$d분 후 (오이도)</item>
     </plurals>
     <plurals name="subway_transfer_down_item_format_no_transfer">
         <item quantity="one">[%1$s행] %2$d분 후 (%3$s)</item>
         <item quantity="other">[%1$s행] %2$d분 후 (%3$s)</item>
     </plurals>
     <plurals name="subway_transfer_choji_item_format">
-        <item quantity="one">[%1$s행] %2$d분 후\n→ [%3$s행] %4$d분 후 (초지)</item>
-        <item quantity="other">[%1$s행] %2$d분 후\n→ [%3$s행] %4$d분 후 (초지)</item>
+        <item quantity="one">[%1$s행] %2$d분 후\n▶ [%3$s행] %4$d분 후 (초지)</item>
+        <item quantity="other">[%1$s행] %2$d분 후\n▶ [%3$s행] %4$d분 후 (초지)</item>
     </plurals>
     <string name="subway_transfer_destination_format">%1$s행</string>
     <string name="subway_transfer_board_at_hanyang">한대앞 탑승</string>
@@ -663,11 +663,11 @@
     <string name="shuttle_via_title">차량별 경로 조회</string>
     <string name="bus_timetable_empty">시간표가 제공되지 않는 노선입니다.</string>
     <string name="bus_stop_gwangmyeong_station">광명역</string>
-    <string name="shuttle_via_format_6_stops">%1$s→%2$s→%3$s→%4$s→%5$s→%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s→%2$s→%3$s→%4$s→%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s→%2$s→%3$s→%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s→%2$s→%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s→%2$s</string>
+    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
+    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
+    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
+    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
+    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
     <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">이전</string>
     <string name="next_day">다음</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="shuttle_bus">셔틀버스</string>
     <string name="bus">노선버스</string>
     <string name="tabbar_bus">버스</string>
-    <string name="tabbar_more">더 보기</string>
     <string name="tabbar_campus">캠퍼스</string>
     <!-- 홈 -->
     <string name="home_hero_title">지금 필요한 것만</string>
@@ -35,7 +34,6 @@
     <string name="home_weather_confidence_low">예보가 달라질 수 있어요</string>
     <string name="home_weather_attribution">Open-Meteo ↗</string>
     <string name="home_movement_title">지금 이동</string>
-    <string name="home_movement_detail">셔틀 상세</string>
     <string name="home_movement_timetable">전체 시간표</string>
     <string name="home_departure_selector_description">출발 정류장 선택: %1$s</string>
     <string name="home_destination_summary">%1$s 방면</string>
@@ -43,8 +41,6 @@
     <string name="home_quick_settings_action_bar_title">홈에 보일 내용을 조정해요</string>
     <string name="home_quick_settings_button">설정</string>
     <string name="home_quick_settings_title">설정</string>
-    <string name="home_quick_settings_legacy_title">기존 셔틀 화면</string>
-    <string name="home_quick_settings_legacy_subtitle">전체 도착 정보와 시간표를 확인합니다.</string>
     <string name="home_quick_settings_legacy_button">기존 셔틀 화면</string>
     <string name="home_quick_settings_bus50_transfer_title">50번 환승 정보 표시</string>
     <string name="home_quick_settings_bus50_transfer_subtitle">예술인에서 광명역 가는 50번 버스 도착 정보를 보여줘요.</string>
@@ -56,15 +52,9 @@
     <string name="home_quick_settings_subway_destination_oido">오이도</string>
     <string name="home_quick_settings_subway_destination_sosa">일산.부천</string>
     <string name="home_transfer_bus50_badge">50번</string>
-    <string name="home_transfer_bus50_title">%1$s 도착 예정</string>
-    <string name="home_transfer_bus50_subtitle">예술인에서 버스 환승</string>
-    <string name="home_transfer_buffer">+%1$d분</string>
     <string name="home_transfer_subway_suin_bundang_badge">수인분당</string>
     <string name="home_transfer_subway_seohae_badge">서해선</string>
     <string name="home_transfer_subway_title">%1$s 행</string>
-    <string name="home_transfer_subway_subtitle">한대앞에서 전철 환승</string>
-    <string name="home_transfer_subway_oido_subtitle">오이도역에서 전철 환승</string>
-    <string name="home_transfer_subway_choji_subtitle">초지역에서 전철 환승</string>
     <string name="home_transfer_bus50_connector">예술인</string>
     <string name="home_transfer_wait_minutes">%1$d분 대기</string>
     <string name="home_transfer_wait_immediate">바로 탑승</string>
@@ -89,15 +79,12 @@
     <string name="home_destination_terminal">예술인</string>
     <string name="home_destination_jungang">중앙역</string>
     <string name="home_destination_dormitory">기숙사</string>
-    <string name="home_route_format">%1$s ▶ %2$s</string>
     <string name="home_departure_format">%1$s 출발</string>
     <string name="home_minutes">%1$d분</string>
     <string name="home_check">확인</string>
     <string name="home_shuttle_last_run_subtitle">막차 · %1$s</string>
     <string name="home_no_data_title">지금 탈 수 있는 셔틀이 없어요</string>
     <string name="home_no_data_message">잠시 후 다시 확인하거나 아래 대체 노선을 확인해요.</string>
-    <string name="home_bus_title_format">%1$s번 버스</string>
-    <string name="home_bus_subtitle_format">%1$s 정류장</string>
     <string name="home_alt_bus_direction">%1$s 방면</string>
     <string name="home_alt_dormitory_nearby">한양대기숙사앞</string>
     <string name="home_alt_gyeonggi_technopark">경기테크노파크</string>
@@ -115,7 +102,6 @@
     <string name="home_meal_dinner">석식</string>
     <string name="home_meal_period_selector_description">식사 시간대 선택: %1$s</string>
     <string name="home_meal_tomorrow_format">내일 %1$s</string>
-    <string name="home_meal_tomorrow_breakfast">내일 조식</string>
     <string name="home_meal_empty_title">%1$s 메뉴가 없어요</string>
     <string name="home_meal_empty_message">전체 학식에서 다른 시간대 메뉴를 확인할 수 있어요.</string>
     <!-- 셔틀버스 도착 정보 탭 -->
@@ -138,11 +124,8 @@
     <string name="shuttle_footer_entire_timetable_jungang_station">전체 시간표 (중앙역)</string>
     <string name="shuttle_footer_stop_info">정류장 위치 &amp; 첫차/막차</string>
     <string name="shuttle_footer_help">셔틀버스 도움말</string>
-    <string name="shuttle_action_bar_title">셔틀 표시 옵션</string>
     <string name="shuttle_quick_settings_button">설정</string>
     <string name="shuttle_quick_settings_title">설정</string>
-    <string name="shuttle_quick_settings_arrival_by_time_subtitle">셔틀 도착 정보를 남은 시간 기준으로 보여줘요.</string>
-    <string name="shuttle_quick_settings_departure_time_subtitle">셔틀 시간을 출발 시각 기준으로 보여줘요.</string>
     <string name="shuttle_quick_settings_presence_title">함께 보는 사람 표시</string>
     <string name="shuttle_quick_settings_presence_subtitle">현재 같은 정류장 정보를 보고 있는 사람 수를 표시해요.</string>
     <string name="shuttle_quick_settings_section_display">셔틀 표시</string>
@@ -157,14 +140,6 @@
     <string name="shuttle_quick_settings_alternative_mode_hidden">숨김</string>
     <string name="shuttle_connection_transfer_format">%1$s 환승</string>
     <string name="shuttle_presence_viewer_count">%1$d명이 함께 보는 중</string>
-    <string name="shuttle_display_order_title">표시 순서</string>
-    <string name="shuttle_display_order_subtitle">셔틀 도착 정보를 시간순 또는 행선지별로 정리해요.</string>
-    <string name="shuttle_display_time_order">시간순</string>
-    <string name="shuttle_display_destination_order">행선지별</string>
-    <string name="shuttle_time_display_title">시간 표시</string>
-    <string name="shuttle_time_display_subtitle">셔틀 시간을 남은 시간 또는 출발 시각으로 보여줘요.</string>
-    <string name="shuttle_time_remaining">남은 시간</string>
-    <string name="shuttle_time_departure">출발 시각</string>
     <string name="home_experience_new">새 홈 체험하기</string>
     <!-- 셔틀버스 도착 정보 없음 -->
     <string name="shuttle_bus_alternative_route">10-1 (상록수역 출발)</string>
@@ -189,19 +164,11 @@
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 도착</string>
     <string name="shuttle_alarm_alighting_tracking">거리 확인 중</string>
     <string name="shuttle_alarm_boarding_initial">%1$d분 후 출발</string>
-    <string name="shuttle_alarm_boarding_initial_checkpoint">%1$d분 후 출발 · %2$s 통과</string>
-    <string name="shuttle_alarm_boarding_content">%1$d분 · %2$s방향 %3$s</string>
-    <string name="shuttle_alarm_boarding_content_checkpoint">%1$d분 · %2$s 통과 · %3$s방향 %4$s</string>
-    <string name="shuttle_alarm_boarding_short">%1$d분</string>
     <string name="shuttle_alarm_checkpoint_waiting">%1$s 대기</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s 출발</string>
     <string name="shuttle_alarm_checkpoint_approaching">%1$s 접근</string>
-    <string name="shuttle_alarm_now">승차 시간이 되었습니다.</string>
     <string name="shuttle_alarm_alighting_title">셔틀버스 하차 알림</string>
-    <string name="shuttle_alarm_alighting_preparing">하차 정류장 모니터링 중</string>
     <string name="shuttle_alarm_alighting_content">정류장까지 약 %1$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_distance">%1$s, %2$s까지 %3$s</string>
-    <string name="shuttle_alarm_alighting_checkpoint_tracking">%1$s, %2$s까지 거리 확인 중</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">추적 중</string>
     <string name="shuttle_alarm_alighting_alert_title">하차 준비하세요!</string>
@@ -240,7 +207,6 @@
     <string name="shuttle_type_dormitory_direct">기숙사 (직행)</string>
     <string name="shuttle_type_shuttlecock_circular">셔틀콕 (순환)</string>
     <string name="shuttle_type_dormitory_circular">기숙사 (순환)</string>
-    <string name="shuttle_type_jungang_circular">기숙사 (중앙역)</string>
     <string name="shuttle_type_shuttlecock_finishing">셔틀콕 종착</string>
     <!-- 셔틀버스 첫막차 시간 -->
     <string name="shuttle_first_last_time_title">첫차 &amp; 막차</string>
@@ -327,7 +293,6 @@
     </plurals>
     <string name="bus_arrival_estimated_format">%1$d분 (예정)</string>
     <string name="bus_arrival_secondary_format">" ▶ %1$s 도착"</string>
-    <string name="bus_timetable_format">%1$s시 %2$s분 출발</string>
     <plurals name="bus_realtime_format_seats_last">
         <item quantity="one">%1$d분 (%2$d전, %3$d석, 막차)</item>
         <item quantity="other">%1$d분 (%2$d전, %3$d석, 막차)</item>
@@ -336,7 +301,6 @@
         <item quantity="one">%1$d분 (%2$d전, 막차)</item>
         <item quantity="other">%1$d분 (%2$d전, 막차)</item>
     </plurals>
-    <string name="bus_timetable_format_last">%1$s시 %2$s분 출발 (막차)</string>
     <!-- 노선버스 도착 정보 없음 -->
     <string name="bus_no_realtime_data">도착 예정인 버스가 없습니다.</string>
     <string name="bus_departure_log">도착 기록</string>
@@ -373,15 +337,12 @@
     <string name="subway_blue_down">4호선 (안산.오이도)</string>
     <string name="subway_yellow_up">수인선 (왕십리.수원)</string>
     <string name="subway_yellow_down">수인선 (오이도.인천)</string>
-    <string name="subway_transfer_up">인천▶한대앞</string>
-    <string name="subway_transfer_down">한대앞▶인천</string>
     <string name="subway_transfer_incheon_oido">인천·오이도</string>
     <string name="subway_transfer_ilsan_bucheon">일산·부천</string>
     <plurals name="subway_transfer_up_item_format">
         <item quantity="one">[%1$s행] %2$s\n▶ [%3$s행] %4$d분 후 (오이도)</item>
         <item quantity="other">[%1$s행] %2$s\n▶ [%3$s행] %4$d분 후 (오이도)</item>
     </plurals>
-    <string name="subway_transfer_up_item_format_no_transfer">[%1$s행] %2$s</string>
     <plurals name="subway_transfer_down_item_format">
         <item quantity="one">[%1$s행] %2$d분 후 (%3$s)\n▶ [%4$s행] %5$d분 후 (오이도)</item>
         <item quantity="other">[%1$s행] %2$d분 후 (%3$s)\n▶ [%4$s행] %5$d분 후 (오이도)</item>
@@ -407,7 +368,6 @@
         <item quantity="other">%1$d분 대기</item>
     </plurals>
     <!-- 전철 도착 정보 없음 -->
-    <string name="subway_no_realtime_data">도착 예정인 전철 정보가 없습니다.</string>
     <!-- 전철 도착 정보 시간 -->
     <string name="subway_realtime_destination_format">%1$s행</string>
     <string name="subway_realtime_destination_format_last">%1$s행(막차)</string>
@@ -535,16 +495,12 @@
     <string name="menu_chat">문의하기</string>
     <string name="menu_donate">기부하기</string>
     <string name="inquiry_title">문의하기</string>
-    <string name="inquiry_short">문의</string>
     <string name="inquiry_input_hint">메시지를 입력하세요</string>
     <string name="inquiry_send">전송</string>
     <string name="inquiry_empty">아직 대화가 없습니다. 궁금한 점을 남겨주세요.</string>
     <string name="inquiry_read">읽음</string>
     <string name="inquiry_load_failed">대화를 불러오지 못했습니다.</string>
     <string name="menu_review">앱 평가하기</string>
-    <string name="menu_section_school_life">학교생활</string>
-    <string name="menu_section_support">지원 및 설정</string>
-    <string name="menu_section_external">외부 링크</string>
     <string name="menu_map">캠퍼스 지도</string>
     <string name="campus_tools_title">캠퍼스 도구</string>
     <string name="campus_tools_subtitle">학교생활에 필요한 기능을 빠르게 찾아보세요.</string>
@@ -569,7 +525,6 @@
     <string name="reading_room_alarm_3_hour">3시간 후 알림</string>
     <string name="reading_room_alarm_4_hour">4시간 후 알림</string>
     <string name="reading_room_alarm_cancel">알림 취소</string>
-    <string name="reading_room_seat_format">%1$d/%2$d 석</string>
     <string name="reading_room_available_seat_format">잔여 %1$d석 · 전체 %2$d석</string>
     <string name="reading_room_full_seat_format">만석 · 전체 %1$d석</string>
     <string name="default_notification_channel_id">HYUabot notification channel ID</string>
@@ -601,11 +556,9 @@
     <string name="reading_room_extend_noti_content">열람실 이용 시간이 10분 후 만료됩니다. 연장이 필요하시면 확인해 주세요.</string>
     <string name="reading_room_alarm_extend">열람실 연장 알림입니다!</string>
     <string name="reading_room_alarm_format">%1$s 에 알림이 설정되어 있어요.</string>
-    <string name="shuttle_realtime_location_error">가장 가까운 정류장을 찾는데 실패했습니다.</string>
     <string name="campus_settings">캠퍼스 설정</string>
     <string name="language_settings">언어 설정</string>
     <string name="theme_settings">테마 설정</string>
-    <string name="theme_settings_description">테마를 선택해주세요.</string>
     <string name="theme_light">주간</string>
     <string name="theme_dark">야간</string>
     <string name="theme_system">자동</string>
@@ -631,22 +584,18 @@
     <string name="open_source_licenses_description">앱에서 사용하는 오픈소스 소프트웨어를 확인합니다.</string>
     <string name="developer_name">개발자: 이정인</string>
     <string name="developer_belong">소속: 소프트웨어학부 17학번</string>
-    <string name="contact_loading">전화부 목록을 불러오는 중입니다…</string>
     <string name="contact_search_guide">이름 / 전화번호 검색</string>
     <!-- 캘린더 -->
     <string name="month_header">%1$d년 %2$d월</string>
-    <string name="event_date_format">%1$d월 %2$d일</string>
     <string name="event_date_range_format">%1$d월 %2$d일 - %3$d월 %4$d일</string>
     <string name="calendar_select_date_hint">날짜를 선택하면 일정을 확인할 수 있습니다</string>
     <string name="calendar_upcoming_empty">다가오는 일정이 없습니다</string>
     <string name="calendar_previous_month">이전 달</string>
     <string name="calendar_next_month">다음 달</string>
     <string name="calendar_event_ongoing">진행 중</string>
-    <string name="calendar_loading">학사일정 목록을 불러오는 중입니다.</string>
     <string name="do_not_show_again_this_year">올해는 다시 보지 않기</string>
     <string name="dialog_title">개발자 생일 공지</string>
     <string name="dialog_message">오늘(12/12)은 개발자의 생일입니다.\n\n항상 잘 사용해주시는 여러분이 저에게는 크나큰 선물입니다. 앞으로도 더 좋은 서비스를 제공할 수 있도록 노력하겠습니다.\n\n감사합니다.</string>
-    <string name="bus_departure_log_error">도착 기록을 불러오는데 실패했습니다.</string>
     <string name="bus_realtime_error">버스 도착 정보를 불러오는데 실패했습니다.</string>
     <string name="bus_route_info_error">버스 노선 정보를 불러오는데 실패했습니다.</string>
     <string name="bus_timetable_error">버스 시간표를 불러오는데 실패했습니다.</string>
@@ -663,12 +612,6 @@
     <string name="shuttle_via_title">차량별 경로 조회</string>
     <string name="bus_timetable_empty">시간표가 제공되지 않는 노선입니다.</string>
     <string name="bus_stop_gwangmyeong_station">광명역</string>
-    <string name="shuttle_via_format_6_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s▶%6$s</string>
-    <string name="shuttle_via_format_5_stops">%1$s▶%2$s▶%3$s▶%4$s▶%5$s</string>
-    <string name="shuttle_via_format_4_stops">%1$s▶%2$s▶%3$s▶%4$s</string>
-    <string name="shuttle_via_format_3_stops">%1$s▶%2$s▶%3$s</string>
-    <string name="shuttle_via_format_2_stops">%1$s▶%2$s</string>
-    <string name="shuttle_via_format_1_stop">%1$s</string>
     <string name="previous_day">이전</string>
     <string name="next_day">다음</string>
     <string name="show_by_destination">목적지/시간 순서</string>
@@ -792,7 +735,6 @@
     <string name="bus_help_departure_content">경기도에서 제공한 각 노선의 정류장 통과 시간을 제공합니다. 현재 실시간 도착 정보가 존재하지 않아도 이를 참고하여 버스 도착 시간을 가늠해볼 수 있습니다.</string>
     <!-- Bus Stop Info Dialog -->
     <string name="bus_stop_info_title">정류장 정보</string>
-    <string name="bus_stop_info_empty">정류장 정보를 불러올 수 없습니다.</string>
     <string name="bus_stop_info_error">정보를 불러오는데 실패했습니다.</string>
     <string name="bus_first_last_up">상행: 첫차 %1$s / 막차 %2$s</string>
     <string name="bus_first_last_down">하행: 첫차 %1$s / 막차 %2$s</string>


### PR DESCRIPTION
## Summary
- Rename the English home shuttle destination buttons from Handaeap to Station and Jungang to Jungang Stn.
- Send the selected app language separately from the Korean/English notice language for home and shuttle subway data.
- Clear previously loaded subway data when the app language changes and bypass stale timetable cache entries.

## Test plan
- [x] ./gradlew ktlintCheck
- [x] ./gradlew testDevDebugUnitTest testProductionDebugUnitTest
- [x] Verified the user-facing copy change is English-only and existing Korean, Japanese, and Simplified Chinese resources remain complete.