### PR TITLE
feat: add debug deep links and localized UI QA

### DIFF
--- a/DEBUG_DEEPLINKS.md
+++ b/DEBUG_DEEPLINKS.md
@@ -1,0 +1,35 @@
+# Debug deep links
+
+Debug builds accept `hyuabot://debug/<route>?<key>=<value>`. The debug host is
+handled only when `BuildConfig.DEBUG` is true; release builds continue to use
+the existing public routes and ignore this host.
+
+Examples:
+
+```sh
+adb shell am start -a android.intent.action.VIEW \
+  -d 'hyuabot://debug/shuttle?stop=station&to=terminal'
+adb shell am start -a android.intent.action.VIEW \
+  -d 'hyuabot://debug/bus-departure-dialog?stopID=216000383&firstRouteID=216000068'
+adb shell am start -a android.intent.action.VIEW \
+  -d 'hyuabot://debug/building-webview?title=Library&url=https%3A%2F%2Fhyuabot.app'
+```
+
+Supported page routes are `home`, `shuttle`, `bus`, `subway`, `cafeteria`,
+`reading-room`, `map`, `setting`, `contact`, `calendar`, `inquiry`, and
+`campus`. Timetable routes are `shuttle-timetable`, `bus-timetable`, and
+`subway-timetable`.
+
+Supported navigation dialogs are `shuttle-stop-dialog`,
+`shuttle-help-dialog`, `shuttle-timetable-dialog`,
+`shuttle-timetable-filter-dialog`, `bus-help-dialog`, `bus-stop-info`,
+`bus-departure-dialog`, `bus-route-dialog`, `language-setting-dialog`,
+`campus-setting-dialog`, `theme-setting-dialog`, and `developer-dialog`.
+
+Supported direct sheets are `home-quick-settings`, `bus-quick-settings`,
+`shuttle-quick-settings`, `shuttle-via`, and `building-webview`.
+
+Useful arguments include `stopID`, `destinationID`, `firstRouteID`,
+`secondRouteID`, `thirdRouteID`, `routeID`, `seq`, `stationID`, `heading`,
+`tab`, `stop`, `to`, `url`, and `title`. Missing or invalid numeric values use
+safe preview defaults.

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/DebugDeepLinkRouter.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/DebugDeepLinkRouter.kt
@@ -1,0 +1,78 @@
+package app.kobuggi.hyuabot.ui
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.navigation.NavController
+import app.kobuggi.hyuabot.BuildConfig
+import app.kobuggi.hyuabot.R
+
+internal object DebugDeepLinkRouter {
+    private const val DEBUG_HOST = "debug"
+
+    fun uriFrom(intent: Intent?): android.net.Uri? {
+        val uri = intent?.data ?: return null
+        if (!BuildConfig.DEBUG || intent.action != Intent.ACTION_VIEW) return null
+        if (uri.scheme != "hyuabot" || uri.host != DEBUG_HOST) return null
+        return uri
+    }
+
+    fun navigate(uri: android.net.Uri, navController: NavController): Boolean {
+        val route = uri.pathSegments.firstOrNull()?.lowercase() ?: return false
+        val arguments = Bundle().apply {
+            putInt("stopID", uri.intParameter("stopID", 1))
+            putInt("destinationID", uri.intParameter("destinationID", 1))
+            putInt("firstRouteID", uri.intParameter("firstRouteID", 0))
+            putInt("secondRouteID", uri.intParameter("secondRouteID", 0))
+            putInt("thirdRouteID", uri.intParameter("thirdRouteID", 0))
+            putInt("routeID", uri.intParameter("routeID", 0))
+            putInt("seq", uri.intParameter("seq", -1))
+            putString("stationID", uri.getQueryParameter("stationID") ?: "K449")
+            putString("heading", uri.getQueryParameter("heading") ?: "up")
+            putString("tab", uri.getQueryParameter("tab").orEmpty())
+            putString("stop", uri.getQueryParameter("stop").orEmpty())
+            putString("to", uri.getQueryParameter("to").orEmpty())
+            putString("entryScreen", uri.getQueryParameter("entryScreen") ?: "debug")
+            putString("entryScreenName", uri.getQueryParameter("entryScreenName") ?: "Debug")
+            uri.getQueryParameter("url")?.let { putString("url", it) }
+            uri.getQueryParameter("title")?.let { putString("title", it) }
+        }
+
+        val destination = when (route) {
+            "home" -> R.id.homeFragment
+            "shuttle", "shuttle-realtime" -> R.id.shuttleRealtimeFragment
+            "shuttle-timetable" -> R.id.shuttleTimetableFragment
+            "shuttle-stop-dialog" -> R.id.shuttleStopDialogFragment
+            "shuttle-help-dialog" -> R.id.shuttleHelpDialogFragment
+            "shuttle-timetable-dialog" -> R.id.shuttleTimetableDialogFragment
+            "shuttle-timetable-filter-dialog" -> R.id.shuttleTimetableFilterDialogFragment
+            "bus", "bus-realtime" -> R.id.busRealtimeFragment
+            "bus-timetable" -> R.id.busTimetableFragment
+            "bus-help-dialog" -> R.id.busHelpDialogFragment
+            "bus-stop-info" -> R.id.busStopInfoFragment
+            "bus-departure-dialog" -> R.id.busDepartureLogDialogFragment
+            "bus-route-dialog" -> R.id.busRouteInfoDialogFragment
+            "subway", "subway-realtime" -> R.id.subwayRealtimeFragment
+            "subway-timetable" -> R.id.subwayTimetableFragment
+            "cafeteria" -> R.id.cafeteriaFragment
+            "reading-room" -> R.id.readingRoomFragment
+            "map" -> R.id.mapFragment
+            "setting" -> R.id.settingFragment
+            "contact" -> R.id.contactFragment
+            "calendar" -> R.id.calendarFragment
+            "inquiry" -> R.id.inquiryChatFragment
+            "campus" -> R.id.menuFragment
+            "notice" -> R.id.noticeWebViewFragment
+            "language-setting-dialog" -> R.id.languageSettingDialogFragment
+            "campus-setting-dialog" -> R.id.campusSettingDialogFragment
+            "theme-setting-dialog" -> R.id.themeSettingDialogFragment
+            "developer-dialog" -> R.id.settingDeveloperDialogFragment
+            else -> return false
+        }
+
+        navController.navigate(destination, arguments)
+        return true
+    }
+
+    private fun android.net.Uri.intParameter(name: String, default: Int): Int =
+        getQueryParameter(name)?.toIntOrNull() ?: default
+}

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -46,6 +46,14 @@ import app.kobuggi.hyuabot.util.AnalyticsScreen
 import app.kobuggi.hyuabot.util.AnalyticsScreenDispatcher
 import app.kobuggi.hyuabot.util.InAppReviewManager
 import app.kobuggi.hyuabot.ui.common.applyGodoTypography
+import app.kobuggi.hyuabot.ui.bus.realtime.BusQuickSettingsDialog
+import app.kobuggi.hyuabot.ui.bus.realtime.BusSeoulTargetStop
+import app.kobuggi.hyuabot.ui.home.HomeQuickSettingsDialog
+import app.kobuggi.hyuabot.ui.home.HomeSubwayTransferDestination
+import app.kobuggi.hyuabot.ui.map.BuildingWebViewSheet
+import app.kobuggi.hyuabot.ui.shuttle.realtime.ShuttleAlternativeDisplayMode
+import app.kobuggi.hyuabot.ui.shuttle.realtime.ShuttleQuickSettingsDialog
+import app.kobuggi.hyuabot.ui.shuttle.via.ShuttleViaSheetDialog
 import app.kobuggi.hyuabot.widget.ShuttleWidgetProvider
 import com.google.android.material.navigation.NavigationBarView
 import dagger.hilt.android.AndroidEntryPoint
@@ -107,7 +115,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         openBirthDayDialog()
         requestInAppReview()
         syncShuttleServiceNotices()
-        val handledDeepLink = navController.handleDeepLink(intent)
+        val handledDeepLink = handleDebugDeepLink(intent) || navController.handleDeepLink(intent)
         if (
             savedInstanceState == null &&
             !handledDeepLink &&
@@ -455,7 +463,50 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        navController.handleDeepLink(intent)
+        handleDebugDeepLink(intent) || navController.handleDeepLink(intent)
+    }
+
+    private fun handleDebugDeepLink(intent: Intent): Boolean {
+        val uri = DebugDeepLinkRouter.uriFrom(intent) ?: return false
+        if (DebugDeepLinkRouter.navigate(uri, navController)) return true
+
+        val route = uri.pathSegments.firstOrNull()?.lowercase() ?: return true
+        when (route) {
+            "home-quick-settings" -> HomeQuickSettingsDialog.newInstance(
+                showPresenceStatus = true,
+                showBus50Transfer = true,
+                showSubwayTransfer = true,
+                subwayTransferDestination = HomeSubwayTransferDestination.SEOUL,
+            ).show(supportFragmentManager, "debug-home-quick-settings")
+
+            "bus-quick-settings" -> BusQuickSettingsDialog.newInstance(
+                showSecondaryEta = true,
+                seoulTarget = BusSeoulTargetStop.GANGNAM,
+            ).show(supportFragmentManager, "debug-bus-quick-settings")
+
+            "shuttle-quick-settings" -> ShuttleQuickSettingsDialog.newInstance(
+                showByDestination = true,
+                showDepartureTime = false,
+                showPresenceStatus = true,
+                showBusTransfer = true,
+                showSubwayTransfer = true,
+                subwayDestination = HomeSubwayTransferDestination.SEOUL,
+                alternativeMode = ShuttleAlternativeDisplayMode.AUTOMATIC,
+            ).show(supportFragmentManager, "debug-shuttle-quick-settings")
+
+            "shuttle-via" -> ShuttleViaSheetDialog().show(
+                supportFragmentManager,
+                "debug-shuttle-via",
+            )
+
+            "building-webview" -> BuildingWebViewSheet.newInstance(
+                title = uri.getQueryParameter("title") ?: "Debug WebView",
+                url = uri.getQueryParameter("url") ?: "https://hyuabot.app",
+            ).show(supportFragmentManager, "debug-building-webview")
+
+            else -> Unit
+        }
+        return true
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -11,7 +11,7 @@
     <string name="tabbar_campus">Campus</string>
     <!-- Home -->
     <string name="home_hero_title">Only what you need now</string>
-    <string name="home_hero_subtitle">We bring up the information that fits your situation, from routes to meals.</string>
+    <string name="home_hero_subtitle">Information tailored to your situation.</string>
     <string name="home_weather_rain_title">Rain is expected today</string>
     <string name="home_weather_rain_now_title">It\'s raining now</string>
     <string name="home_weather_rain_start_title">Rain starts at %1$s</string>
@@ -47,10 +47,10 @@
     <string name="home_quick_settings_subway_transfer_title">Show subway transfers</string>
     <string name="home_quick_settings_subway_transfer_subtitle">Choose the destination to prioritize when subway transfer info is added.</string>
     <string name="home_quick_settings_subway_destination_seoul">Seoul</string>
-    <string name="home_quick_settings_subway_destination_suwon_yongin">Suwon/Yongin</string>
+    <string name="home_quick_settings_subway_destination_suwon_yongin">Suwon</string>
     <string name="home_quick_settings_subway_destination_incheon">Incheon</string>
     <string name="home_quick_settings_subway_destination_oido">Oido</string>
-    <string name="home_quick_settings_subway_destination_sosa">Ilsan/Bucheon</string>
+    <string name="home_quick_settings_subway_destination_sosa">Ilsan</string>
     <string name="home_transfer_bus50_badge">50</string>
     <string name="home_transfer_subway_suin_bundang_badge">Suin</string>
     <string name="home_transfer_subway_seohae_badge">Seohae</string>
@@ -86,7 +86,7 @@
     <string name="home_no_data_title">No shuttle available now</string>
     <string name="home_no_data_message">Check again later or use an alternative route below.</string>
     <string name="home_alt_bus_direction">Toward %1$s</string>
-    <string name="home_alt_dormitory_nearby">Hanyang Univ. Dormitory Front</string>
+    <string name="home_alt_dormitory_nearby">Dormitory</string>
     <string name="home_alt_gyeonggi_technopark">Gyeonggi Techno Park</string>
     <string name="home_alt_sangnoksu">Sangnoksu Station</string>
     <string name="home_alt_seongan_entrance">Seongan-gil Entrance</string>
@@ -230,11 +230,11 @@
     <string name="bus_stop_gyodae">Gyodae Station</string>
     <string name="bus_stop_gangnam">Gangnam Station</string>
     <string name="bus_stop_yangjae">Yangjae Station</string>
-    <string name="bus_stop_yangjae_forest">Yangjae Citizens\' Forest Station</string>
+    <string name="bus_stop_yangjae_forest">Yangjae Forest Station</string>
     <string name="bus_stop_suwon_station">Suwon Station</string>
     <string name="bus_quick_settings_title">Bus settings</string>
     <string name="bus_quick_settings_show_secondary_eta">Show arrival time</string>
-    <string name="bus_quick_settings_seoul_target">Seoul-bound destination</string>
+    <string name="bus_quick_settings_seoul_target">To Seoul</string>
     <!-- 노선 버스 정류장 선택 -->
     <string name="bus_stop_title">Stop Information</string>
     <string-array name="bus_stop_list">
@@ -513,7 +513,7 @@
     <string name="theme_settings">Theme Settings</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
-    <string name="theme_system">System</string>
+    <string name="theme_system">Auto</string>
     <string name="campus_erica">ERICA</string>
     <string name="campus_seoul">Seoul</string>
     <string name="bus_low_floor">Low-floor</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -490,7 +490,7 @@
     <string name="theme_settings">テーマ設定</string>
     <string name="theme_light">ライト</string>
     <string name="theme_dark">ダーク</string>
-    <string name="theme_system">システム</string>
+    <string name="theme_system">自動</string>
     <string name="campus_erica">ERICA</string>
     <string name="campus_seoul">ソウル</string>
     <string name="bus_low_floor">低床</string>


### PR DESCRIPTION
## Summary

- Add DEBUG-only `hyuabot://debug/...` deep links for previewing app pages, dialogs, and sheets without navigating through the UI.
- Document the supported Android routes and `adb` usage examples.
- Shorten English and Japanese localized labels that were visibly truncated in the localization QA pass.

## Test plan

- [x] `./gradlew :app:compileProductionDebugKotlin`
- [x] Reviewed Android English, Japanese, and Simplified Chinese resource coverage.
- [ ] Manually launch the documented routes on an Android emulator or device.