### PR TITLE
fix: exclude emulator errors from Crashlytics

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/GlobalApplication.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/GlobalApplication.kt
@@ -6,7 +6,7 @@ import android.app.NotificationManager
 import android.content.Context
 import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.util.AnalyticsManager
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import app.kobuggi.hyuabot.util.CrashlyticsManager
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -32,7 +32,7 @@ class GlobalApplication : Application() {
         applicationScope.launch {
             val enabled = userPreferencesRepository.analyticsConsent.first()
             AnalyticsManager.setCollectionEnabled(enabled)
-            FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = enabled
+            CrashlyticsManager.setCollectionEnabled(enabled)
         }
     }
 

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/setting/SettingFragment.kt
@@ -1,7 +1,4 @@
 package app.kobuggi.hyuabot.ui.setting
-import app.kobuggi.hyuabot.util.AnalyticsContentType
-import app.kobuggi.hyuabot.util.AnalyticsItem
-import app.kobuggi.hyuabot.util.AnalyticsManager
 
 import android.content.DialogInterface
 import android.content.Intent
@@ -24,7 +21,10 @@ import app.kobuggi.hyuabot.ui.MainActivity
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import app.kobuggi.hyuabot.util.AnalyticsContentType
+import app.kobuggi.hyuabot.util.AnalyticsItem
+import app.kobuggi.hyuabot.util.AnalyticsManager
+import app.kobuggi.hyuabot.util.CrashlyticsManager
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -84,7 +84,7 @@ class SettingFragment @Inject constructor() : Fragment(), DialogInterface.OnDism
                 viewLifecycleOwner.lifecycleScope.launch {
                     userPreferencesRepository.setAnalyticsConsent(isChecked)
                     AnalyticsManager.setCollectionEnabled(isChecked)
-                    FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled = isChecked
+                    CrashlyticsManager.setCollectionEnabled(isChecked)
                 }
             }
         }

--- a/app/src/main/java/app/kobuggi/hyuabot/util/CrashlyticsManager.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/util/CrashlyticsManager.kt
@@ -1,0 +1,48 @@
+package app.kobuggi.hyuabot.util
+
+import android.os.Build
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/** Keeps emulator-generated reports out of the production Crashlytics data. */
+object CrashlyticsManager {
+    fun setCollectionEnabled(userConsent: Boolean) {
+        FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled =
+            userConsent && !isEmulator()
+    }
+}
+
+internal fun isEmulator(build: EmulatorBuild = EmulatorBuild.current()): Boolean =
+    build.fingerprint.startsWith("generic") ||
+        build.fingerprint.startsWith("unknown") ||
+        build.fingerprint.contains("emulator") ||
+        build.model.contains("google_sdk", ignoreCase = true) ||
+        build.model.contains("emulator", ignoreCase = true) ||
+        build.model.contains("android sdk built for", ignoreCase = true) ||
+        build.manufacturer.contains("genymotion", ignoreCase = true) ||
+        (build.brand.startsWith("generic") && build.device.startsWith("generic")) ||
+        build.product.contains("sdk", ignoreCase = true) ||
+        build.product.contains("emulator", ignoreCase = true) ||
+        build.hardware.equals("goldfish", ignoreCase = true) ||
+        build.hardware.equals("ranchu", ignoreCase = true)
+
+internal data class EmulatorBuild(
+    val fingerprint: String,
+    val model: String,
+    val manufacturer: String,
+    val brand: String,
+    val device: String,
+    val product: String,
+    val hardware: String,
+) {
+    companion object {
+        fun current() = EmulatorBuild(
+            fingerprint = Build.FINGERPRINT,
+            model = Build.MODEL,
+            manufacturer = Build.MANUFACTURER,
+            brand = Build.BRAND,
+            device = Build.DEVICE,
+            product = Build.PRODUCT,
+            hardware = Build.HARDWARE,
+        )
+    }
+}

--- a/app/src/test/java/app/kobuggi/hyuabot/util/CrashlyticsConfigurationTest.kt
+++ b/app/src/test/java/app/kobuggi/hyuabot/util/CrashlyticsConfigurationTest.kt
@@ -1,0 +1,41 @@
+package app.kobuggi.hyuabot.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashlyticsConfigurationTest {
+    @Test
+    fun `recognizes common Android emulator fingerprints`() {
+        assertTrue(isEmulator(build(model = "sdk_gphone64_x86_64", hardware = "ranchu")))
+        assertTrue(isEmulator(build(fingerprint = "generic_x86/sdk/generic_x86:35/XYZ")))
+        assertTrue(isEmulator(build(manufacturer = "Genymotion")))
+    }
+
+    @Test
+    fun `does not classify a physical device as an emulator`() {
+        assertFalse(
+            isEmulator(
+                build(
+                    fingerprint = "samsung/e1sxxx/SM-G990:14/UP1A.231005.007/123456:user/release-keys",
+                    model = "SM-G990",
+                    manufacturer = "samsung",
+                    brand = "samsung",
+                    device = "e1sxxx",
+                    product = "e1sxxx",
+                    hardware = "exynos",
+                )
+            )
+        )
+    }
+
+    private fun build(
+        fingerprint: String = "physical/device/release-keys",
+        model: String = "Physical Device",
+        manufacturer: String = "Acme",
+        brand: String = "acme",
+        device: String = "device",
+        product: String = "physical",
+        hardware: String = "device",
+    ) = EmulatorBuild(fingerprint, model, manufacturer, brand, device, product, hardware)
+}


### PR DESCRIPTION
## Summary

- Disable Crashlytics collection on Android emulators.
- Apply the emulator exclusion during app startup and analytics-consent changes.
- Add coverage for common emulator fingerprints and a physical-device fingerprint.

## Test plan

- [x] ./gradlew testDevDebugUnitTest testProductionDebugUnitTest
- [x] Verified the Crashlytics collection gate is disabled on emulators and remains consent-controlled on physical devices.