### PR TITLE
fix: add prominent location disclosures

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -17,7 +17,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.CheckBox
-import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -111,7 +110,6 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             }
         }
         suggestLanguageIfNeeded()
-        checkLocationPermission()
         openBirthDayDialog()
         requestInAppReview()
         syncShuttleServiceNotices()
@@ -278,6 +276,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     override fun onResume() {
         super.onResume()
         updatePrimaryNavigationItem(navController.currentDestination?.id)
+        if (hasLocationPermission()) {
+            maybeRequestBackgroundLocation()
+        }
     }
 
     private fun updateBottomNavigationLabels() {
@@ -385,35 +386,9 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         }
     }
 
-    private fun checkLocationPermission() {
-        if (
-            ActivityCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED ||
-            ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED
-        ) {
-            if (ActivityCompat.shouldShowRequestPermissionRationale(this, ACCESS_FINE_LOCATION)) {
-                Toast.makeText(
-                    this,
-                    getString(R.string.location_permission_nearest_stop),
-                    Toast.LENGTH_SHORT
-                ).show()
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION),
-                    LOCATION_PERMISSION_REQUEST_CODE
-                )
-            } else {
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(
-                        ACCESS_FINE_LOCATION,
-                        ACCESS_COARSE_LOCATION
-                    ),
-                    LOCATION_PERMISSION_REQUEST_CODE
-                )
-            }
-        } else {
-            maybeRequestBackgroundLocation()
-        }
+    private fun hasLocationPermission(): Boolean {
+        return ActivityCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+            ActivityCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun maybeRequestBackgroundLocation() {
@@ -451,11 +426,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (
-            requestCode == LOCATION_PERMISSION_REQUEST_CODE &&
-            grantResults.isNotEmpty() &&
-            grantResults.any { it == PackageManager.PERMISSION_GRANTED }
-        ) {
+        if (requestCode == LOCATION_PERMISSION_REQUEST_CODE && hasLocationPermission()) {
             maybeRequestBackgroundLocation()
         }
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -2,6 +2,7 @@ package app.kobuggi.hyuabot.ui.home
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -30,6 +31,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.PopupMenu
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityCompat
@@ -50,6 +52,7 @@ import app.kobuggi.hyuabot.databinding.FragmentHomeBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeRowBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeTransferRowBinding
 import app.kobuggi.hyuabot.ui.MainActivity
+import app.kobuggi.hyuabot.ui.common.applyGodoTypography
 import app.kobuggi.hyuabot.ui.bus.realtime.BusSeoulTargetStop
 import app.kobuggi.hyuabot.ui.bus.realtime.BusTravelTimeEstimator
 import app.kobuggi.hyuabot.ui.bus.realtime.LogEntry
@@ -105,6 +108,14 @@ class HomeFragment : Fragment() {
     private var locationCancellationTokenSource: CancellationTokenSource? = null
     private var locationCallback: LocationCallback? = null
     private var pendingDepartureLocation: Location? = null
+    private var locationDisclosureShown = false
+    private val locationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        if (permissions.values.any { it }) {
+            moveToNearestDeparture()
+        }
+    }
     private val refreshHandler = Handler(Looper.getMainLooper())
     private val noticeScrollHandler = Handler(Looper.getMainLooper())
     private val noticeAutoScrollRunnable = Runnable {
@@ -500,9 +511,33 @@ class HomeFragment : Fragment() {
     }
 
     private fun moveToNearestDeparture() {
-        if (lockDepartureSelection || isDepartureManuallySelected || !hasLocationPermission()) return
+        if (lockDepartureSelection || isDepartureManuallySelected) return
+        if (!hasLocationPermission()) {
+            showLocationDisclosure()
+            return
+        }
         val client = LocationServices.getFusedLocationProviderClient(requireActivity())
         requestCurrentLocation(client)
+    }
+
+    private fun showLocationDisclosure() {
+        if (locationDisclosureShown || !isAdded || view == null) return
+        locationDisclosureShown = true
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.location_permission_disclosure_title)
+            .setMessage(R.string.location_permission_disclosure_message)
+            .setPositiveButton(R.string.location_permission_disclosure_allow) { dialog, _ ->
+                dialog.dismiss()
+                locationPermissionLauncher.launch(
+                    arrayOf(
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                    )
+                )
+            }
+            .setNegativeButton(R.string.location_permission_disclosure_later, null)
+            .show()
+            .applyGodoTypography()
     }
 
     @SuppressLint("MissingPermission")

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/map/MapFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/map/MapFragment.kt
@@ -6,6 +6,7 @@ import app.kobuggi.hyuabot.util.UIUtility
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Canvas
@@ -25,6 +26,7 @@ import androidx.core.graphics.createBitmap
 import androidx.core.graphics.toColorInt
 import androidx.core.net.toUri
 import androidx.core.widget.addTextChangedListener
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -37,6 +39,7 @@ import app.kobuggi.hyuabot.service.translation.DynamicTextTranslator
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
+import app.kobuggi.hyuabot.ui.common.applyGodoTypography
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
@@ -69,6 +72,15 @@ class MapFragment @Inject constructor() : Fragment(), OnMapReadyCallback {
     private var isMapViewCreated = false
     private val buildingMarkerIconCache = mutableMapOf<String, OverlayImage>()
     private val markerTranslationRequests = mutableSetOf<String>()
+    private val locationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        if (permissions.values.any { it }) {
+            centerOnCurrentLocation()
+        } else {
+            Toast.makeText(requireContext(), R.string.map_location_permission_denied, Toast.LENGTH_SHORT).show()
+        }
+    }
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -141,16 +153,34 @@ class MapFragment @Inject constructor() : Fragment(), OnMapReadyCallback {
         return binding.root
     }
 
-    @SuppressLint("MissingPermission")
     private fun moveToCurrentLocation() {
         if (!this::naverMap.isInitialized) return
         val hasLocationPermission =
             ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
                 ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
         if (!hasLocationPermission) {
-            Toast.makeText(requireContext(), R.string.map_location_permission_required, Toast.LENGTH_SHORT).show()
+            AlertDialog.Builder(requireContext())
+                .setTitle(R.string.location_permission_disclosure_title)
+                .setMessage(R.string.location_permission_disclosure_message)
+                .setPositiveButton(R.string.location_permission_disclosure_allow) { dialog, _ ->
+                    dialog.dismiss()
+                    locationPermissionLauncher.launch(
+                        arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                        )
+                    )
+                }
+                .setNegativeButton(R.string.location_permission_disclosure_later, null)
+                .show()
+                .applyGodoTypography()
             return
         }
+        centerOnCurrentLocation()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun centerOnCurrentLocation() {
         LocationServices.getFusedLocationProviderClient(requireActivity())
             .getCurrentLocation(Priority.PRIORITY_BALANCED_POWER_ACCURACY, CancellationTokenSource().token)
             .addOnSuccessListener { location ->

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/readingRoom/ReadingRoomFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/readingRoom/ReadingRoomFragment.kt
@@ -4,6 +4,7 @@ import app.kobuggi.hyuabot.util.AnalyticsItem
 import app.kobuggi.hyuabot.util.AnalyticsManager
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.AlertDialog
 import android.app.AlarmManager
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -29,7 +30,7 @@ import app.kobuggi.hyuabot.service.preferences.UserPreferencesRepository
 import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
-import com.google.android.material.snackbar.Snackbar
+import app.kobuggi.hyuabot.ui.common.applyGodoTypography
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -148,16 +149,17 @@ class ReadingRoomFragment @Inject constructor() : Fragment() {
 
     private fun askNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(requireContext(), POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
-                // FCM SDK (and your app) can post notifications.
-            } else if (shouldShowRequestPermissionRationale(POST_NOTIFICATIONS)) {
-                Snackbar.make(binding.root, R.string.reading_room_noti_rationale, Snackbar.LENGTH_LONG)
-                    .setAction(R.string.reading_room_noti_settings) {
+            if (ContextCompat.checkSelfPermission(requireContext(), POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.notification_permission_disclosure_title)
+                    .setMessage(R.string.reading_room_notification_permission_disclosure_message)
+                    .setPositiveButton(R.string.notification_permission_disclosure_allow) { dialog, _ ->
+                        dialog.dismiss()
                         requestPermissionLauncher.launch(POST_NOTIFICATIONS)
                     }
+                    .setNegativeButton(R.string.notification_permission_disclosure_later, null)
                     .show()
-            } else {
-                requestPermissionLauncher.launch(POST_NOTIFICATIONS)
+                    .applyGodoTypography()
             }
         }
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleAlarmDialogFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/shuttle/realtime/ShuttleAlarmDialogFragment.kt
@@ -1,6 +1,7 @@
 package app.kobuggi.hyuabot.ui.shuttle.realtime
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -17,6 +18,7 @@ import androidx.core.content.res.ResourcesCompat
 import app.kobuggi.hyuabot.R
 import app.kobuggi.hyuabot.databinding.DialogShuttleAlarmBinding
 import app.kobuggi.hyuabot.service.alarm.ShuttleAlarmService
+import app.kobuggi.hyuabot.ui.common.applyGodoTypography
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import java.time.Instant
 import java.time.ZoneId
@@ -234,7 +236,18 @@ class ShuttleAlarmDialogFragment : BottomSheetDialogFragment() {
         }
 
         pendingAlarmStart = action
-        notificationPermissionLauncher.launch(POST_NOTIFICATIONS)
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.notification_permission_disclosure_title)
+            .setMessage(R.string.shuttle_notification_permission_disclosure_message)
+            .setPositiveButton(R.string.notification_permission_disclosure_allow) { dialog, _ ->
+                dialog.dismiss()
+                notificationPermissionLauncher.launch(POST_NOTIFICATIONS)
+            }
+            .setNegativeButton(R.string.notification_permission_disclosure_later) { _, _ ->
+                pendingAlarmStart = null
+            }
+            .show()
+            .applyGodoTypography()
     }
 
     private fun startBoardingAlarm(

--- a/app/src/main/res/layout/widget_cafeteria.xml
+++ b/app/src/main/res/layout/widget_cafeteria.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,7 +20,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_meal_lunch"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_name" />
 
         <TextView
@@ -53,7 +54,7 @@
             android:layout_marginEnd="-8dp"
             android:padding="8dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_cafeteria_preview.xml
+++ b/app/src/main/res/layout/widget_cafeteria_preview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_meal_lunch"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_name" />
 
         <TextView
@@ -45,7 +46,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle.xml
+++ b/app/src/main/res/layout/widget_shuttle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/widget_shuttle_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -63,7 +64,7 @@
             android:layout_marginEnd="-8dp"
             android:padding="8dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle_preview.xml
+++ b/app/src/main/res/layout/widget_shuttle_preview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -57,7 +58,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle_small.xml
+++ b/app/src/main/res/layout/widget_shuttle_small.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/widget_shuttle_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -51,7 +52,7 @@
             android:layout_marginEnd="-8dp"
             android:padding="8dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle_small_preview.xml
+++ b/app/src/main/res/layout/widget_shuttle_small_preview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -47,7 +48,7 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle_transfer.xml
+++ b/app/src/main/res/layout/widget_shuttle_transfer.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/widget_transfer_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -17,7 +18,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -50,7 +51,7 @@
             android:layout_marginEnd="-8dp"
             android:padding="8dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_shuttle_transfer_preview.xml
+++ b/app/src/main/res/layout/widget_shuttle_transfer_preview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,7 +19,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_shuttle"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/shuttle_bus" />
 
         <TextView
@@ -45,7 +46,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:src="@drawable/ic_widget_refresh"
-            android:tint="@color/widget_accent"
+            app:tint="@color/widget_accent"
             android:contentDescription="@string/widget_cafeteria_refresh" />
     </LinearLayout>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -235,6 +235,11 @@
     <string name="shuttle_period_vacation_session">Seasonal Semester</string>
     <string name="confirm">Apply</string>
     <string name="location_permission_nearest_stop">Location permission is required to find the nearest stop.</string>
+    <string name="location_permission_disclosure_title">Location access notice</string>
+    <string name="location_permission_disclosure_message">HYUabot uses your location to find the nearest shuttle stop and show your current position on the map. Your location is processed only on your device and is not sent to or stored on a server. You can choose a stop manually without location access.</string>
+    <string name="location_permission_disclosure_allow">Agree and allow location</string>
+    <string name="location_permission_disclosure_later">Later</string>
+    <string name="map_location_permission_denied">Location access was not allowed.</string>
     <!-- 셔틀버스 등하교 팝업 -->
     <string name="shuttle_realtime_toast">During peak school commute hours, some shuttle may not depart from Shuttlecock.</string>
     <!-- 셔틀버스 소요 시간 -->
@@ -511,6 +516,11 @@
     <string name="reading_room_noti_allowed">Notifications enabled.</string>
     <string name="reading_room_noti_denied">Notifications disabled.</string>
     <string name="reading_room_noti_rationale">Permission is required for seat availability notifications. Please enable it in settings.</string>
+    <string name="notification_permission_disclosure_title">Notification permission notice</string>
+    <string name="reading_room_notification_permission_disclosure_message">Notification permission is required to send reading room seat availability and usage-time notices. You can continue using other features without allowing notifications.</string>
+    <string name="shuttle_notification_permission_disclosure_message">Notification permission is required to send shuttle bus alarms. You can continue using other features without allowing notifications.</string>
+    <string name="notification_permission_disclosure_allow">Agree and allow notifications</string>
+    <string name="notification_permission_disclosure_later">Later</string>
     <string name="reading_room_noti_settings">Settings</string>
     <string name="reading_room_update_time">Updated: %1$s</string>
     <string name="reading_room_noti_on">Reading room notifications set.</string>
@@ -608,7 +618,7 @@
     <string name="shuttle_service_notice_period_unknown">a new period</string>
     <string name="info_button_shuttle">Information button for shuttle</string>
     <string name="analytics_settings">App Analytics</string>
-    <string name="analytics_settings_description">We collect anonymous usage data and your Advertising ID (AD ID) to improve the app. You can disable this at any time.</string>
+    <string name="analytics_settings_description">We collect anonymous usage data, your Advertising ID (AD ID), and crash and diagnostic information to improve the app and detect crashes. You can disable this at any time.</string>
     <string name="coachmark_skip">Skip</string>
     <string name="coachmark_next">Next</string>
     <string name="coachmark_done">Done</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -236,7 +236,7 @@
     <string name="confirm">Apply</string>
     <string name="location_permission_nearest_stop">Location permission is required to find the nearest stop.</string>
     <string name="location_permission_disclosure_title">Location access notice</string>
-    <string name="location_permission_disclosure_message">HYUabot uses your location to find the nearest shuttle stop and show your current position on the map. Your location is processed only on your device and is not sent to or stored on a server. You can choose a stop manually without location access.</string>
+    <string name="location_permission_disclosure_message">HYUabot uses your location to find nearby shuttle and city bus stops, show nearby bus information, and show your current position on the map. Your location is processed only on your device and is not sent to or stored on a server. You can choose a stop manually without location access.</string>
     <string name="location_permission_disclosure_allow">Agree and allow location</string>
     <string name="location_permission_disclosure_later">Later</string>
     <string name="map_location_permission_denied">Location access was not allowed.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -729,7 +729,7 @@
     <string name="shuttle_alarm_alighting">Alighting Alert · Share Trip</string>
     <string name="shuttle_alarm_start">Start Alert</string>
     <string name="shuttle_alarm_cancel">Cancel Alert</string>
-    <string name="shuttle_alarm_boarding_title">Shuttle Bus Boarding Alert</string>
+    <string name="shuttle_alarm_boarding_title">Shuttle Bus Boarding Alert: %1$s</string>
     <string name="shuttle_alarm_boarding_live_departure">Departs at %1$s</string>
     <string name="shuttle_alarm_boarding_live_direction_distance">%1$s %2$s</string>
     <string name="shuttle_alarm_alighting_live_arrival">Arrives at %1$s</string>
@@ -738,7 +738,7 @@
     <string name="shuttle_alarm_checkpoint_waiting">Waiting at %1$s</string>
     <string name="shuttle_alarm_checkpoint_departed">Departed %1$s</string>
     <string name="shuttle_alarm_checkpoint_approaching">Approaching %1$s</string>
-    <string name="shuttle_alarm_alighting_title">Shuttle Bus Alighting Alert</string>
+    <string name="shuttle_alarm_alighting_title">Shuttle Bus Alighting Alert: %1$s</string>
     <string name="shuttle_alarm_alighting_content">About %1$s to the stop</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">Tracking</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -223,6 +223,11 @@
     <string name="shuttle_period_vacation_session">季節学期</string>
     <string name="confirm">確認</string>
     <string name="location_permission_nearest_stop">最寄りのバス停を探すには位置情報の権限が必要です。</string>
+    <string name="location_permission_disclosure_title">位置情報の使用について</string>
+    <string name="location_permission_disclosure_message">HYUabotは、最寄りのシャトルバス停留所を探し、地図に現在地を表示するために位置情報を使用します。位置情報は端末内でのみ処理され、サーバーへ送信・保存されません。位置情報を許可しなくても停留所を手動で選択できます。</string>
+    <string name="location_permission_disclosure_allow">同意して位置情報を許可</string>
+    <string name="location_permission_disclosure_later">後で</string>
+    <string name="map_location_permission_denied">位置情報が許可されませんでした。</string>
     <string name="shuttle_realtime_toast">通学ラッシュ時は、シャトルコックから一部シャトルが運行しない場合があります。</string>
     <string name="shuttle_realtime_duration_format">%1$d分</string>
     <string name="bus_tab_city">市内バス</string>
@@ -488,6 +493,11 @@
     <string name="reading_room_noti_allowed">通知権限が許可されました。</string>
     <string name="reading_room_noti_denied">通知権限が拒否されました。</string>
     <string name="reading_room_noti_rationale">残席通知のためには権限が必要です。設定から権限を許可してください。</string>
+    <string name="notification_permission_disclosure_title">通知権限の使用について</string>
+    <string name="reading_room_notification_permission_disclosure_message">自習室の空席状況と利用時間のお知らせを送るため、通知権限が必要です。通知を許可しなくても他の機能は利用できます。</string>
+    <string name="shuttle_notification_permission_disclosure_message">シャトルバスのアラームを送るため、通知権限が必要です。通知を許可しなくても他の機能は利用できます。</string>
+    <string name="notification_permission_disclosure_allow">同意して通知を許可</string>
+    <string name="notification_permission_disclosure_later">後で</string>
     <string name="reading_room_noti_settings">設定</string>
     <string name="reading_room_update_time">更新時間: %1$s</string>
     <string name="reading_room_noti_on">閲覧室アラームを設定しました。</string>
@@ -587,7 +597,7 @@
     <string name="shuttle_service_notice_period_unknown">新しい期間</string>
     <string name="info_button_shuttle">シャトル情報ボタン</string>
     <string name="analytics_settings">アプリ分析データの収集</string>
-    <string name="analytics_settings_description">アプリ改善のため、匿名の使用データおよび広告識別子（AD ID）を収集します。いつでも無効にできます。</string>
+    <string name="analytics_settings_description">アプリの改善とクラッシュ検知のため、匿名の利用データ、広告識別子（AD ID）、クラッシュ・診断情報を収集します。いつでも無効にできます。</string>
     <string name="coachmark_skip">スキップ</string>
     <string name="coachmark_next">次へ</string>
     <string name="coachmark_done">完了</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -224,7 +224,7 @@
     <string name="confirm">確認</string>
     <string name="location_permission_nearest_stop">最寄りのバス停を探すには位置情報の権限が必要です。</string>
     <string name="location_permission_disclosure_title">位置情報の使用について</string>
-    <string name="location_permission_disclosure_message">HYUabotは、最寄りのシャトルバス停留所を探し、地図に現在地を表示するために位置情報を使用します。位置情報は端末内でのみ処理され、サーバーへ送信・保存されません。位置情報を許可しなくても停留所を手動で選択できます。</string>
+    <string name="location_permission_disclosure_message">HYUabotは、近くのシャトルバス・路線バスの停留所を探し、周辺の路線バス情報と地図上の現在地を表示するために位置情報を使用します。位置情報は端末内でのみ処理され、サーバーへ送信・保存されません。位置情報を許可しなくても停留所を手動で選択できます。</string>
     <string name="location_permission_disclosure_allow">同意して位置情報を許可</string>
     <string name="location_permission_disclosure_later">後で</string>
     <string name="map_location_permission_denied">位置情報が許可されませんでした。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -706,7 +706,7 @@
     <string name="shuttle_alarm_alighting">降車アラート · 行程を共有</string>
     <string name="shuttle_alarm_start">アラート開始</string>
     <string name="shuttle_alarm_cancel">アラートキャンセル</string>
-    <string name="shuttle_alarm_boarding_title">シャトルバス乗車アラート</string>
+    <string name="shuttle_alarm_boarding_title">シャトルバス乗車アラート：%1$s</string>
     <string name="shuttle_alarm_boarding_live_departure">%1$s 出発</string>
     <string name="shuttle_alarm_boarding_live_direction_distance">%1$s方向 %2$s</string>
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 到着</string>
@@ -715,7 +715,7 @@
     <string name="shuttle_alarm_checkpoint_waiting">%1$s待機</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s出発</string>
     <string name="shuttle_alarm_checkpoint_approaching">%1$s接近</string>
-    <string name="shuttle_alarm_alighting_title">シャトルバス降車アラート</string>
+    <string name="shuttle_alarm_alighting_title">シャトルバス降車アラート：%1$s</string>
     <string name="shuttle_alarm_alighting_content">停留所まで約%1$s</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">追跡中</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -706,7 +706,7 @@
     <string name="shuttle_alarm_alighting">下车提醒 · 分享行程</string>
     <string name="shuttle_alarm_start">开始提醒</string>
     <string name="shuttle_alarm_cancel">取消提醒</string>
-    <string name="shuttle_alarm_boarding_title">校车上车提醒</string>
+    <string name="shuttle_alarm_boarding_title">校车上车提醒：%1$s</string>
     <string name="shuttle_alarm_boarding_live_departure">%1$s 出发</string>
     <string name="shuttle_alarm_boarding_live_direction_distance">%1$s方向 %2$s</string>
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 到达</string>
@@ -715,7 +715,7 @@
     <string name="shuttle_alarm_checkpoint_waiting">%1$s等待</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s出发</string>
     <string name="shuttle_alarm_checkpoint_approaching">接近%1$s</string>
-    <string name="shuttle_alarm_alighting_title">校车下车提醒</string>
+    <string name="shuttle_alarm_alighting_title">校车下车提醒：%1$s</string>
     <string name="shuttle_alarm_alighting_content">距站点约%1$s</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">追踪中</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -224,7 +224,7 @@
     <string name="confirm">确认</string>
     <string name="location_permission_nearest_stop">需要位置权限才能查找最近的站点。</string>
     <string name="location_permission_disclosure_title">位置使用说明</string>
-    <string name="location_permission_disclosure_message">HYUabot使用您的位置信息查找最近的校车站点，并在地图上显示当前位置。位置信息仅在设备本地处理，不会传输或存储至服务器。即使不授予位置权限，也可以手动选择站点。</string>
+    <string name="location_permission_disclosure_message">HYUabot使用您的位置信息查找附近的校车和公交车站，显示附近的公交信息，并在地图上显示当前位置。位置信息仅在设备本地处理，不会传输或存储至服务器。即使不授予位置权限，也可以手动选择站点。</string>
     <string name="location_permission_disclosure_allow">同意并允许位置权限</string>
     <string name="location_permission_disclosure_later">稍后</string>
     <string name="map_location_permission_denied">位置权限未被允许。</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -223,6 +223,11 @@
     <string name="shuttle_period_vacation_session">小学期</string>
     <string name="confirm">确认</string>
     <string name="location_permission_nearest_stop">需要位置权限才能查找最近的站点。</string>
+    <string name="location_permission_disclosure_title">位置使用说明</string>
+    <string name="location_permission_disclosure_message">HYUabot使用您的位置信息查找最近的校车站点，并在地图上显示当前位置。位置信息仅在设备本地处理，不会传输或存储至服务器。即使不授予位置权限，也可以手动选择站点。</string>
+    <string name="location_permission_disclosure_allow">同意并允许位置权限</string>
+    <string name="location_permission_disclosure_later">稍后</string>
+    <string name="map_location_permission_denied">位置权限未被允许。</string>
     <string name="shuttle_realtime_toast">上下学高峰时段，部分校车可能不从羽毛球场出发。</string>
     <string name="shuttle_realtime_duration_format">%1$d分钟</string>
     <string name="bus_tab_city">市内公交</string>
@@ -488,6 +493,11 @@
     <string name="reading_room_noti_allowed">通知权限已允许。</string>
     <string name="reading_room_noti_denied">通知权限已拒绝。</string>
     <string name="reading_room_noti_rationale">需要权限才能发送剩余座位通知。请在设置中允许权限。</string>
+    <string name="notification_permission_disclosure_title">通知权限说明</string>
+    <string name="reading_room_notification_permission_disclosure_message">需要通知权限才能发送自习室剩余座位和使用时间提醒。不允许通知也可以继续使用其他功能。</string>
+    <string name="shuttle_notification_permission_disclosure_message">需要通知权限才能发送校车提醒。不允许通知也可以继续使用其他功能。</string>
+    <string name="notification_permission_disclosure_allow">同意并允许通知</string>
+    <string name="notification_permission_disclosure_later">稍后</string>
     <string name="reading_room_noti_settings">设置</string>
     <string name="reading_room_update_time">更新时间: %1$s</string>
     <string name="reading_room_noti_on">已设置阅览室提醒。</string>
@@ -587,7 +597,7 @@
     <string name="shuttle_service_notice_period_unknown">新期间</string>
     <string name="info_button_shuttle">校车信息按钮</string>
     <string name="analytics_settings">应用分析数据收集</string>
-    <string name="analytics_settings_description">为改善应用，将收集匿名使用数据及广告标识符（AD ID）。可随时关闭。</string>
+    <string name="analytics_settings_description">为改善应用并检测崩溃，将收集匿名使用数据、广告标识符（AD ID）以及崩溃和诊断信息。可随时关闭。</string>
     <string name="coachmark_skip">跳过</string>
     <string name="coachmark_next">下一步</string>
     <string name="coachmark_done">完成</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@
     <string name="shuttle_alarm_alighting">하차 알림 · 여정 공유</string>
     <string name="shuttle_alarm_start">알림 시작</string>
     <string name="shuttle_alarm_cancel">알림 취소</string>
-    <string name="shuttle_alarm_boarding_title">셔틀버스 승차 알림</string>
+    <string name="shuttle_alarm_boarding_title">셔틀버스 승차 알림: %1$s</string>
     <string name="shuttle_alarm_boarding_live_departure">%1$s 출발</string>
     <string name="shuttle_alarm_boarding_live_direction_distance">%1$s방향 %2$s</string>
     <string name="shuttle_alarm_alighting_live_arrival">%1$s 도착</string>
@@ -195,7 +195,7 @@
     <string name="shuttle_alarm_checkpoint_waiting">%1$s 대기</string>
     <string name="shuttle_alarm_checkpoint_departed">%1$s 출발</string>
     <string name="shuttle_alarm_checkpoint_approaching">%1$s 접근</string>
-    <string name="shuttle_alarm_alighting_title">셔틀버스 하차 알림</string>
+    <string name="shuttle_alarm_alighting_title">셔틀버스 하차 알림: %1$s</string>
     <string name="shuttle_alarm_alighting_content">정류장까지 약 %1$s</string>
     <string name="shuttle_alarm_distance_short">%1$s</string>
     <string name="shuttle_alarm_tracking_short">추적 중</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,11 @@
     <string name="shuttle_period_vacation_session">계절학기</string>
     <string name="confirm">확인</string>
     <string name="location_permission_nearest_stop">가까운 정류장을 찾기 위해 위치 권한이 필요합니다.</string>
+    <string name="location_permission_disclosure_title">위치 정보 사용 안내</string>
+    <string name="location_permission_disclosure_message">휴아봇은 현재 위치를 사용해 가까운 셔틀버스 정류장을 찾고 지도에서 현재 위치를 표시합니다. 위치 정보는 기기에서만 처리되며 서버에 전송하거나 저장하지 않습니다. 위치 권한 없이도 정류장을 직접 선택할 수 있습니다.</string>
+    <string name="location_permission_disclosure_allow">동의하고 위치 허용</string>
+    <string name="location_permission_disclosure_later">나중에</string>
+    <string name="map_location_permission_denied">위치 권한이 허용되지 않았습니다.</string>
     <!-- 셔틀버스 등하교 팝업 -->
     <string name="shuttle_realtime_toast">등하교 집중 시간대에는 셔틀콕에서 일부 셔틀버스가 운행하지 않을 수 있습니다.</string>
     <!-- 셔틀버스 소요 시간 -->
@@ -559,6 +564,11 @@
     <string name="reading_room_noti_allowed">알림 권한이 허용되었습니다.</string>
     <string name="reading_room_noti_denied">알림 권한이 거부되었습니다.</string>
     <string name="reading_room_noti_rationale">잔여 좌석 알림을 위해서는 권한이 필요합니다. 설정에서 권한을 허용해주세요.</string>
+    <string name="notification_permission_disclosure_title">알림 권한 안내</string>
+    <string name="reading_room_notification_permission_disclosure_message">열람실 잔여 좌석과 이용 시간 안내를 보내기 위해 알림 권한이 필요합니다. 알림을 허용하지 않아도 다른 기능은 계속 사용할 수 있습니다.</string>
+    <string name="shuttle_notification_permission_disclosure_message">셔틀버스 알람을 보내기 위해 알림 권한이 필요합니다. 알림을 허용하지 않아도 다른 기능은 계속 사용할 수 있습니다.</string>
+    <string name="notification_permission_disclosure_allow">동의하고 알림 허용</string>
+    <string name="notification_permission_disclosure_later">나중에</string>
     <string name="reading_room_noti_settings">설정</string>
     <string name="reading_room_update_time">업데이트 시간: %1$s</string>
     <string name="reading_room_noti_on">열람실 알람을 설정했습니다.</string>
@@ -664,7 +674,7 @@
     <string name="shuttle_service_notice_period_unknown">새 기간</string>
     <string name="info_button_shuttle">셔틀 정보 버튼</string>
     <string name="analytics_settings">앱 분석 데이터 수집</string>
-    <string name="analytics_settings_description">앱 개선을 위해 익명의 사용 데이터 및 광고 식별자(AD ID)를 수집합니다. 언제든지 해제할 수 있습니다.</string>
+    <string name="analytics_settings_description">앱 개선과 충돌 감지를 위해 익명의 사용 데이터, 광고 식별자(AD ID), 충돌·진단 정보를 수집합니다. 언제든지 해제할 수 있습니다.</string>
     <string name="coachmark_skip">건너뛰기</string>
     <string name="coachmark_next">다음</string>
     <string name="coachmark_done">완료</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,7 +276,7 @@
     <string name="confirm">확인</string>
     <string name="location_permission_nearest_stop">가까운 정류장을 찾기 위해 위치 권한이 필요합니다.</string>
     <string name="location_permission_disclosure_title">위치 정보 사용 안내</string>
-    <string name="location_permission_disclosure_message">휴아봇은 현재 위치를 사용해 가까운 셔틀버스 정류장을 찾고 지도에서 현재 위치를 표시합니다. 위치 정보는 기기에서만 처리되며 서버에 전송하거나 저장하지 않습니다. 위치 권한 없이도 정류장을 직접 선택할 수 있습니다.</string>
+    <string name="location_permission_disclosure_message">휴아봇은 현재 위치를 사용해 가까운 셔틀버스·노선버스 정류장을 찾고, 주변 노선버스 정보를 보여주며 지도에서 현재 위치를 표시합니다. 위치 정보는 기기에서만 처리되며 서버에 전송하거나 저장하지 않습니다. 위치 권한 없이도 정류장을 직접 선택할 수 있습니다.</string>
     <string name="location_permission_disclosure_allow">동의하고 위치 허용</string>
     <string name="location_permission_disclosure_later">나중에</string>
     <string name="map_location_permission_denied">위치 권한이 허용되지 않았습니다.</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,5 @@ android.r8.strictFullModeForKeepRules=false
 android.builtInKotlin=true
 android.newDsl=true
 # Shared version for app and watch modules (kept in sync manually on release)
-APP_VERSION_NAME=26.08.07
-APP_VERSION_CODE=2026080700
+APP_VERSION_NAME=26.08.16
+APP_VERSION_CODE=2026081600


### PR DESCRIPTION
## Summary

- Add a prominent home-screen disclosure before requesting location permission.
- Explain nearby shuttle and city bus stop discovery, nearby bus information, and map location use.
- Keep the disclosure localized across Korean, English, Japanese, and Chinese.

## Test plan

- [x] ./gradlew :app:lintDevDebug :app:assembleDevDebug :app:testDevDebugUnitTest
- [x] Verified the home disclosure appears before the Android location permission prompt on an emulator.
- [x] Verified localized strings exist for all supported locales.