### PR TITLE
fix: complete location disclosure compliance

### DIFF
--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -18,6 +18,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.CheckBox
 import androidx.activity.SystemBarStyle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.graphics.drawable.DrawerArrowDrawable
@@ -76,6 +77,17 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     private val homeExperiencePreferences by lazy {
         getSharedPreferences(HOME_EXPERIENCE_PREFERENCES, MODE_PRIVATE)
     }
+    private var pendingBackgroundLocationRequest = false
+    private var foregroundLocationDisclosureShown = false
+    private val foregroundLocationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        if (permissions.values.any { it }) {
+            maybeRequestBackgroundLocation()
+        } else {
+            pendingBackgroundLocationRequest = false
+        }
+    }
 
     @Inject
     lateinit var inAppReviewManager: InAppReviewManager
@@ -113,6 +125,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         openBirthDayDialog()
         requestInAppReview()
         syncShuttleServiceNotices()
+        pendingBackgroundLocationRequest = intent.getBooleanExtra(EXTRA_REQUEST_BACKGROUND_LOCATION, false)
         val handledDeepLink = handleDebugDeepLink(intent) || navController.handleDeepLink(intent)
         if (
             savedInstanceState == null &&
@@ -276,8 +289,15 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     override fun onResume() {
         super.onResume()
         updatePrimaryNavigationItem(navController.currentDestination?.id)
+        handlePendingBackgroundLocationRequest()
+    }
+
+    private fun handlePendingBackgroundLocationRequest() {
+        if (!pendingBackgroundLocationRequest) return
         if (hasLocationPermission()) {
             maybeRequestBackgroundLocation()
+        } else {
+            showForegroundLocationDisclosure()
         }
     }
 
@@ -400,6 +420,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             appWidgetManager.getAppWidgetIds(ComponentName(this, provider)).isNotEmpty()
         }
         if (!hasShuttleWidget) {
+            pendingBackgroundLocationRequest = false
             return
         }
         AlertDialog.Builder(this)
@@ -407,6 +428,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             .setMessage(getString(R.string.widget_shuttle_background_location_message))
             .setPositiveButton(getString(R.string.widget_shuttle_background_location_allow)) { dialog, _ ->
                 dialog.dismiss()
+                pendingBackgroundLocationRequest = false
                 ActivityCompat.requestPermissions(
                     this,
                     arrayOf(ACCESS_BACKGROUND_LOCATION),
@@ -415,26 +437,40 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             }
             .setNegativeButton(getString(R.string.widget_shuttle_background_location_later)) { dialog, _ ->
                 dialog.dismiss()
+                pendingBackgroundLocationRequest = false
             }
             .show()
             .applyGodoTypography()
     }
 
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == LOCATION_PERMISSION_REQUEST_CODE && hasLocationPermission()) {
-            maybeRequestBackgroundLocation()
-        }
+    private fun showForegroundLocationDisclosure() {
+        if (foregroundLocationDisclosureShown || isFinishing || isDestroyed) return
+        foregroundLocationDisclosureShown = true
+        AlertDialog.Builder(this)
+            .setTitle(R.string.location_permission_disclosure_title)
+            .setMessage(R.string.location_permission_disclosure_message)
+            .setPositiveButton(R.string.location_permission_disclosure_allow) { dialog, _ ->
+                dialog.dismiss()
+                foregroundLocationPermissionLauncher.launch(
+                    arrayOf(ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION)
+                )
+            }
+            .setNegativeButton(R.string.location_permission_disclosure_later) { dialog, _ ->
+                dialog.dismiss()
+                pendingBackgroundLocationRequest = false
+            }
+            .show()
+            .applyGodoTypography()
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_REQUEST_BACKGROUND_LOCATION, false)) {
+            pendingBackgroundLocationRequest = true
+        }
         handleDebugDeepLink(intent) || navController.handleDeepLink(intent)
+        binding.root.post(::handlePendingBackgroundLocationRequest)
     }
 
     private fun handleDebugDeepLink(intent: Intent): Boolean {
@@ -608,8 +644,8 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     companion object {
         const val HOME_EXPERIENCE_PREFERENCES = "home_experience"
         const val HOME_EXPERIENCE_ENABLED = "enabled"
+        const val EXTRA_REQUEST_BACKGROUND_LOCATION = "request_background_location"
         private const val STATUS_BAR_BACKGROUND_TAG = "status_bar_background"
-        private const val LOCATION_PERMISSION_REQUEST_CODE = 1
         private const val BACKGROUND_LOCATION_PERMISSION_REQUEST_CODE = 2
     }
 }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -77,12 +77,16 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
     private val homeExperiencePreferences by lazy {
         getSharedPreferences(HOME_EXPERIENCE_PREFERENCES, MODE_PRIVATE)
     }
+    private val locationDisclosurePreferences by lazy {
+        getSharedPreferences(LOCATION_DISCLOSURE_PREFERENCES, MODE_PRIVATE)
+    }
     private var pendingBackgroundLocationRequest = false
     private var foregroundLocationDisclosureShown = false
     private val foregroundLocationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         if (permissions.values.any { it }) {
+            resetLocationDisclosureDeclineCount(FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT)
             maybeRequestBackgroundLocation()
         } else {
             pendingBackgroundLocationRequest = false
@@ -413,6 +417,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
 
     private fun maybeRequestBackgroundLocation() {
         if (ActivityCompat.checkSelfPermission(this, ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            resetLocationDisclosureDeclineCount(BACKGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT)
             return
         }
         val appWidgetManager = AppWidgetManager.getInstance(this)
@@ -420,6 +425,14 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             appWidgetManager.getAppWidgetIds(ComponentName(this, provider)).isNotEmpty()
         }
         if (!hasShuttleWidget) {
+            pendingBackgroundLocationRequest = false
+            return
+        }
+        if (locationDisclosurePreferences.getInt(
+                BACKGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT,
+                0,
+            ) >= MAX_LOCATION_DISCLOSURE_DECLINES
+        ) {
             pendingBackgroundLocationRequest = false
             return
         }
@@ -438,13 +451,25 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             .setNegativeButton(getString(R.string.widget_shuttle_background_location_later)) { dialog, _ ->
                 dialog.dismiss()
                 pendingBackgroundLocationRequest = false
+                recordLocationDisclosureDecline(BACKGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT)
             }
             .show()
             .applyGodoTypography()
     }
 
     private fun showForegroundLocationDisclosure() {
-        if (foregroundLocationDisclosureShown || isFinishing || isDestroyed) return
+        if (
+            foregroundLocationDisclosureShown ||
+            isFinishing ||
+            isDestroyed ||
+            locationDisclosurePreferences.getInt(
+                FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT,
+                0,
+            ) >= MAX_LOCATION_DISCLOSURE_DECLINES
+        ) {
+            pendingBackgroundLocationRequest = false
+            return
+        }
         foregroundLocationDisclosureShown = true
         AlertDialog.Builder(this)
             .setTitle(R.string.location_permission_disclosure_title)
@@ -458,9 +483,19 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             .setNegativeButton(R.string.location_permission_disclosure_later) { dialog, _ ->
                 dialog.dismiss()
                 pendingBackgroundLocationRequest = false
+                recordLocationDisclosureDecline(FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT)
             }
             .show()
             .applyGodoTypography()
+    }
+
+    private fun recordLocationDisclosureDecline(key: String) {
+        val count = locationDisclosurePreferences.getInt(key, 0)
+        locationDisclosurePreferences.edit().putInt(key, count + 1).apply()
+    }
+
+    private fun resetLocationDisclosureDeclineCount(key: String) {
+        locationDisclosurePreferences.edit().putInt(key, 0).apply()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -645,6 +680,10 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
         const val HOME_EXPERIENCE_PREFERENCES = "home_experience"
         const val HOME_EXPERIENCE_ENABLED = "enabled"
         const val EXTRA_REQUEST_BACKGROUND_LOCATION = "request_background_location"
+        const val LOCATION_DISCLOSURE_PREFERENCES = "location_disclosure"
+        const val FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT = "foreground_decline_count"
+        const val BACKGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT = "background_decline_count"
+        const val MAX_LOCATION_DISCLOSURE_DECLINES = 3
         private const val STATUS_BAR_BACKGROUND_TAG = "status_bar_background"
         private const val BACKGROUND_LOCATION_PERMISSION_REQUEST_CODE = 2
     }

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/MainActivity.kt
@@ -46,6 +46,7 @@ import app.kobuggi.hyuabot.util.AnalyticsScreen
 import app.kobuggi.hyuabot.util.AnalyticsScreenDispatcher
 import app.kobuggi.hyuabot.util.InAppReviewManager
 import app.kobuggi.hyuabot.ui.common.applyGodoTypography
+import app.kobuggi.hyuabot.ui.common.applyPermissionDialogButtonColors
 import app.kobuggi.hyuabot.ui.bus.realtime.BusQuickSettingsDialog
 import app.kobuggi.hyuabot.ui.bus.realtime.BusSeoulTargetStop
 import app.kobuggi.hyuabot.ui.home.HomeQuickSettingsDialog
@@ -455,6 +456,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             }
             .show()
             .applyGodoTypography()
+            .applyPermissionDialogButtonColors()
     }
 
     private fun showForegroundLocationDisclosure() {
@@ -487,6 +489,7 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemReselectedList
             }
             .show()
             .applyGodoTypography()
+            .applyPermissionDialogButtonColors()
     }
 
     private fun recordLocationDisclosureDecline(key: String) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/common/DialogTypography.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/common/DialogTypography.kt
@@ -5,12 +5,21 @@ import android.graphics.Typeface
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import app.kobuggi.hyuabot.R
 
-fun AlertDialog.applyGodoTypography() {
-    val godo = ResourcesCompat.getFont(context, R.font.godo) ?: return
+fun AlertDialog.applyGodoTypography(): AlertDialog {
+    val godo = ResourcesCompat.getFont(context, R.font.godo) ?: return this
     window?.decorView?.applyGodoTypeface(godo)
+    return this
+}
+
+fun AlertDialog.applyPermissionDialogButtonColors(): AlertDialog {
+    val buttonColor = ContextCompat.getColor(context, R.color.location_permission_dialog_button)
+    getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(buttonColor)
+    getButton(AlertDialog.BUTTON_NEGATIVE)?.setTextColor(buttonColor)
+    return this
 }
 
 private fun View.applyGodoTypeface(typeface: Typeface) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -54,6 +54,7 @@ import app.kobuggi.hyuabot.databinding.ItemHomeRowBinding
 import app.kobuggi.hyuabot.databinding.ItemHomeTransferRowBinding
 import app.kobuggi.hyuabot.ui.MainActivity
 import app.kobuggi.hyuabot.ui.common.applyGodoTypography
+import app.kobuggi.hyuabot.ui.common.applyPermissionDialogButtonColors
 import app.kobuggi.hyuabot.ui.bus.realtime.BusSeoulTargetStop
 import app.kobuggi.hyuabot.ui.bus.realtime.BusTravelTimeEstimator
 import app.kobuggi.hyuabot.ui.bus.realtime.LogEntry
@@ -557,6 +558,7 @@ class HomeFragment : Fragment() {
             }
             .show()
             .applyGodoTypography()
+            .applyPermissionDialogButtonColors()
     }
 
     private fun locationDisclosurePreferences() = requireContext().getSharedPreferences(

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/home/HomeFragment.kt
@@ -3,6 +3,7 @@ package app.kobuggi.hyuabot.ui.home
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -113,6 +114,9 @@ class HomeFragment : Fragment() {
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
         if (permissions.values.any { it }) {
+            locationDisclosurePreferences().edit()
+                .putInt(MainActivity.FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT, 0)
+                .apply()
             moveToNearestDeparture()
         }
     }
@@ -521,7 +525,15 @@ class HomeFragment : Fragment() {
     }
 
     private fun showLocationDisclosure() {
-        if (locationDisclosureShown || !isAdded || view == null) return
+        if (
+            locationDisclosureShown ||
+            !isAdded ||
+            view == null ||
+            locationDisclosurePreferences().getInt(
+                MainActivity.FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT,
+                0,
+            ) >= MainActivity.MAX_LOCATION_DISCLOSURE_DECLINES
+        ) return
         locationDisclosureShown = true
         AlertDialog.Builder(requireContext())
             .setTitle(R.string.location_permission_disclosure_title)
@@ -535,10 +547,22 @@ class HomeFragment : Fragment() {
                     )
                 )
             }
-            .setNegativeButton(R.string.location_permission_disclosure_later, null)
+            .setNegativeButton(R.string.location_permission_disclosure_later) { dialog, _ ->
+                dialog.dismiss()
+                val preferences = locationDisclosurePreferences()
+                val count = preferences.getInt(MainActivity.FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT, 0)
+                preferences.edit()
+                    .putInt(MainActivity.FOREGROUND_LOCATION_DISCLOSURE_DECLINE_COUNT, count + 1)
+                    .apply()
+            }
             .show()
             .applyGodoTypography()
     }
+
+    private fun locationDisclosurePreferences() = requireContext().getSharedPreferences(
+        MainActivity.LOCATION_DISCLOSURE_PREFERENCES,
+        Context.MODE_PRIVATE,
+    )
 
     @SuppressLint("MissingPermission")
     private fun selectLastKnownLocation(client: FusedLocationProviderClient) {

--- a/app/src/main/java/app/kobuggi/hyuabot/ui/map/MapFragment.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/ui/map/MapFragment.kt
@@ -40,6 +40,7 @@ import app.kobuggi.hyuabot.ui.common.coachmark.Coachmarks
 import app.kobuggi.hyuabot.ui.common.coachmark.CoachmarkStep
 import app.kobuggi.hyuabot.ui.common.coachmark.showCoachmarkOnce
 import app.kobuggi.hyuabot.ui.common.applyGodoTypography
+import app.kobuggi.hyuabot.ui.common.applyPermissionDialogButtonColors
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
@@ -174,6 +175,7 @@ class MapFragment @Inject constructor() : Fragment(), OnMapReadyCallback {
                 .setNegativeButton(R.string.location_permission_disclosure_later, null)
                 .show()
                 .applyGodoTypography()
+                .applyPermissionDialogButtonColors()
             return
         }
         centerOnCurrentLocation()

--- a/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleTransferWidgetProvider.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleTransferWidgetProvider.kt
@@ -177,6 +177,7 @@ class ShuttleTransferWidgetProvider : AppWidgetProvider() {
             MainActivity::class.java
         ).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(MainActivity.EXTRA_REQUEST_BACKGROUND_LOCATION, true)
         }
         views.setOnClickPendingIntent(
             R.id.widget_transfer_root,

--- a/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleWidgetProvider.kt
+++ b/app/src/main/java/app/kobuggi/hyuabot/widget/ShuttleWidgetProvider.kt
@@ -186,6 +186,7 @@ abstract class ShuttleWidgetProvider : AppWidgetProvider() {
             MainActivity::class.java
         ).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(MainActivity.EXTRA_REQUEST_BACKGROUND_LOCATION, true)
         }
     }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -236,7 +236,7 @@
     <string name="confirm">Apply</string>
     <string name="location_permission_nearest_stop">Location permission is required to find the nearest stop.</string>
     <string name="location_permission_disclosure_title">Location access notice</string>
-    <string name="location_permission_disclosure_message">HYUabot uses your location to find nearby shuttle and city bus stops, show nearby bus information, and show your current position on the map. Your location is processed only on your device and is not sent to or stored on a server. You can choose a stop manually without location access.</string>
+    <string name="location_permission_disclosure_message">While you use the app, HYUabot uses your location to find nearby shuttle and city bus stops, show nearby bus information, and show your current position on the map. Your location is processed only on your device to provide these features and is not sent to or stored on a server. You can choose a stop manually or use the map without location access.</string>
     <string name="location_permission_disclosure_allow">Agree and allow location</string>
     <string name="location_permission_disclosure_later">Later</string>
     <string name="map_location_permission_denied">Location access was not allowed.</string>
@@ -450,7 +450,7 @@
     <string name="widget_shuttle_no_location">Location Unavailable</string>
     <string name="widget_shuttle_permission_required">Location Access Required</string>
     <string name="widget_shuttle_background_location_title">Background location access</string>
-    <string name="widget_shuttle_background_location_message">The shuttle widget uses your location in the background, even when the app is closed, to show the nearest stop. Please set location permission to \'Allow all the time\' on the next screen.</string>
+    <string name="widget_shuttle_background_location_message">HYUabot collects location data in the background, even when the app is closed or not in use, so the shuttle widget can find the nearest shuttle stop and show arrival information for that stop. Your location is processed on your device to provide this feature and is not sent to or stored on a server or used for advertising or analytics. On the next Android settings screen, choose \'Allow all the time\' to let the widget update without opening the app. You can still check shuttle information directly in the app without allowing background location.</string>
     <string name="widget_shuttle_background_location_allow">Allow</string>
     <string name="widget_shuttle_background_location_later">Later</string>
     <string name="widget_preview_shuttle_stop_station">· Hanyang Univ. at Ansan</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -224,7 +224,7 @@
     <string name="confirm">確認</string>
     <string name="location_permission_nearest_stop">最寄りのバス停を探すには位置情報の権限が必要です。</string>
     <string name="location_permission_disclosure_title">位置情報の使用について</string>
-    <string name="location_permission_disclosure_message">HYUabotは、近くのシャトルバス・路線バスの停留所を探し、周辺の路線バス情報と地図上の現在地を表示するために位置情報を使用します。位置情報は端末内でのみ処理され、サーバーへ送信・保存されません。位置情報を許可しなくても停留所を手動で選択できます。</string>
+    <string name="location_permission_disclosure_message">アプリの使用中、HYUabotは近くのシャトルバス・路線バスの停留所を探し、周辺の路線バス情報と地図上の現在地を表示するために位置情報を使用します。位置情報はこれらの機能を提供するため端末内でのみ処理され、サーバーへ送信・保存されません。位置情報を許可しなくても停留所を手動で選択したり、地図を利用したりできます。</string>
     <string name="location_permission_disclosure_allow">同意して位置情報を許可</string>
     <string name="location_permission_disclosure_later">後で</string>
     <string name="map_location_permission_denied">位置情報が許可されませんでした。</string>
@@ -427,7 +427,7 @@
     <string name="widget_shuttle_no_location">位置情報使用不可</string>
     <string name="widget_shuttle_permission_required">位置情報が必要です</string>
     <string name="widget_shuttle_background_location_title">バックグラウンド位置情報の許可</string>
-    <string name="widget_shuttle_background_location_message">シャトルウィジェットがアプリを使用していない時も、現在地から最寄りのバス停を表示するため、バックグラウンドで位置情報を使用します。次の画面で位置情報の権限を「常に許可」に設定してください。</string>
+    <string name="widget_shuttle_background_location_message">HYUabotは、アプリを閉じている時や使用していない時も、シャトルウィジェットが現在地から最寄りのシャトル停留所を探し、その停留所の到着情報を表示できるよう、バックグラウンドで位置情報を収集します。位置情報はこの機能の提供のため端末内で処理され、サーバーへ送信・保存されず、広告や分析にも使用されません。次のAndroid設定画面で「常に許可」を選ぶと、アプリを開かなくてもウィジェットが更新されます。バックグラウンド位置情報を許可しなくても、アプリでシャトル情報を直接確認できます。</string>
     <string name="widget_shuttle_background_location_allow">許可</string>
     <string name="widget_shuttle_background_location_later">後で</string>
     <string name="widget_preview_shuttle_stop_station">· 韓大前駅</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="hanyang_orange">#FF9F0A</color>
+    <color name="location_permission_dialog_button">#A8C7FA</color>
     <color name="primary_text">#FFFFFF</color>
     <color name="secondary_text">#99EBEBF5</color>
     <color name="tertiary_text">#4DEBEBF5</color>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -224,7 +224,7 @@
     <string name="confirm">确认</string>
     <string name="location_permission_nearest_stop">需要位置权限才能查找最近的站点。</string>
     <string name="location_permission_disclosure_title">位置使用说明</string>
-    <string name="location_permission_disclosure_message">HYUabot使用您的位置信息查找附近的校车和公交车站，显示附近的公交信息，并在地图上显示当前位置。位置信息仅在设备本地处理，不会传输或存储至服务器。即使不授予位置权限，也可以手动选择站点。</string>
+    <string name="location_permission_disclosure_message">使用应用时，HYUabot会使用您的位置查找附近的校车和公交车站，显示附近的公交信息，并在地图上显示当前位置。位置信息仅为提供这些功能在设备本地处理，不会传输或存储至服务器。即使不授予位置权限，也可以手动选择站点或使用地图。</string>
     <string name="location_permission_disclosure_allow">同意并允许位置权限</string>
     <string name="location_permission_disclosure_later">稍后</string>
     <string name="map_location_permission_denied">位置权限未被允许。</string>
@@ -427,7 +427,7 @@
     <string name="widget_shuttle_no_location">位置不可用</string>
     <string name="widget_shuttle_permission_required">需要位置权限</string>
     <string name="widget_shuttle_background_location_title">后台位置权限说明</string>
-    <string name="widget_shuttle_background_location_message">校车小组件即使在不使用应用时，也会在后台使用位置信息来显示离您最近的站点。请在下一页面将位置权限设置为「始终允许」。</string>
+    <string name="widget_shuttle_background_location_message">即使应用已关闭或未在使用，HYUabot也会在后台收集位置信息，使校车小组件能够查找最近的校车站并显示该站点的到站信息。位置信息仅为提供此功能在设备本地处理，不会传输或存储至服务器，也不会用于广告或分析。在下一个 Android 设置页面选择「始终允许」，小组件即可无需打开应用自动更新。即使不允许后台位置权限，也可以在应用中直接查看校车信息。</string>
     <string name="widget_shuttle_background_location_allow">允许</string>
     <string name="widget_shuttle_background_location_later">稍后</string>
     <string name="widget_preview_shuttle_stop_station">· 汉大前站</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="hanyang_blue">#0E4A84</color>
+    <color name="location_permission_dialog_button">#0E4A84</color>
     <color name="hanyang_blue_variant">#B5BED5</color>
     <color name="hanyang_silver">#898C8E</color>
     <color name="hanyang_green">#7DB928</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,7 +276,7 @@
     <string name="confirm">확인</string>
     <string name="location_permission_nearest_stop">가까운 정류장을 찾기 위해 위치 권한이 필요합니다.</string>
     <string name="location_permission_disclosure_title">위치 정보 사용 안내</string>
-    <string name="location_permission_disclosure_message">휴아봇은 현재 위치를 사용해 가까운 셔틀버스·노선버스 정류장을 찾고, 주변 노선버스 정보를 보여주며 지도에서 현재 위치를 표시합니다. 위치 정보는 기기에서만 처리되며 서버에 전송하거나 저장하지 않습니다. 위치 권한 없이도 정류장을 직접 선택할 수 있습니다.</string>
+    <string name="location_permission_disclosure_message">휴아봇은 앱을 사용하는 동안 현재 위치를 사용해 가까운 셔틀버스·노선버스 정류장을 찾고, 주변 노선버스 정보를 보여주며 지도에 현재 위치를 표시합니다. 위치 정보는 이 기능을 제공하기 위해 기기에서만 처리되며 서버에 전송하거나 저장하지 않습니다. 위치 권한 없이도 정류장을 직접 선택하거나 지도를 사용할 수 있습니다.</string>
     <string name="location_permission_disclosure_allow">동의하고 위치 허용</string>
     <string name="location_permission_disclosure_later">나중에</string>
     <string name="map_location_permission_denied">위치 권한이 허용되지 않았습니다.</string>
@@ -498,7 +498,7 @@
     <string name="widget_shuttle_no_location">위치 사용 불가</string>
     <string name="widget_shuttle_permission_required">위치 권한이 필요합니다</string>
     <string name="widget_shuttle_background_location_title">백그라운드 위치 권한 안내</string>
-    <string name="widget_shuttle_background_location_message">셔틀 위젯이 앱을 사용하지 않을 때에도 현재 위치에서 가장 가까운 정류장을 표시하기 위해 백그라운드에서 위치 정보를 사용합니다. 다음 화면에서 위치 권한을 \'항상 허용\'으로 설정해 주세요.</string>
+    <string name="widget_shuttle_background_location_message">휴아봇은 앱이 닫혀 있거나 사용하지 않는 동안에도 셔틀 위젯이 현재 위치를 사용해 가장 가까운 셔틀 정류장을 찾고, 위젯에 해당 정류장의 도착 정보를 표시할 수 있도록 백그라운드에서 위치 정보를 수집합니다. 위치 정보는 이 기능 제공을 위해 기기에서 처리되며 서버에 전송하거나 광고·분석 목적으로 사용하지 않습니다. 다음 Android 설정에서 위치 권한을 \'항상 허용\'으로 선택하면 앱을 열지 않아도 위젯이 갱신됩니다. 허용하지 않아도 앱에서 셔틀 정보를 직접 확인할 수 있습니다.</string>
     <string name="widget_shuttle_background_location_allow">허용</string>
     <string name="widget_shuttle_background_location_later">나중에</string>
     <string name="widget_preview_shuttle_stop_station">· 한대앞</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,4 +28,4 @@ android.builtInKotlin=true
 android.newDsl=true
 # Shared version for app and watch modules (kept in sync manually on release)
 APP_VERSION_NAME=26.08.16
-APP_VERSION_CODE=2026081600
+APP_VERSION_CODE=2026081601


### PR DESCRIPTION
## Summary

- Add prominent location disclosures before foreground and background location permission requests.
- Explain nearby shuttle and city bus stop discovery, nearby bus information, map positioning, on-device processing, and manual alternatives.
- Limit repeated disclosure prompts after multiple later selections.
- Improve disclosure button contrast in dark mode.
- Bump the app version code for the production release.

## Test plan

- [x] ./gradlew :app:lintDevDebug :app:assembleProductionRelease
- [x] ./gradlew :app:testDevDebugUnitTest
- [x] ./gradlew :app:bundleProductionRelease
- [x] Verified the disclosure appears before the runtime location permission prompt on an emulator.
- [x] Verified the dark-mode disclosure buttons use a brighter color on an emulator.
- [x] Verified repeated later selections stop automatic disclosure prompts after the configured limit.